### PR TITLE
fix(network): never reconnect bootstrap again after failure

### DIFF
--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -784,7 +784,9 @@ impl PeerManager {
             }
         }
 
-        warn!("network: no peers {:?}", no_peers);
+        if !no_peers.is_empty() {
+            warn!("network: no peers {:?}", no_peers);
+        }
 
         // Send message to connected users
         let tar = TargetSession::Multi(connected);

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -921,6 +921,7 @@ impl PeerManager {
 
                 if self.bootstraps.contains(&addr) {
                     error!("network: unconnectable bootstrap address {}", addr);
+                    return;
                 }
 
                 self.inner.try_remove_addr(&addr);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
fix

**What this PR does / why we need it**:
- never reconnect bootstrap again after failure
- no peers warning when it's empty

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
