### PR TITLE
refactor(graphql): Use `protocol::Fixed_codec` to ensure consistent serialization.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,6 @@ dependencies = [
  "juniper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper_codegen 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protocol 0.1.0",
- "rlp 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tide 0.2.0 (git+https://github.com/rustasync/tide?rev=af0b900)",
 ]
 

--- a/core/api/Cargo.toml
+++ b/core/api/Cargo.toml
@@ -16,6 +16,5 @@ juniper = "0.13"
 juniper_codegen = "0.13"
 async-trait = "0.1"
 hex = "0.3"
-rlp = "0.4"
 bytes = "0.4"
 futures-preview = { version = "0.3.0-alpha.19" }

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -97,13 +97,13 @@ where
     // TODO: Cycle limit?
     async fn check_transaction(&self, _ctx: Context, stx: SignedTransaction) -> ProtocolResult<()> {
         // Verify transaction hash
-        let rlp_stx = stx.encode_fixed()?;
-        let stx_hash = Hash::digest(rlp_stx);
+        let fixed_bytes = stx.raw.encode_fixed()?;
+        let tx_hash = Hash::digest(fixed_bytes);
 
-        if stx_hash != stx.tx_hash {
+        if tx_hash != stx.tx_hash {
             let wrong_hash = MemPoolError::CheckHash {
                 expect: stx.tx_hash,
-                actual: stx_hash,
+                actual: tx_hash,
             };
 
             return Err(wrong_hash.into());

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -47,7 +47,6 @@ impl<Adapter> HashMemPool<Adapter>
 where
     Adapter: MemPoolAdapter,
 {
-    #[allow(dead_code)]
     pub fn new(
         pool_size: usize,
         timeout_gap: u64,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
refactor 

**What this PR does / why we need it**:
When consistent serialization is required, we have a unified interface (#11), and the `graphql` module no longer needs additional code to do the repetitive functions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
