### PR TITLE
[ᚬframework] feat(core/binding-macro): Add #[service] to automatically implement the service trait.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
  "protocol 0.1.0",
  "rlp 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -466,10 +467,13 @@ name = "core-binding-macro"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-binding 0.1.0",
  "json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protocol 0.1.0",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,6 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-binding 0.1.0",
- "json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protocol 0.1.0",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/binding-macro/Cargo.toml
+++ b/core/binding-macro/Cargo.toml
@@ -20,7 +20,6 @@ quote = "1.0"
 [dev-dependencies]
 protocol = { path = "../../protocol" }
 
-json = "0.12"
 serde_json = "1.0"
 bytes = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/core/binding-macro/Cargo.toml
+++ b/core/binding-macro/Cargo.toml
@@ -10,11 +10,16 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
+core-binding = { path = "../binding" }
+
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 
 [dev-dependencies]
 protocol = { path = "../../protocol" }
+
 json = "0.12"
+serde_json = "1.0"
 bytes = "0.4"
+serde = { version = "1.0", features = ["derive"] }

--- a/core/binding-macro/Cargo.toml
+++ b/core/binding-macro/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 core-binding = { path = "../binding" }

--- a/core/binding-macro/src/lib.rs
+++ b/core/binding-macro/src/lib.rs
@@ -3,94 +3,215 @@ extern crate proc_macro;
 mod common;
 mod cycles;
 mod read_write;
+mod servive;
 
 use proc_macro::TokenStream;
 
 use crate::cycles::gen_cycles_code;
 use crate::read_write::verify_read_or_write;
+use crate::servive::gen_service_code;
 
-// `#[read]` marks a service method as readable.
-//
-// Methods marked with this macro will have:
-//  Methods with this macro allow access (readable) from outside (RPC or other
-// services).
-//
-// - Verification
-//  1. Is it a struct method marked with #[service]?
-//  2. Is visibility private?
-//  3. Does function generics constrain `fn f<Context: RequestContext>`?
-//  4. Parameter signature contains `&self and ctx:Context`?
-//  5. Is the return value `ProtocolResult <JsonValue>`?
-//
-// example:
-//
-// struct Service;
-// #[service]
-// impl Service {
-//     #[read]
-//     fn test_read_fn<Context: RequestContext>(
-//         &self,
-//         _ctx: Context,
-//     ) -> ProtocolResult<JsonValue> {
-//         Ok(JsonValue::Null)
-//     }
-// }
+#[rustfmt::skip]
+/// `#[read]` marks a service method as readable.
+///
+/// Methods marked with this macro will have:
+///  Methods with this macro allow access (readable) from outside (RPC or other services).
+///
+/// - Verification
+///  1. Is it a struct method marked with #[service]?
+///  2. Is visibility private?
+///  3. Does function generics constrain `fn f<Context: RequestContext>`?
+///  4. Parameter signature contains `&self and ctx:Context`?
+///  5. Is the return value `ProtocolResult <JsonValue>`?
+///
+/// # Example:
+///
+/// ```rust
+/// struct Service;
+/// #[service]
+/// impl Service {
+///     #[read]
+///     fn test_read_fn<Context: RequestContext>(
+///         &self,
+///         _ctx: Context,
+///     ) -> ProtocolResult<JsonValue> {
+///         Ok(JsonValue::Null)
+///     }
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn read(_: TokenStream, item: TokenStream) -> TokenStream {
     verify_read_or_write(item, false)
 }
 
-// `#[write]` marks a service method as writable.
-//
-// Methods marked with this macro will have:
-// - Accessibility
-//  Methods with this macro allow access (writeable) from outside (RPC or other
-// services).
-//
-// - Verification
-//  1. Is it a struct method marked with #[service]?
-//  2. Is visibility private?
-//  3. Does function generics constrain `fn f<Context: RequestContext>`?
-//  4. Parameter signature contains `&mut self and ctx:Context`?
-//  5. Is the return value `ProtocolResult <JsonValue>`?
-//
-// example:
-//
-// struct Service;
-// #[service]
-// impl Service {
-//     #[write]
-//     fn test_write_fn<Context: RequestContext>(
-//         &mut self,
-//         _ctx: Context,
-//     ) -> ProtocolResult<JsonValue> {
-//         Ok(JsonValue::Null)
-//     }
-// }
+#[rustfmt::skip]
+/// `#[write]` marks a service method as writable.
+///
+/// Methods marked with this macro will have:
+/// - Accessibility
+///  Methods with this macro allow access (writeable) from outside (RPC or other services).
+///
+/// - Verification
+///  1. Is it a struct method marked with #[service]?
+///  2. Is visibility private?
+///  3. Does function generics constrain `fn f<Context: RequestContext>`?
+///  4. Parameter signature contains `&mut self and ctx:Context`?
+///  5. Is the return value `ProtocolResult <JsonValue>`?
+///
+/// # Example:
+///
+/// ```rust
+/// struct Service;
+/// #[service]
+/// impl Service {
+///     #[write]
+///     fn test_write_fn<Context: RequestContext>(
+///         &mut self,
+///         _ctx: Context,
+///     ) -> ProtocolResult<JsonValue> {
+///         Ok(JsonValue::Null)
+///     }
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn write(_: TokenStream, item: TokenStream) -> TokenStream {
     verify_read_or_write(item, true)
 }
 
