### PR TITLE
[ᚬframework] feat(framework/binding): add Iterator and impl FixedCodec for rust primitive type

### DIFF
--- a/built-in-services/asset/src/lib.rs
+++ b/built-in-services/asset/src/lib.rs
@@ -113,7 +113,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             .into());
         }
 
-        let to_balance = self.sdk.get_account_value(&to, &asset_id)?.unwrap_or(0);
+        let to_balance: u64 = self.sdk.get_account_value(&to, &asset_id)?.unwrap_or(0);
         let (v, overflow) = to_balance.overflowing_add(value);
         if overflow {
             return Err(ServiceError::U64Overflow.into());

--- a/framework/src/binding/store/primitive.rs
+++ b/framework/src/binding/store/primitive.rs
@@ -28,30 +28,13 @@ impl<S: ServiceState> DefaultStoreBool<S> {
 
 impl<S: ServiceState> StoreBool for DefaultStoreBool<S> {
     fn get(&self) -> ProtocolResult<bool> {
-        let bs: Bytes = self
-            .state
-            .borrow()
-            .get(&self.key)?
-            .ok_or(StoreError::GetNone)?;
+        let b: Option<bool> = self.state.borrow().get(&self.key)?;
 
-        let mut rdr = Cursor::new(bs.to_vec());
-        let u = rdr.read_u8().expect("read u8 should not fail");
-        match u {
-            0 => Ok(false),
-            1 => Ok(true),
-            _ => Err(StoreError::DecodeError.into()),
-        }
+        b.ok_or(StoreError::GetNone.into())
     }
 
     fn set(&mut self, b: bool) -> ProtocolResult<()> {
-        let bs = if b {
-            [1u8; mem::size_of::<u8>()]
-        } else {
-            [0u8; mem::size_of::<u8>()]
-        };
-
-        let val = Bytes::from(bs.as_ref());
-        self.state.borrow_mut().insert(self.key.clone(), val)?;
+        self.state.borrow_mut().insert(self.key.clone(), b)?;
         Ok(())
     }
 }
@@ -72,25 +55,12 @@ impl<S: ServiceState> DefaultStoreUint64<S> {
 
 impl<S: ServiceState> StoreUint64 for DefaultStoreUint64<S> {
     fn get(&self) -> ProtocolResult<u64> {
-        let bs: Bytes = self
-            .state
-            .borrow()
-            .get(&self.key)?
-            .ok_or(StoreError::GetNone)?;
-        let mut rdr = Cursor::new(bs.to_vec());
+        let u: Option<u64> = self.state.borrow().get(&self.key)?;
 
-        Ok(rdr
-            .read_u64::<LittleEndian>()
-            .expect("read u64 should not fail"))
+        u.ok_or(StoreError::GetNone.into())
     }
 
     fn set(&mut self, val: u64) -> ProtocolResult<()> {
-        let mut bs = [0u8; mem::size_of::<u64>()];
-        bs.as_mut()
-            .write_u64::<LittleEndian>(val)
-            .expect("write u64 should not fail");
-        let val = Bytes::from(bs.as_ref());
-
         self.state.borrow_mut().insert(self.key.clone(), val)?;
         Ok(())
     }
@@ -181,24 +151,20 @@ impl<S: ServiceState> DefaultStoreString<S> {
 
 impl<S: ServiceState> StoreString for DefaultStoreString<S> {
     fn set(&mut self, val: &str) -> ProtocolResult<()> {
-        let val = Bytes::from(val);
-
-        self.state.borrow_mut().insert(self.key.clone(), val)?;
+        self.state
+            .borrow_mut()
+            .insert(self.key.clone(), val.to_string())?;
         Ok(())
     }
 
     fn get(&self) -> ProtocolResult<String> {
-        let bs: Bytes = self
-            .state
-            .borrow()
-            .get(&self.key)?
-            .ok_or(StoreError::GetNone)?;
+        let s: Option<String> = self.state.borrow().get(&self.key)?;
 
-        Ok(String::from_utf8(bs.to_vec()).expect("get string should not fail"))
+        s.ok_or(StoreError::GetNone.into())
     }
 
-    fn len(&self) -> ProtocolResult<usize> {
-        self.get().map(|s| s.len())
+    fn len(&self) -> ProtocolResult<u32> {
+        self.get().map(|s| s.len() as u32)
     }
 
     fn is_empty(&self) -> ProtocolResult<bool> {

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -57,6 +57,13 @@ fn test_service_sdk() {
         Bytes::from("val_1")
     );
 
+    let mut it = sdk_map.iter();
+    assert_eq!(
+        it.next().unwrap(),
+        (&Hash::digest(Bytes::from("key_1")), Bytes::from("val_1"))
+    );
+    assert_eq!(it.next().is_none(), true);
+
     // test sdk array
     let mut sdk_array = sdk.alloc_or_recover_array::<Hash>("test_array").unwrap();
     assert_eq!(sdk_array.is_empty().unwrap(), true);
@@ -64,9 +71,13 @@ fn test_service_sdk() {
     sdk_array.push(Hash::digest(Bytes::from("key_1"))).unwrap();
 
     assert_eq!(
-        sdk_array.get(0usize).unwrap(),
+        sdk_array.get(0).unwrap(),
         Hash::digest(Bytes::from("key_1"))
     );
+
+    let mut it = sdk_array.iter();
+    assert_eq!(it.next().unwrap(), (0, Hash::digest(Bytes::from("key_1"))));
+    assert_eq!(it.next().is_none(), true);
 
     // test get/set account value
     sdk.set_account_value(&mock_address(), Bytes::from("ak"), Bytes::from("av"))

--- a/framework/src/binding/tests/store.rs
+++ b/framework/src/binding/tests/store.rs
@@ -69,7 +69,7 @@ fn test_default_store_string() {
 
     ss.set("ok").unwrap();
     assert_eq!(ss.get().unwrap(), String::from("ok"));
-    assert_eq!(ss.len().unwrap(), 2usize);
+    assert_eq!(ss.len().unwrap(), 2u32);
 }
 
 #[test]
@@ -84,6 +84,19 @@ fn test_default_store_map() {
         .unwrap();
     sm.insert(Hash::digest(Bytes::from("key_2")), Bytes::from("val_2"))
         .unwrap();
+
+    {
+        let mut it = sm.iter();
+        assert_eq!(
+            it.next().unwrap(),
+            (&Hash::digest(Bytes::from("key_1")), Bytes::from("val_1"))
+        );
+        assert_eq!(
+            it.next().unwrap(),
+            (&Hash::digest(Bytes::from("key_2")), Bytes::from("val_2"))
+        );
+        assert_eq!(it.next().is_none(), true);
+    }
 
     assert_eq!(
         sm.get(&Hash::digest(Bytes::from("key_1"))).unwrap(),
@@ -100,7 +113,7 @@ fn test_default_store_map() {
         sm.contains(&Hash::digest(Bytes::from("key_1"))).unwrap(),
         false
     );
-    assert_eq!(sm.len().unwrap(), 1usize)
+    assert_eq!(sm.len().unwrap(), 1u32)
 }
 
 #[test]
@@ -111,16 +124,23 @@ fn test_default_store_array() {
 
     let mut sa = DefaultStoreArray::<_, Bytes>::new(Rc::clone(&rs), "test");
 
-    assert_eq!(sa.len().unwrap(), 0usize);
+    assert_eq!(sa.len().unwrap(), 0u32);
 
     sa.push(Bytes::from("111")).unwrap();
     sa.push(Bytes::from("222")).unwrap();
 
-    assert_eq!(sa.get(0usize).unwrap(), Bytes::from("111"));
-    assert_eq!(sa.get(1usize).unwrap(), Bytes::from("222"));
+    {
+        let mut it = sa.iter();
+        assert_eq!(it.next().unwrap(), (0u32, Bytes::from("111")));
+        assert_eq!(it.next().unwrap(), (1u32, Bytes::from("222")));
+        assert_eq!(it.next().is_none(), true);
+    }
 
-    sa.remove(0usize).unwrap();
+    assert_eq!(sa.get(0u32).unwrap(), Bytes::from("111"));
+    assert_eq!(sa.get(1u32).unwrap(), Bytes::from("222"));
 
-    assert_eq!(sa.len().unwrap(), 1usize);
-    assert_eq!(sa.get(0usize).unwrap(), Bytes::from("222"));
+    sa.remove(0u32).unwrap();
+
+    assert_eq!(sa.len().unwrap(), 1u32);
+    assert_eq!(sa.get(0u32).unwrap(), Bytes::from("222"));
 }

--- a/protocol/src/fixed_codec/mod.rs
+++ b/protocol/src/fixed_codec/mod.rs
@@ -25,7 +25,14 @@ pub trait FixedCodec: Sized {
 #[derive(Debug, Display, From)]
 pub enum FixedCodecError {
     Decoder(rlp::DecoderError),
+
     StringUTF8(std::string::FromUtf8Error),
+
+    #[display(fmt = "wrong bytes of bool")]
+    DecodeBool,
+
+    #[display(fmt = "wrong bytes of u8")]
+    DecodeUint8,
 }
 
 impl Error for FixedCodecError {}

--- a/protocol/src/fixed_codec/primitive.rs
+++ b/protocol/src/fixed_codec/primitive.rs
@@ -90,21 +90,6 @@ impl FixedCodec for Bytes {
     }
 }
 
-impl FixedCodec for u64 {
-    fn encode_fixed(&self) -> ProtocolResult<Bytes> {
-        let mut bs = [0u8; mem::size_of::<u64>()];
-        bs.as_mut()
-            .write_u64::<LittleEndian>(*self)
-            .expect("write u64 should not fail");
-
-        Ok(Bytes::from(bs.as_ref()))
-    }
-
-    fn decode_fixed(bytes: Bytes) -> ProtocolResult<Self> {
-        Ok(LittleEndian::read_u64(bytes.as_ref()))
-    }
-}
-
 // AssetID, MerkleRoot are alias of Hash type
 impl rlp::Encodable for Hash {
     fn rlp_append(&self, s: &mut rlp::RlpStream) {

--- a/protocol/src/fixed_codec/tests/fixed_codec.rs
+++ b/protocol/src/fixed_codec/tests/fixed_codec.rs
@@ -17,6 +17,33 @@ macro_rules! test_eq {
 }
 
 #[test]
+fn test_fixed_codec_primitive() {
+    let bs = true.encode_fixed().unwrap();
+    assert_eq!(<bool as FixedCodec>::decode_fixed(bs).unwrap(), true);
+
+    let bs = false.encode_fixed().unwrap();
+    assert_eq!(<bool as FixedCodec>::decode_fixed(bs).unwrap(), false);
+
+    let bs = 0u8.encode_fixed().unwrap();
+    assert_eq!(<u8 as FixedCodec>::decode_fixed(bs).unwrap(), 0u8);
+
+    let bs = 8u8.encode_fixed().unwrap();
+    assert_eq!(<u8 as FixedCodec>::decode_fixed(bs).unwrap(), 8u8);
+
+    let bs = 8u32.encode_fixed().unwrap();
+    assert_eq!(<u32 as FixedCodec>::decode_fixed(bs).unwrap(), 8u32);
+
+    let bs = 8u64.encode_fixed().unwrap();
+    assert_eq!(<u64 as FixedCodec>::decode_fixed(bs).unwrap(), 8u64);
+
+    let bs = "test".to_owned().encode_fixed().unwrap();
+    assert_eq!(
+        <String as FixedCodec>::decode_fixed(bs).unwrap(),
+        "test".to_owned()
+    );
+}
+
+#[test]
 fn test_fixed_codec() {
     test_eq!(primitive, Hash, mock_hash);
 

--- a/protocol/src/traits/binding.rs
+++ b/protocol/src/traits/binding.rs
@@ -1,3 +1,5 @@
+use std::iter::Iterator;
+
 use derive_more::{Display, From};
 use serde::{Deserialize, Serialize};
 
@@ -239,31 +241,25 @@ pub trait StoreMap<Key: FixedCodec + PartialEq, Value: FixedCodec> {
 
     fn remove(&mut self, key: &Key) -> ProtocolResult<()>;
 
-    fn len(&self) -> ProtocolResult<usize>;
+    fn len(&self) -> ProtocolResult<u32>;
 
     fn is_empty(&self) -> ProtocolResult<bool>;
 
-    fn for_each<F>(&mut self, f: F) -> ProtocolResult<()>
-    where
-        Self: Sized,
-        F: FnMut(&mut Value) -> ProtocolResult<()>;
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&Key, Value)> + 'a>;
 }
 
 pub trait StoreArray<Elm: FixedCodec> {
-    fn get(&self, index: usize) -> ProtocolResult<Elm>;
+    fn get(&self, index: u32) -> ProtocolResult<Elm>;
 
     fn push(&mut self, element: Elm) -> ProtocolResult<()>;
 
-    fn remove(&mut self, index: usize) -> ProtocolResult<()>;
+    fn remove(&mut self, index: u32) -> ProtocolResult<()>;
 
-    fn len(&self) -> ProtocolResult<usize>;
+    fn len(&self) -> ProtocolResult<u32>;
 
     fn is_empty(&self) -> ProtocolResult<bool>;
 
-    fn for_each<F>(&mut self, f: F) -> ProtocolResult<()>
-    where
-        Self: Sized,
-        F: FnMut(&mut Elm) -> ProtocolResult<()>;
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (u32, Elm)> + 'a>;
 }
 
 pub trait StoreUint64 {
@@ -301,7 +297,7 @@ pub trait StoreString {
 
     fn set(&mut self, val: &str) -> ProtocolResult<()>;
 
-    fn len(&self) -> ProtocolResult<usize>;
+    fn len(&self) -> ProtocolResult<u32>;
 
     fn is_empty(&self) -> ProtocolResult<bool>;
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**

add feat(framework/binding)

**What this PR does / why we need it**:
1. Add Iterator for StoreMap and StoreArray
```rust
pub trait StoreMap<Key: FixedCodec + PartialEq, Value: FixedCodec> {
    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&Key, Value)> + 'a>;
}

pub trait StoreArray<Elm: FixedCodec> {
    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (u32, Elm)> + 'a>;
}
```
2. Impl FixedCodec for u8, u32, u64, bool, String

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
