### PR TITLE
[ᚬframework] feat(core/binding-macro): Support for returning a struct.

### DIFF
--- a/binding-macro/src/lib.rs
+++ b/binding-macro/src/lib.rs
@@ -22,7 +22,7 @@ use crate::servive::gen_service_code;
 ///  2. Is visibility private?
 ///  3. Does function generics constrain `fn f<Context: RequestContext>`?
 ///  4. Parameter signature contains `&self and ctx:Context`?
-///  5. Is the return value `ProtocolResult <String>`?
+///  5. Is the return value `ProtocolResult <T: Deserialize + Serialize>`?
 ///
 /// # Example:
 ///
@@ -198,7 +198,8 @@ pub fn hook_before(_: TokenStream, item: TokenStream) -> TokenStream {
 ///             "create_kitty" => {
 ///                 let payload: CreateKittyPayload = serde_json::from_str(ctx.get_payload())
 ///                     .map_err(|e| core_binding::ServiceError::JsonParse(e))?;
-///                 self.create_kitty(ctx, payload)
+///                 let res = self.create_kitty(ctx, payload)?;
+///                 serde_json::to_string(&res).map_err(|e| framework::ServiceError::JsonParse(e).into())
 ///             }
 ///             _ => Err(core_binding::ServiceError::NotFoundMethod(method.to_owned()).into()),
 ///         }
@@ -211,7 +212,8 @@ pub fn hook_before(_: TokenStream, item: TokenStream) -> TokenStream {
 ///             "get_kitty" => {
 ///                 let payload: GetKittyPayload = serde_json::from_str(ctx.get_payload())
 ///                     .map_err(|e| core_binding::ServiceError::JsonParse(e))?;
-///                 self.get_kitty(ctx, payload)
+///                 let res = self.get_kitty(ctx, payload)?;
+///                 serde_json::to_string(&res).map_err(|e| framework::ServiceError::JsonParse(e).into())
 ///             }
 ///             _ => Err(core_binding::ServiceError::NotFoundMethod(method.to_owned()).into()),
 ///         }

--- a/binding-macro/tests/mod.rs
+++ b/binding-macro/tests/mod.rs
@@ -89,6 +89,11 @@ fn test_impl_service() {
         age:  u64,
         sex:  bool,
     }
+    #[derive(Serialize, Deserialize, Debug)]
+    struct TestServiceResponse {
+        pub message: String,
+    }
+
     struct Tests<SDK: ServiceSDK> {
         _sdk:        SDK,
         hook_before: bool,
@@ -123,8 +128,10 @@ fn test_impl_service() {
             &self,
             _ctx: Context,
             _payload: TestServicePayload,
-        ) -> ProtocolResult<String> {
-            Ok("read ok".to_owned())
+        ) -> ProtocolResult<TestServiceResponse> {
+            Ok(TestServiceResponse {
+                message: "read ok".to_owned(),
+            })
         }
 
         #[write]
@@ -132,8 +139,10 @@ fn test_impl_service() {
             &mut self,
             _ctx: Context,
             _payload: TestServicePayload,
-        ) -> ProtocolResult<String> {
-            Ok("write ok".to_owned())
+        ) -> ProtocolResult<TestServiceResponse> {
+            Ok(TestServiceResponse {
+                message: "write ok".to_owned(),
+            })
         }
     }
 
@@ -149,11 +158,11 @@ fn test_impl_service() {
 
     let context = MockRequestContext::with_method(1024 * 1024, "test_write", &payload_str);
     let write_res = test_service.write_(context).unwrap();
-    assert_eq!(write_res, "write ok");
+    assert_eq!(write_res, r#"{"message":"write ok"}"#);
 
     let context = MockRequestContext::with_method(1024 * 1024, "test_read", &payload_str);
     let read_res = test_service.read_(context).unwrap();
-    assert_eq!(read_res, "read ok");
+    assert_eq!(read_res, r#"{"message":"read ok"}"#);
 
     let context = MockRequestContext::with_method(1024 * 1024, "test_notfound", &payload_str);
     let read_res = test_service.read_(context.clone());


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
feature

**What this PR does / why we need it**:
Return structs are supported, but `serde::Deserialize` and `serde::Serialize` must be added to `Derive`.

such as
```rust
#[derive(Deserialize, Serialize, Clone)]
pub struct GetBalancePayload {
    pub asset_id: Hash,
}

#[service]
impl<SDK: ServiceSDK> AssetService<SDK> {
    #[read]
    fn get_balance<Context: RequestContext>(
        &self,
        ctx: Context,
        payload: GetBalancePayload,
    ) -> ProtocolResult<GetBalanceResponse> {
        let balance = self
            .sdk
            .get_account_value(&ctx.get_caller(), &payload.asset_id)?
            .unwrap_or(0);
        Ok(GetBalanceResponse {
            asset_id: payload.asset_id,
            balance,
        })
    }
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