-// `# [cycles]` mark an `ImplFn` or `fn`, it will automatically generate code to
-// complete the cycle deduction,
-//
-// // Source Code
-// impl Tests {
-//     #[cycles(100)]
-//     fn test_cycles<Context: RequestContext>(&self, ctx: Context) ->
-// ProtocolResult<()> {         Ok(())
-//     }
-// }
-//
-// // Generated code.
-// impl Tests {
-//     fn test_cycles<Context: RequestContext>(&self, ctx: Context) ->
-// ProtocolResult<()> {         ctx.sub_cycles(100)?;
-//         Ok(())
-//     }
-// }
+#[rustfmt::skip]
+/// `# [cycles]` mark an `ImplFn` or `fn`, it will automatically generate code
+/// to complete the cycle deduction,
+///
+/// ```rust
+/// // Source Code
+/// impl Tests {
+///     #[cycles(100)]
+///     fn test_cycles<Context: RequestContext>(&self, ctx: Context) -> ProtocolResult<()> {
+///         Ok(())
+///     }
+/// }
+///
+/// // Generated code.
+/// impl Tests {
+///     fn test_cycles<Context: RequestContext>(&self, ctx: Context) -> ProtocolResult<()> {
+///         ctx.sub_cycles(100)?;
+///         Ok(())
+///     }
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn cycles(attr: TokenStream, item: TokenStream) -> TokenStream {
     gen_cycles_code(attr, item)
+}
+
+/// Marks a method so that it executes before the entire block executes.
+// TODO(@yejiayu): Verify the function signature.
+#[proc_macro_attribute]
+pub fn hook_after(_: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
+/// Marks a method so that it executes after the entire block executes.
+// TODO(@yejiayu): Verify the function signature.
+#[proc_macro_attribute]
+pub fn hook_before(_: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
+#[rustfmt::skip]
+/// Marking a ImplItem for service, it will automatically trait
+/// `protocol::traits::Service`.
+///
+/// # Example
+///
+/// use serde::{Deserialize, Serialize};
+/// use protocol::traits::RequestContext;
+/// use protocol::ProtocolResult;
+///
+/// ```rust
+/// // Source code
+/// 
+/// // serde::Deserialize and serde::Serialize are required.
+/// #[derive(Serialize, Deserialize)]
+/// struct CreateKittyPayload {
+///     // fields
+/// }
+/// 
+/// // serde::Deserialize and serde::Serialize are required.
+/// #[derive(Serialize, Deserialize)]
+/// struct GetKittyPayload {
+///     // fields
+/// }
+/// 
+/// #[service]
+/// impl KittyService {
+///     #[hook_before]
+///     fn custom_hook_before(&mut self) -> ProtoResult<()> {
+///         // Do something
+///     }
+/// 
+///     #[hook_after]
+///     fn custom_hook_after(&mut self) -> ProtoResult<()> {
+///         // Do something
+///     }
+/// 
+///     #[read]
+///     fn get_kitty<Context: RequestContext>(
+///         &self,
+///         ctx: Context,
+///         payload: GetKittyPayload,
+///     ) -> ProtoResult<&str> {
+///         // Do something
+///     }
+/// 
+///     #[write]
+///     fn create_kitty<Context: RequestContext>(
+///         &mut self,
+///         ctx: Context,
+///         payload: CreateKittyPayload,
+///     ) -> ProtoResult<&str> {
+///         // Do something
+///     }
+/// }
+/// 
+/// // Generated code.
+/// impl Service for KittyService {
+///     fn hook_before_(&mut self) -> ProtocolResult<()> {
+///         self.custom_hook_before()
+///     }
+/// 
+///     fn hook_after(&mut self) -> ProtocolResult<()> {
+///         self.custom_hook_after()
+///     }
+/// 
+///     fn write<Context: RequestContext>(&mut self, ctx: Context) -> ProtocolResult<&str> {
+///         let method = ctx.get_service_method();
+/// 
+///         match ctx.get_service_method() {
+///             "create_kitty" => {
+///                 let payload: CreateKittyPayload = serde_json::from_str(ctx.get_payload())
+///                     .map_err(|e| core_binding::ServiceError::JsonParse(e))?;
+///                 self.create_kitty(ctx, payload)
+///             }
+///             _ => Err(core_binding::ServiceError::NotFoundMethod(method.to_owned()).into()),
+///         }
+///     }
+/// 
+///     fn read<Context: RequestContext>(&self, ctx: Context) -> ProtocolResult<&str> {
+///         let method = ctx.get_service_method();
+/// 
+///         match ctx.get_service_method() {
+///             "get_kitty" => {
+///                 let payload: GetKittyPayload = serde_json::from_str(ctx.get_payload())
+///                     .map_err(|e| core_binding::ServiceError::JsonParse(e))?;
+///                 self.get_kitty(ctx, payload)
+///             }
+///             _ => Err(core_binding::ServiceError::NotFoundMethod(method.to_owned()).into()),
+///         }
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn service(attr: TokenStream, item: TokenStream) -> TokenStream {
+    gen_service_code(attr, item)
 }

--- a/core/binding-macro/src/lib.rs
+++ b/core/binding-macro/src/lib.rs
@@ -22,7 +22,7 @@ use crate::servive::gen_service_code;
 ///  2. Is visibility private?
 ///  3. Does function generics constrain `fn f<Context: RequestContext>`?
 ///  4. Parameter signature contains `&self and ctx:Context`?
-///  5. Is the return value `ProtocolResult <JsonValue>`?
+///  5. Is the return value `ProtocolResult <String>`?
 ///
 /// # Example:
 ///
@@ -34,8 +34,8 @@ use crate::servive::gen_service_code;
 ///     fn test_read_fn<Context: RequestContext>(
 ///         &self,
 ///         _ctx: Context,
-///     ) -> ProtocolResult<JsonValue> {
-///         Ok(JsonValue::Null)
+///     ) -> ProtocolResult<String> {
+///         Ok("test read".to_owend())
 ///     }
 /// }
 /// ```
@@ -56,7 +56,7 @@ pub fn read(_: TokenStream, item: TokenStream) -> TokenStream {
 ///  2. Is visibility private?
 ///  3. Does function generics constrain `fn f<Context: RequestContext>`?
 ///  4. Parameter signature contains `&mut self and ctx:Context`?
-///  5. Is the return value `ProtocolResult <JsonValue>`?
+///  5. Is the return value `ProtocolResult <String>`?
 ///
 /// # Example:
 ///
@@ -68,8 +68,8 @@ pub fn read(_: TokenStream, item: TokenStream) -> TokenStream {
 ///     fn test_write_fn<Context: RequestContext>(
 ///         &mut self,
 ///         _ctx: Context,
-///     ) -> ProtocolResult<JsonValue> {
-///         Ok(JsonValue::Null)
+///     ) -> ProtocolResult<String> {
+///         Ok("test write".to_owned())
 ///     }
 /// }
 /// ```
@@ -130,31 +130,31 @@ pub fn hook_before(_: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```rust
 /// // Source code
-/// 
+///
 /// // serde::Deserialize and serde::Serialize are required.
 /// #[derive(Serialize, Deserialize)]
 /// struct CreateKittyPayload {
 ///     // fields
 /// }
-/// 
+///
 /// // serde::Deserialize and serde::Serialize are required.
 /// #[derive(Serialize, Deserialize)]
 /// struct GetKittyPayload {
 ///     // fields
 /// }
-/// 
+///
 /// #[service]
 /// impl KittyService {
 ///     #[hook_before]
 ///     fn custom_hook_before(&mut self) -> ProtoResult<()> {
 ///         // Do something
 ///     }
-/// 
+///
 ///     #[hook_after]
 ///     fn custom_hook_after(&mut self) -> ProtoResult<()> {
 ///         // Do something
 ///     }
-/// 
+///
 ///     #[read]
 ///     fn get_kitty<Context: RequestContext>(
 ///         &self,
@@ -163,7 +163,7 @@ pub fn hook_before(_: TokenStream, item: TokenStream) -> TokenStream {
 ///     ) -> ProtoResult<&str> {
 ///         // Do something
 ///     }
-/// 
+///
 ///     #[write]
 ///     fn create_kitty<Context: RequestContext>(
 ///         &mut self,
@@ -173,20 +173,20 @@ pub fn hook_before(_: TokenStream, item: TokenStream) -> TokenStream {
 ///         // Do something
 ///     }
 /// }
-/// 
+///
 /// // Generated code.
 /// impl Service for KittyService {
 ///     fn hook_before_(&mut self) -> ProtocolResult<()> {
 ///         self.custom_hook_before()
 ///     }
-/// 
+///
 ///     fn hook_after(&mut self) -> ProtocolResult<()> {
 ///         self.custom_hook_after()
 ///     }
-/// 
+///
 ///     fn write<Context: RequestContext>(&mut self, ctx: Context) -> ProtocolResult<&str> {
 ///         let method = ctx.get_service_method();
-/// 
+///
 ///         match ctx.get_service_method() {
 ///             "create_kitty" => {
 ///                 let payload: CreateKittyPayload = serde_json::from_str(ctx.get_payload())
@@ -196,10 +196,10 @@ pub fn hook_before(_: TokenStream, item: TokenStream) -> TokenStream {
 ///             _ => Err(core_binding::ServiceError::NotFoundMethod(method.to_owned()).into()),
 ///         }
 ///     }
-/// 
+///
 ///     fn read<Context: RequestContext>(&self, ctx: Context) -> ProtocolResult<&str> {
 ///         let method = ctx.get_service_method();
-/// 
+///
 ///         match ctx.get_service_method() {
 ///             "get_kitty" => {
 ///                 let payload: GetKittyPayload = serde_json::from_str(ctx.get_payload())

--- a/core/binding-macro/src/read_write.rs
+++ b/core/binding-macro/src/read_write.rs
@@ -71,9 +71,11 @@ fn verify_ret_type(ret_type: &ReturnType) {
                 PathArguments::AngleBracketed(arg) => {
                     let generic_args = &arg.args;
                     let generic_type = &generic_args[0];
-                    generic_type_is_jsonvalue(generic_type);
+                    if !generic_type_is_string(generic_type) {
+                        panic!("The return value of read/write method must be String");
+                    }
                 }
-                _ => panic!("The return value of read/write method must be json::JsonValue"),
+                _ => panic!("The return value of read/write method must be String"),
             };
         }
         _ => panic!("The return type of read/write method must be protocol::ProtocolResult"),
@@ -87,10 +89,10 @@ fn path_is_jsonvalue(path: &Path) -> bool {
     }
 
     // JsonValue
-    path.segments.len() == 1 && path.segments[0].ident == "JsonValue"
+    path.segments.len() == 1 && path.segments[0].ident == "String"
 }
 
-fn generic_type_is_jsonvalue(generic_type: &GenericArgument) -> bool {
+fn generic_type_is_string(generic_type: &GenericArgument) -> bool {
     match generic_type {
         GenericArgument::Type(t) => match t {
             Type::Path(type_path) => path_is_jsonvalue(&type_path.path),

--- a/core/binding-macro/src/servive.rs
+++ b/core/binding-macro/src/servive.rs
@@ -1,0 +1,199 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, FnArg, Ident, ImplItem, ImplItemMethod, ItemImpl, Type};
+
+enum ServiceMethod {
+    Read(ImplItemMethod),
+    Write(ImplItemMethod),
+}
+
+struct Hooks {
+    before: Option<Ident>,
+    after:  Option<Ident>,
+}
+
+struct MethodMeta {
+    method_ident:  Ident,
+    payload_ident: Ident,
+    readonly:      bool,
+}
+
+pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
+    let impl_item = parse_macro_input!(item as ItemImpl);
+
+    let service_ident = get_service_ident(&impl_item);
+    let items = &impl_item.items;
+    let generics = &impl_item.generics;
+
+    let mut methods: Vec<ServiceMethod> = vec![];
+
+    for item in items {
+        if let ImplItem::Method(method) = item {
+            if let Some(service_method) = find_service_method(method) {
+                methods.push(service_method)
+            }
+        }
+    }
+
+    let hooks = extract_hooks(items);
+    let hook_before = &hooks.before;
+    let hook_before_body = match hook_before {
+        Some(hook_before) => quote! { self.#hook_before() },
+        None => quote! {Ok(())},
+    };
+    let hook_after = &hooks.after;
+    let hook_after_body = match hook_after {
+        Some(hook_after) => quote! { self.#hook_after() },
+        None => quote! {Ok(())},
+    };
+
+    let list_method_meta: Vec<MethodMeta> = methods.into_iter().map(extract_method_meta).collect();
+
+    let (list_read_name, list_read_ident, list_read_payload) =
+        split_list_for_metadata(&list_method_meta, true);
+    let (list_write_name, list_write_ident, list_write_payload) =
+        split_list_for_metadata(&list_method_meta, false);
+
+    TokenStream::from(quote! {
+        impl#generics protocol::traits::Service for #service_ident#generics {
+            fn hook_before_(&mut self) -> protocol::ProtocolResult<()> {
+                #hook_before_body
+            }
+
+            fn hook_after_(&mut self) -> protocol::ProtocolResult<()> {
+                #hook_after_body
+            }
+
+            fn read_<Context: protocol::traits::RequestContext>(&self, ctx: Context) -> protocol::ProtocolResult<String> {
+                let method = ctx.get_service_method();
+
+                match method {
+                    #(#list_read_name => {
+                        let payload: #list_read_payload = serde_json::from_str(ctx.get_payload())
+                                .map_err(|e| core_binding::ServiceError::JsonParse(e))?;
+                        self.#list_read_ident(ctx, payload)
+                    },)*
+                    _ => Err(core_binding::ServiceError::NotFoundMethod(method.to_owned()).into())
+                }
+            }
+
+            fn write_<Context: protocol::traits::RequestContext>(&mut self, ctx: Context) -> protocol::ProtocolResult<String> {
+                let method = ctx.get_service_method();
+
+                match method {
+                    #(#list_write_name => {
+                        let payload: #list_write_payload = serde_json::from_str(ctx.get_payload())
+                                .map_err(|e| core_binding::ServiceError::JsonParse(e))?;
+                        self.#list_write_ident(ctx, payload)
+                    },)*
+                    _ => Err(core_binding::ServiceError::NotFoundMethod(method.to_owned()).into())
+                }
+            }
+        }
+
+        #impl_item
+    })
+}
+
+fn split_list_for_metadata(
+    list: &[MethodMeta],
+    readonly: bool,
+) -> (Vec<String>, Vec<Ident>, Vec<Ident>) {
+    let mut methods = vec![];
+    let mut method_idents = vec![];
+    let mut payload_idents = vec![];
+
+    list.iter()
+        .filter(|meta| meta.readonly == readonly)
+        .for_each(|meta| {
+            methods.push(meta.method_ident.to_string());
+            method_idents.push(meta.method_ident.clone());
+            payload_idents.push(meta.payload_ident.clone());
+        });
+    (methods, method_idents, payload_idents)
+}
+
+fn get_service_ident(impl_item: &ItemImpl) -> Ident {
+    match &*impl_item.self_ty {
+        Type::Path(type_path) => type_path
+            .path
+            .get_ident()
+            .expect("The identity of the service was not found.")
+            .clone(),
+        _ => panic!("The identity of the service was not found."),
+    }
+}
+
+fn find_service_method(method: &ImplItemMethod) -> Option<ServiceMethod> {
+    let attrs = &method.attrs;
+
+    for attr in attrs {
+        for segment in &attr.path.segments {
+            if segment.ident == "read" {
+                return Some(ServiceMethod::Read(method.clone()));
+            } else if segment.ident == "write" {
+                return Some(ServiceMethod::Write(method.clone()));
+            }
+        }
+    }
+
+    None
+}
+
+fn extract_hooks(items: &[ImplItem]) -> Hooks {
+    let mut hooks = Hooks {
+        before: None,
+        after:  None,
+    };
+
+    for item in items {
+        if let ImplItem::Method(method) = item {
+            for attr in &method.attrs {
+                for segment in &attr.path.segments {
+                    if segment.ident == "hook_before" {
+                        hooks.before = Some(method.sig.ident.clone())
+                    } else if segment.ident == "hook_after" {
+                        hooks.after = Some(method.sig.ident.clone())
+                    }
+                }
+            }
+        }
+    }
+
+    hooks
+}
+
+fn extract_method_meta(method: ServiceMethod) -> MethodMeta {
+    let (impl_method, readonly) = match method {
+        ServiceMethod::Read(impl_method) => (impl_method, true),
+        ServiceMethod::Write(impl_method) => (impl_method, false),
+    };
+
+    // inputs[0] = &self or &mut self
+    // inputs[1] = RequestContext
+    // inputs[2] = MethodPayload: FromStr
+    if impl_method.sig.inputs.len() != 3 {
+        panic!(
+            "The correct signature of the service method is: fn
+(&self/&mut self, RequestContext, Payload)"
+        );
+    }
+
+    let payload_arg = &impl_method.sig.inputs[2];
+    let pat_type = match payload_arg {
+        FnArg::Typed(pat_type) => pat_type,
+        _ => unreachable!(),
+    };
+
+    let payload_ident = if let Type::Path(path) = &*pat_type.ty {
+        path.path.get_ident().expect("")
+    } else {
+        panic!("")
+    };
+
+    MethodMeta {
+        method_ident: impl_method.sig.ident,
+        payload_ident: payload_ident.clone(),
+        readonly,
+    }
+}

--- a/core/binding-macro/tests/mod.rs
+++ b/core/binding-macro/tests/mod.rs
@@ -5,7 +5,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use bytes::Bytes;
-use json::JsonValue;
 use serde::{Deserialize, Serialize};
 
 use core_binding_macro::{cycles, read, write};
@@ -19,27 +18,24 @@ fn test_read_and_write() {
 
     impl Tests {
         #[read]
-        fn test_read_fn<Context: RequestContext>(
-            &self,
-            _ctx: Context,
-        ) -> ProtocolResult<JsonValue> {
-            Ok(JsonValue::Null)
+        fn test_read_fn<Context: RequestContext>(&self, _ctx: Context) -> ProtocolResult<String> {
+            Ok("read".to_owned())
         }
 
         #[write]
         fn test_write_fn<Context: RequestContext>(
             &mut self,
             _ctx: Context,
-        ) -> ProtocolResult<JsonValue> {
-            Ok(JsonValue::Null)
+        ) -> ProtocolResult<String> {
+            Ok("write".to_owned())
         }
     }
 
     let context = MockRequestContext::new(1000);
 
     let mut t = Tests {};
-    assert_eq!(t.test_read_fn(context.clone()).unwrap(), JsonValue::Null);
-    assert_eq!(t.test_write_fn(context).unwrap(), JsonValue::Null);
+    assert_eq!(t.test_read_fn(context.clone()).unwrap(), "read".to_owned());
+    assert_eq!(t.test_write_fn(context).unwrap(), "write".to_owned());
 }
 
 #[test]

--- a/core/binding-macro/tests/mod.rs
+++ b/core/binding-macro/tests/mod.rs
@@ -6,8 +6,10 @@ use std::rc::Rc;
 
 use bytes::Bytes;
 use json::JsonValue;
+use serde::{Deserialize, Serialize};
 
-use protocol::traits::RequestContext;
+use core_binding_macro::{cycles, read, write};
+use protocol::traits::{RequestContext, Service};
 use protocol::types::{Address, Hash};
 use protocol::ProtocolResult;
 
@@ -69,66 +71,160 @@ fn test_cycles() {
     let t = Tests {};
     let context = MockRequestContext::new(1000);
     t.test_cycles(context.clone()).unwrap();
-    assert_eq!(context.get_cycles_limit().unwrap(), 900);
+    assert_eq!(context.get_cycles_limit(), 900);
 
     t.test_cycles2(context.clone()).unwrap();
-    assert_eq!(context.get_cycles_limit().unwrap(), 400);
+    assert_eq!(context.get_cycles_limit(), 400);
 
     test_sub_cycles_fn1(context.clone()).unwrap();
-    assert_eq!(context.get_cycles_limit().unwrap(), 200);
+    assert_eq!(context.get_cycles_limit(), 200);
 
     test_sub_cycles_fn2(1, context.clone()).unwrap();
-    assert_eq!(context.get_cycles_limit().unwrap(), 0);
+    assert_eq!(context.get_cycles_limit(), 0);
+}
+
+#[test]
+fn test_impl_service() {
+    #[derive(Serialize, Deserialize, Debug)]
+    struct TestServicePayload {
+        name: String,
+        age:  u64,
+        sex:  bool,
+    }
+    struct Tests {
+        hook_before: bool,
+        hook_after:  bool,
+    }
+
+    #[service]
+    impl Tests {
+        #[hook_before]
+        fn custom_hook_before(&mut self) -> ProtocolResult<()> {
+            self.hook_before = true;
+            Ok(())
+        }
+
+        #[hook_after]
+        fn custom_hook_after(&mut self) -> ProtocolResult<()> {
+            self.hook_after = true;
+            Ok(())
+        }
+
+        #[read]
+        fn test_read<Context: RequestContext>(
+            &self,
+            _ctx: Context,
+            _payload: TestServicePayload,
+        ) -> ProtocolResult<String> {
+            Ok("read ok".to_owned())
+        }
+
+        #[write]
+        fn test_write<Context: RequestContext>(
+            &mut self,
+            _ctx: Context,
+            _payload: TestServicePayload,
+        ) -> ProtocolResult<String> {
+            Ok("write ok".to_owned())
+        }
+    }
+
+    let payload = TestServicePayload {
+        name: "test".to_owned(),
+        age:  10,
+        sex:  false,
+    };
+    let payload_str = serde_json::to_string(&payload).unwrap();
+
+    let mut test_service = Tests {
+        hook_before: false,
+        hook_after:  false,
+    };
+    let context = MockRequestContext::with_method(1024 * 1024, "test_write", &payload_str);
+    let write_res = test_service.write_(context).unwrap();
+    assert_eq!(write_res, "write ok");
+
+    let context = MockRequestContext::with_method(1024 * 1024, "test_read", &payload_str);
+    let read_res = test_service.read_(context).unwrap();
+    assert_eq!(read_res, "read ok");
+
+    let context = MockRequestContext::with_method(1024 * 1024, "test_notfound", &payload_str);
+    let read_res = test_service.read_(context.clone());
+    assert_eq!(read_res.is_err(), true);
+    let write_res = test_service.write_(context);
+    assert_eq!(write_res.is_err(), true);
+
+    test_service.hook_before_().unwrap();
+    assert_eq!(test_service.hook_before, true);
+
+    test_service.hook_after_().unwrap();
+    assert_eq!(test_service.hook_after, true);
 }
 
 #[derive(Clone)]
 struct MockRequestContext {
     cycles_limit: Rc<RefCell<u64>>,
+    method:       String,
+    payload:      String,
 }
 
 impl MockRequestContext {
     pub fn new(cycles_limit: u64) -> Self {
         Self {
             cycles_limit: Rc::new(RefCell::new(cycles_limit)),
+            method:       "method".to_owned(),
+            payload:      "payload".to_owned(),
+        }
+    }
+
+    pub fn with_method(cycles_limit: u64, method: &str, payload: &str) -> Self {
+        Self {
+            cycles_limit: Rc::new(RefCell::new(cycles_limit)),
+            method:       method.to_owned(),
+            payload:      payload.to_owned(),
         }
     }
 }
 
 impl RequestContext for MockRequestContext {
-    fn sub_cycles(&self, cycels: u64) -> ProtocolResult<()> {
-        self.cycles_limit.replace_with(|&mut old| old - cycels);
+    fn sub_cycles(&self, cycles: u64) -> ProtocolResult<()> {
+        self.cycles_limit.replace_with(|&mut old| old - cycles);
         Ok(())
     }
 
-    fn get_cycles_price(&self) -> ProtocolResult<u64> {
-        Ok(0)
+    fn get_cycles_price(&self) -> u64 {
+        0
     }
 
-    fn get_cycles_limit(&self) -> ProtocolResult<u64> {
-        Ok(*self.cycles_limit.borrow())
+    fn get_cycles_limit(&self) -> u64 {
+        *self.cycles_limit.borrow()
     }
 
-    fn get_cycles_used(&self) -> ProtocolResult<u64> {
-        Ok(0)
+    fn get_cycles_used(&self) -> u64 {
+        0
     }
 
-    fn get_caller(&self) -> ProtocolResult<Address> {
-        Address::from_hash(Hash::digest(Bytes::from("test")))
+    fn get_caller(&self) -> Address {
+        Address::from_hash(Hash::digest(Bytes::from("test"))).unwrap()
     }
 
-    fn get_current_epoch_id(&self) -> ProtocolResult<u64> {
-        Ok(0)
+    fn get_current_epoch_id(&self) -> u64 {
+        0
     }
 
-    fn get_service_name(&self) -> ProtocolResult<&str> {
-        Ok("service")
+    fn get_service_name(&self) -> &str {
+        "service"
     }
 
-    fn get_service_method(&self) -> ProtocolResult<&str> {
-        Ok("method")
+    fn get_service_method(&self) -> &str {
+        &self.method
     }
 
-    fn get_payload(&self) -> ProtocolResult<&str> {
-        Ok("payload")
+    fn get_payload(&self) -> &str {
+        &self.payload
+    }
+
+    fn emit_event(&mut self, message: String) -> ProtocolResult<()> {
+        unimplemented!()
     }
 }

--- a/core/binding/Cargo.toml
+++ b/core/binding/Cargo.toml
@@ -18,5 +18,8 @@ lazy_static = "1.4"
 byteorder = "1.3"
 rlp = "0.4"
 futures = "0.3"
-async-trait = "0.1"
 json = "0.12"
+serde_json = "1.0"
+
+[dev-dependencies]
+async-trait = "0.1"

--- a/core/binding/src/lib.rs
+++ b/core/binding/src/lib.rs
@@ -7,3 +7,23 @@ mod request_context;
 mod sdk;
 mod state;
 mod store;
+
+use derive_more::{Display, From};
+
+use protocol::{ProtocolError, ProtocolErrorKind};
+
+#[derive(Debug, Display, From)]
+pub enum ServiceError {
+    #[display(fmt = "method {:?} was not found", _0)]
+    NotFoundMethod(String),
+
+    #[display(fmt = "Parsing payload to json failed {:?}", _0)]
+    JsonParse(serde_json::Error),
+}
+impl std::error::Error for ServiceError {}
+
+impl From<ServiceError> for ProtocolError {
+    fn from(err: ServiceError) -> ProtocolError {
+        ProtocolError::new(ProtocolErrorKind::Binding, Box::new(err))
+    }
+}

--- a/core/binding/src/request_context.rs
+++ b/core/binding/src/request_context.rs
@@ -9,15 +9,15 @@ use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DefaultRequestContext {
-    cycles_limit:     u64,
-    cycles_price:     u64,
-    cycles_used:      Rc<RefCell<u64>>,
-    caller:           Address,
-    epoch_id:         u64,
-    service_name:     String,
-    service_method:   String,
-    service_playload: String,
-    events:           Rc<RefCell<Vec<Event>>>,
+    cycles_limit:    u64,
+    cycles_price:    u64,
+    cycles_used:     Rc<RefCell<u64>>,
+    caller:          Address,
+    epoch_id:        u64,
+    service_name:    String,
+    service_method:  String,
+    service_payload: String,
+    events:          Rc<RefCell<Vec<Event>>>,
 }
 
 impl DefaultRequestContext {
@@ -29,7 +29,7 @@ impl DefaultRequestContext {
         epoch_id: u64,
         service_name: String,
         service_method: String,
-        service_playload: String,
+        service_payload: String,
     ) -> Self {
         Self {
             cycles_limit,
@@ -39,7 +39,7 @@ impl DefaultRequestContext {
             epoch_id,
             service_name,
             service_method,
-            service_playload,
+            service_payload,
             events: Rc::new(RefCell::new(Vec::new())),
         }
     }
@@ -48,7 +48,7 @@ impl DefaultRequestContext {
         context: &DefaultRequestContext,
         service_name: String,
         service_method: String,
-        service_playload: String,
+        service_payload: String,
     ) -> Self {
         Self {
             cycles_limit: context.cycles_limit,
@@ -58,14 +58,14 @@ impl DefaultRequestContext {
             epoch_id: context.epoch_id,
             service_name,
             service_method,
-            service_playload,
+            service_payload,
             events: Rc::clone(&context.events),
         }
     }
 }
 
 impl RequestContext for DefaultRequestContext {
-    fn sub_cycles(&mut self, cycles: u64) -> ProtocolResult<()> {
+    fn sub_cycles(&self, cycles: u64) -> ProtocolResult<()> {
         if self.get_cycles_used() + cycles <= self.cycles_limit {
             *self.cycles_used.borrow_mut() = self.get_cycles_used() + cycles;
             Ok(())
@@ -102,8 +102,8 @@ impl RequestContext for DefaultRequestContext {
         &self.service_method
     }
 
-    fn get_playload(&self) -> &str {
-        &self.service_playload
+    fn get_payload(&self) -> &str {
+        &self.service_payload
     }
 
     fn emit_event(&mut self, message: String) -> ProtocolResult<()> {

--- a/core/binding/src/sdk/mod.rs
+++ b/core/binding/src/sdk/mod.rs
@@ -144,18 +144,13 @@ impl<S: 'static + ServiceState, C: ChainQuerier, R: RequestContext> ServiceSDK
     // Call other read-only methods of `service` and return the results
     // synchronously NOTE: You can use recursive calls, but the maximum call
     // stack is 1024
-    fn read(&self, service: &str, method: &str, playload: &str) -> ProtocolResult<json::JsonValue> {
+    fn read(&self, service: &str, method: &str, payload: &str) -> ProtocolResult<&str> {
         unimplemented!();
     }
 
     // Call other writable methods of `service` and return the results synchronously
     // NOTE: You can use recursive calls, but the maximum call stack is 1024
-    fn write(
-        &mut self,
-        service: &str,
-        method: &str,
-        playload: &str,
-    ) -> ProtocolResult<json::JsonValue> {
+    fn write(&mut self, service: &str, method: &str, payload: &str) -> ProtocolResult<&str> {
         unimplemented!();
     }
 }

--- a/core/binding/src/tests/request_context.rs
+++ b/core/binding/src/tests/request_context.rs
@@ -13,7 +13,7 @@ fn test_request_context() {
         1,
         "service_name".to_owned(),
         "service_method".to_owned(),
-        "service_playload".to_owned(),
+        "service_payload".to_owned(),
     );
 
     ctx.sub_cycles(8).unwrap();
@@ -25,5 +25,5 @@ fn test_request_context() {
     assert_eq!(ctx.get_current_epoch_id(), 1);
     assert_eq!(ctx.get_service_name(), "service_name");
     assert_eq!(ctx.get_service_method(), "service_method");
-    assert_eq!(ctx.get_playload(), "service_playload");
+    assert_eq!(ctx.get_payload(), "service_payload");
 }

--- a/core/binding/src/tests/sdk.rs
+++ b/core/binding/src/tests/sdk.rs
@@ -304,6 +304,6 @@ pub fn mock_request_context() -> DefaultRequestContext {
         1,
         "service_name".to_owned(),
         "service_method".to_owned(),
-        "service_playload".to_owned(),
+        "service_payload".to_owned(),
     )
 }

--- a/protocol/src/traits/binding.rs
+++ b/protocol/src/traits/binding.rs
@@ -54,7 +54,7 @@ pub trait ChainQuerier {
 }
 
 pub trait RequestContext: Clone {
-    fn sub_cycles(&mut self, cycles: u64) -> ProtocolResult<()>;
+    fn sub_cycles(&self, cycles: u64) -> ProtocolResult<()>;
 
     fn get_cycles_price(&self) -> u64;
 
@@ -70,7 +70,7 @@ pub trait RequestContext: Clone {
 
     fn get_service_method(&self) -> &str;
 
-    fn get_playload(&self) -> &str;
+    fn get_payload(&self) -> &str;
 
     // Trigger an `event`, which can be any string
     // NOTE: The string is recommended as json string
@@ -95,18 +95,18 @@ pub trait AdmissionControl {
 // - write: provide some writable functions for users or other services to call
 pub trait Service {
     // Executed before the epoch is executed.
-    fn hook_before(&mut self) -> ProtocolResult<()> {
+    fn hook_before_(&mut self) -> ProtocolResult<()> {
         Ok(())
     }
 
     // Executed after epoch execution.
-    fn hook_after(&mut self) -> ProtocolResult<()> {
+    fn hook_after_(&mut self) -> ProtocolResult<()> {
         Ok(())
     }
 
-    fn write<Context: RequestContext>(&mut self, ctx: Context) -> ProtocolResult<json::JsonValue>;
+    fn write_<Context: RequestContext>(&mut self, ctx: Context) -> ProtocolResult<String>;
 
-    fn read<Context: RequestContext>(&self, ctx: Context) -> ProtocolResult<json::JsonValue>;
+    fn read_<Context: RequestContext>(&self, ctx: Context) -> ProtocolResult<String>;
 }
 
 // `ServiceSDK` provides multiple rich interfaces for `service` developers
@@ -193,16 +193,11 @@ pub trait ServiceSDK {
     // Call other read-only methods of `service` and return the results
     // synchronously NOTE: You can use recursive calls, but the maximum call
     // stack is 1024
-    fn read(&self, service: &str, method: &str, playload: &str) -> ProtocolResult<json::JsonValue>;
+    fn read(&self, servide: &str, method: &str, payload: &str) -> ProtocolResult<&str>;
 
     // Call other writable methods of `service` and return the results synchronously
     // NOTE: You can use recursive calls, but the maximum call stack is 1024
-    fn write(
-        &mut self,
-        service: &str,
-        method: &str,
-        playload: &str,
-    ) -> ProtocolResult<json::JsonValue>;
+    fn write(&mut self, servide: &str, method: &str, payload: &str) -> ProtocolResult<&str>;
 }
 
 pub trait StoreMap<Key: FixedCodec + PartialEq, Value: FixedCodec> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
Feature

**What this PR does / why we need it**:

`#[service]` will automatically implement trait `protocol::traits::Service` and enrich its 4 methods (`hook_before_`、`hook_after_`、`write_`、`read_`).

- #[read]: accessible via `read_`.
- #[write]: accessible via `write_`.
- #[hook_before]: when calling `hook_before_`, it is actually calling a method with the attribute `#[hook_before]`
- #[hook_after]: when calling `hook_after_`, it is actually calling a method with the attribute `#[hook_after]`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
The main code logic is in `core/binding-macro/src/servive.rs`, you can look at `core/binding-macro/tests/mod.rs#test_impl_service` first and learn how to use it.

You can also view the expanded code of the macro through the `core/binding-macro/src/lib.rs#service` documentation comments.
