### PR TITLE
refactor(consensus): Ensure that the consensus state source is consistent.

### DIFF
--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -12,19 +12,27 @@ pub enum MessageTarget {
     Specified(UserAddress),
 }
 
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    pub chain_id:     Hash,
+    pub self_address: UserAddress,
+}
+
 #[derive(Clone, Debug)]
 pub struct CurrentConsensusStatus {
-    pub cycles_price: u64,
-    pub cycles_limit: u64,
-    pub epoch_id:     u64,
-    pub prev_hash:    Hash,
-    pub logs_bloom:   Bloom,
-    pub order_root:   MerkleRoot,
-    pub confirm_root: Vec<MerkleRoot>,
-    pub state_root:   MerkleRoot,
-    pub receipt_root: Vec<MerkleRoot>,
-    pub cycles_used:  u64,
-    pub proof:        Proof,
+    pub cycles_price:       u64,
+    pub cycles_limit:       u64,
+    pub epoch_id:           u64,
+    pub prev_hash:          Hash,
+    pub logs_bloom:         Bloom,
+    pub order_root:         MerkleRoot,
+    pub confirm_root:       Vec<MerkleRoot>,
+    pub state_root:         MerkleRoot,
+    pub receipt_root:       Vec<MerkleRoot>,
+    pub cycles_used:        u64,
+    pub proof:              Proof,
+    pub validators:         Vec<Validator>,
+    pub consensus_interval: u64,
 }
 
 #[async_trait]

--- a/protocol/src/traits/mod.rs
+++ b/protocol/src/traits/mod.rs
@@ -7,7 +7,7 @@ mod storage;
 pub mod executor;
 
 pub use api::APIAdapter;
-pub use consensus::{Consensus, ConsensusAdapter, MessageTarget};
+pub use consensus::{Consensus, ConsensusAdapter, CurrentConsensusStatus, MessageTarget, NodeInfo};
 pub use mempool::{MemPool, MemPoolAdapter, MixedTxHashes};
 pub use network::{Gossip, MessageCodec, MessageHandler, Priority, Rpc};
 pub use storage::{Storage, StorageAdapter, StorageBatchModify, StorageCategory, StorageSchema};


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
feature

**What this PR does / why we need it**:
Now, the state of the consensus module is split into two structures, mutable and immutable.

Immutable
````rust
#[derive(Debug, Clone)]
pub struct NodeInfo {
    pub chain_id:     Hash,
    pub self_address: UserAddress,
}
````

Mutable
````rust
#[derive(Clone, Debug)]
pub struct CurrentConsensusStatus {
    pub cycles_price:       u64,
    pub cycles_limit:       u64,
    pub epoch_id:           u64,
    pub prev_hash:          Hash,
    pub logs_bloom:         Bloom,
    pub order_root:         MerkleRoot,
    pub confirm_root:       Vec<MerkleRoot>,
    pub state_root:         MerkleRoot,
    pub receipt_root:       Vec<MerkleRoot>,
    pub cycles_used:        u64,
    pub proof:              Proof,
    pub validators:         Vec<Validator>,
    pub consensus_interval: u64,
}
````
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
