### PR TITLE
[ᚬmaster] feat(framework): add service-call-service feature

### DIFF
--- a/binding-macro/tests/mod.rs
+++ b/binding-macro/tests/mod.rs
@@ -282,13 +282,25 @@ impl ServiceSDK for MockServiceSDK {
     // Call other read-only methods of `service` and return the results
     // synchronously NOTE: You can use recursive calls, but the maximum call
     // stack is 1024
-    fn read(&self, _service: &str, _method: &str, _payload: &str) -> ProtocolResult<&str> {
+    fn read(
+        &self,
+        _ctx: &ServiceContext,
+        _service: &str,
+        _method: &str,
+        _payload: &str,
+    ) -> ProtocolResult<String> {
         unimplemented!()
     }
 
     // Call other writable methods of `service` and return the results synchronously
     // NOTE: You can use recursive calls, but the maximum call stack is 1024
-    fn write(&mut self, _service: &str, _method: &str, _payload: &str) -> ProtocolResult<&str> {
+    fn write(
+        &mut self,
+        _ctx: &ServiceContext,
+        _service: &str,
+        _method: &str,
+        _payload: &str,
+    ) -> ProtocolResult<String> {
         unimplemented!()
     }
 }

--- a/built-in-services/asset/src/tests/mod.rs
+++ b/built-in-services/asset/src/tests/mod.rs
@@ -7,7 +7,7 @@ use cita_trie::MemoryDB;
 
 use framework::binding::sdk::{DefalutServiceSDK, DefaultChainQuerier};
 use framework::binding::state::{GeneralServiceState, MPTTrie};
-use protocol::traits::{DispatcherHolder, Storage};
+use protocol::traits::{NoopDispatcher, Storage};
 use protocol::types::{
     Address, Epoch, Hash, Proof, Receipt, ServiceContext, ServiceContextParams, SignedTransaction,
 };
@@ -95,7 +95,7 @@ fn new_asset_service() -> AssetService<
     DefalutServiceSDK<
         GeneralServiceState<MemoryDB>,
         DefaultChainQuerier<MockStorage>,
-        DispatcherHolder,
+        NoopDispatcher,
     >,
 > {
     let chain_db = DefaultChainQuerier::new(Arc::new(MockStorage {}));
@@ -105,7 +105,7 @@ fn new_asset_service() -> AssetService<
     let sdk = DefalutServiceSDK::new(
         Rc::new(RefCell::new(state)),
         Rc::new(chain_db),
-        DispatcherHolder {},
+        NoopDispatcher {},
     );
 
     AssetService::init(sdk).unwrap()

--- a/built-in-services/asset/src/tests/mod.rs
+++ b/built-in-services/asset/src/tests/mod.rs
@@ -7,7 +7,7 @@ use cita_trie::MemoryDB;
 
 use framework::binding::sdk::{DefalutServiceSDK, DefaultChainQuerier};
 use framework::binding::state::{GeneralServiceState, MPTTrie};
-use protocol::traits::Storage;
+use protocol::traits::{DispatcherHolder, Storage};
 use protocol::types::{
     Address, Epoch, Hash, Proof, Receipt, ServiceContext, ServiceContextParams, SignedTransaction,
 };
@@ -91,14 +91,22 @@ fn test_transfer() {
     assert_eq!(balance_res.balance, 1024);
 }
 
-fn new_asset_service(
-) -> AssetService<DefalutServiceSDK<GeneralServiceState<MemoryDB>, DefaultChainQuerier<MockStorage>>>
-{
+fn new_asset_service() -> AssetService<
+    DefalutServiceSDK<
+        GeneralServiceState<MemoryDB>,
+        DefaultChainQuerier<MockStorage>,
+        DispatcherHolder,
+    >,
+> {
     let chain_db = DefaultChainQuerier::new(Arc::new(MockStorage {}));
     let trie = MPTTrie::new(Arc::new(MemoryDB::new(false)));
     let state = GeneralServiceState::new(trie);
 
-    let sdk = DefalutServiceSDK::new(Rc::new(RefCell::new(state)), Rc::new(chain_db));
+    let sdk = DefalutServiceSDK::new(
+        Rc::new(RefCell::new(state)),
+        Rc::new(chain_db),
+        DispatcherHolder {},
+    );
 
     AssetService::init(sdk).unwrap()
 }

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -26,3 +26,4 @@ serde_json = "1.0"
 [dev-dependencies]
 async-trait = "0.1"
 toml = "0.5"
+binding-macro = { path = "../binding-macro" }

--- a/framework/src/binding/sdk/mod.rs
+++ b/framework/src/binding/sdk/mod.rs
@@ -156,7 +156,7 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
             payload.to_string(),
         );
 
-        let result = self.dispatcher.call(ctx, true)?;
+        let result = self.dispatcher.read(ctx)?;
         if result.is_error {
             Err(SDKError::DispatchFailed { error: result.ret }.into())
         } else {
@@ -180,7 +180,7 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
             payload.to_string(),
         );
 
-        let result = self.dispatcher.call(ctx, false)?;
+        let result = self.dispatcher.write(ctx)?;
         if result.is_error {
             Err(SDKError::DispatchFailed { error: result.ret }.into())
         } else {

--- a/framework/src/binding/sdk/mod.rs
+++ b/framework/src/binding/sdk/mod.rs
@@ -5,33 +5,39 @@ pub use chain_querier::{ChainQueryError, DefaultChainQuerier};
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use derive_more::{Display, From};
+
 use protocol::fixed_codec::FixedCodec;
 use protocol::traits::{
-    ChainQuerier, ServiceSDK, ServiceState, StoreArray, StoreBool, StoreMap, StoreString,
-    StoreUint64,
+    ChainQuerier, Dispatcher, ServiceSDK, ServiceState, StoreArray, StoreBool, StoreMap,
+    StoreString, StoreUint64,
 };
-use protocol::types::{Address, Epoch, Hash, Receipt, SignedTransaction};
-use protocol::ProtocolResult;
+use protocol::types::{Address, Epoch, Hash, Receipt, ServiceContext, SignedTransaction};
+use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 use crate::binding::store::{
     DefaultStoreArray, DefaultStoreBool, DefaultStoreMap, DefaultStoreString, DefaultStoreUint64,
 };
 
-pub struct DefalutServiceSDK<S: ServiceState, C: ChainQuerier> {
+pub struct DefalutServiceSDK<S: ServiceState, C: ChainQuerier, D: Dispatcher> {
     state:         Rc<RefCell<S>>,
     chain_querier: Rc<C>,
+    dispatcher:    D,
 }
 
-impl<S: ServiceState, C: ChainQuerier> DefalutServiceSDK<S, C> {
-    pub fn new(state: Rc<RefCell<S>>, chain_querier: Rc<C>) -> Self {
+impl<S: ServiceState, C: ChainQuerier, D: Dispatcher> DefalutServiceSDK<S, C, D> {
+    pub fn new(state: Rc<RefCell<S>>, chain_querier: Rc<C>, dispatcher: D) -> Self {
         Self {
             state,
             chain_querier,
+            dispatcher,
         }
     }
 }
 
-impl<S: 'static + ServiceState, C: ChainQuerier> ServiceSDK for DefalutServiceSDK<S, C> {
+impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
+    for DefalutServiceSDK<S, C, D>
+{
     // Alloc or recover a `Map` by` var_name`
     fn alloc_or_recover_map<K: 'static + FixedCodec + PartialEq, V: 'static + FixedCodec>(
         &mut self,
@@ -136,13 +142,62 @@ impl<S: 'static + ServiceState, C: ChainQuerier> ServiceSDK for DefalutServiceSD
     // Call other read-only methods of `service` and return the results
     // synchronously NOTE: You can use recursive calls, but the maximum call
     // stack is 1024
-    fn read(&self, _service: &str, _method: &str, _payload: &str) -> ProtocolResult<&str> {
-        unimplemented!();
+    fn read(
+        &self,
+        ctx: &ServiceContext,
+        service: &str,
+        method: &str,
+        payload: &str,
+    ) -> ProtocolResult<String> {
+        let ctx = ServiceContext::with_context(
+            ctx,
+            service.to_string(),
+            method.to_string(),
+            payload.to_string(),
+        );
+
+        let result = self.dispatcher.call(ctx, true)?;
+        if result.is_error {
+            Err(SDKError::DispatchFailed { error: result.ret }.into())
+        } else {
+            Ok(result.ret)
+        }
     }
 
     // Call other writable methods of `service` and return the results synchronously
     // NOTE: You can use recursive calls, but the maximum call stack is 1024
-    fn write(&mut self, _service: &str, _method: &str, _payload: &str) -> ProtocolResult<&str> {
-        unimplemented!();
+    fn write(
+        &mut self,
+        ctx: &ServiceContext,
+        service: &str,
+        method: &str,
+        payload: &str,
+    ) -> ProtocolResult<String> {
+        let ctx = ServiceContext::with_context(
+            ctx,
+            service.to_string(),
+            method.to_string(),
+            payload.to_string(),
+        );
+
+        let result = self.dispatcher.call(ctx, false)?;
+        if result.is_error {
+            Err(SDKError::DispatchFailed { error: result.ret }.into())
+        } else {
+            Ok(result.ret)
+        }
+    }
+}
+
+#[derive(Debug, Display, From)]
+pub enum SDKError {
+    #[display(fmt = "dispatch failed: {:?}", error)]
+    DispatchFailed { error: String },
+}
+impl std::error::Error for SDKError {}
+
+impl From<SDKError> for ProtocolError {
+    fn from(err: SDKError) -> ProtocolError {
+        ProtocolError::new(ProtocolErrorKind::Binding, Box::new(err))
     }
 }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use cita_trie::MemoryDB;
 
-use protocol::traits::{ServiceSDK, Storage};
+use protocol::traits::{DispatcherHolder, ServiceSDK, Storage};
 use protocol::types::{
     Address, Epoch, EpochHeader, Event, Hash, MerkleRoot, Proof, RawTransaction, Receipt,
     ReceiptResponse, SignedTransaction, TransactionRequest, Validator,
@@ -26,7 +26,7 @@ fn test_service_sdk() {
     let arcs = Arc::new(MockStorage {});
     let cq = DefaultChainQuerier::new(Arc::clone(&arcs));
 
-    let mut sdk = DefalutServiceSDK::new(Rc::clone(&rs), Rc::new(cq));
+    let mut sdk = DefalutServiceSDK::new(Rc::clone(&rs), Rc::new(cq), DispatcherHolder {});
 
     // test sdk store bool
     let mut sdk_bool = sdk.alloc_or_recover_bool("test_bool").unwrap();

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use cita_trie::MemoryDB;
 
-use protocol::traits::{DispatcherHolder, ServiceSDK, Storage};
+use protocol::traits::{NoopDispatcher, ServiceSDK, Storage};
 use protocol::types::{
     Address, Epoch, EpochHeader, Event, Hash, MerkleRoot, Proof, RawTransaction, Receipt,
     ReceiptResponse, SignedTransaction, TransactionRequest, Validator,
@@ -26,7 +26,7 @@ fn test_service_sdk() {
     let arcs = Arc::new(MockStorage {});
     let cq = DefaultChainQuerier::new(Arc::clone(&arcs));
 
-    let mut sdk = DefalutServiceSDK::new(Rc::clone(&rs), Rc::new(cq), DispatcherHolder {});
+    let mut sdk = DefalutServiceSDK::new(Rc::clone(&rs), Rc::new(cq), NoopDispatcher {});
 
     // test sdk store bool
     let mut sdk_bool = sdk.alloc_or_recover_bool("test_bool").unwrap();

--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -6,7 +6,6 @@ pub use factory::ServiceExecutorFactory;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -237,8 +236,8 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
             .get_service(context.get_service_name(), sdk)?;
 
         let result = match exec_type {
-            ExecType::Read => service.deref().read_(context),
-            ExecType::Write => service.deref_mut().write_(context),
+            ExecType::Read => service.read_(context),
+            ExecType::Write => service.write_(context),
         };
 
         let (ret, is_error) = match result {

--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -15,7 +15,7 @@ use derive_more::{Display, From};
 
 use bytes::BytesMut;
 use protocol::traits::{
-    Dispatcher, DispatcherHolder, ExecResp, Executor, ExecutorParams, ExecutorResp, ServiceMapping,
+    Dispatcher, ExecResp, Executor, ExecutorParams, ExecutorResp, NoopDispatcher, ServiceMapping,
     ServiceState, Storage,
 };
 use protocol::types::{
@@ -90,7 +90,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
                         service: context.get_service_name().to_owned(),
                     })?;
             let sdk =
-                DefalutServiceSDK::new(Rc::clone(state), Rc::clone(&querier), DispatcherHolder {});
+                DefalutServiceSDK::new(Rc::clone(state), Rc::clone(&querier), NoopDispatcher {});
 
             let mut service = mapping.get_service(context.get_service_name(), sdk)?;
             service.write_(context.clone())?;

--- a/framework/src/executor/tests/mod.rs
+++ b/framework/src/executor/tests/mod.rs
@@ -1,3 +1,5 @@
+mod service_call_service;
+
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/framework/src/executor/tests/service_call_service.rs
+++ b/framework/src/executor/tests/service_call_service.rs
@@ -1,0 +1,142 @@
+use std::sync::Arc;
+
+use bytes::{Bytes, BytesMut};
+use cita_trie::MemoryDB;
+
+use asset::types::{Asset, CreateAssetPayload};
+use asset::{AssetService, ServiceError};
+use binding_macro::{cycles, service};
+
+use protocol::traits::{Executor, ExecutorParams, Service, ServiceMapping, ServiceSDK};
+use protocol::types::{
+    Genesis, Hash, RawTransaction, ServiceContext, SignedTransaction, TransactionRequest,
+};
+use protocol::ProtocolResult;
+
+use crate::executor::tests::MockStorage;
+use crate::executor::ServiceExecutor;
+
+#[test]
+fn test_service_call_service() {
+    let memdb = Arc::new(MemoryDB::new(false));
+    let arcs = Arc::new(MockStorage {});
+
+    let toml_str = include_str!("./genesis_services.toml");
+    let genesis: Genesis = toml::from_str(toml_str).unwrap();
+
+    let root = ServiceExecutor::create_genesis(
+        genesis.services,
+        Arc::clone(&memdb),
+        Arc::new(MockStorage {}),
+        Arc::new(MockServiceMapping {}),
+    )
+    .unwrap();
+
+    let mut executor = ServiceExecutor::with_root(
+        root.clone(),
+        Arc::clone(&memdb),
+        Arc::clone(&arcs),
+        Arc::new(MockServiceMapping {}),
+    )
+    .unwrap();
+
+    let params = ExecutorParams {
+        state_root:   root,
+        epoch_id:     1,
+        timestamp:    0,
+        cycels_limit: std::u64::MAX,
+    };
+
+    let raw = RawTransaction {
+        chain_id:     Hash::from_empty(),
+        nonce:        Hash::from_empty(),
+        timeout:      0,
+        cycles_price: 1,
+        cycles_limit: 60_000,
+        request:      TransactionRequest {
+            service_name: "mock".to_owned(),
+            method:       "call_asset".to_owned(),
+            payload:      r#"{ "name": "TestCallAsset", "symbol": "TCA", "supply": 320000011 }"#
+                .to_owned(),
+        },
+    };
+    let stx = SignedTransaction {
+        raw,
+        tx_hash: Hash::from_empty(),
+        pubkey: Bytes::from(
+            hex::decode("031288a6788678c25952eba8693b2f278f66e2187004b64ac09416d07f83f96d5b")
+                .unwrap(),
+        ),
+        signature: BytesMut::from("").freeze(),
+    };
+
+    let txs = vec![stx];
+    let executor_resp = executor.exec(&params, &txs).unwrap();
+    let receipt = &executor_resp.receipts[0];
+    let event = &receipt.events[0];
+
+    assert_eq!(50_000, receipt.cycles_used);
+    assert_eq!(
+        ("mock", "call create asset succeed"),
+        (event.service.as_str(), event.data.as_str())
+    );
+
+    assert_eq!(receipt.response.is_error, false);
+    let asset: Asset = serde_json::from_str(&receipt.response.ret).unwrap();
+    assert_eq!(asset.name, "TestCallAsset");
+    assert_eq!(asset.symbol, "TCA");
+    assert_eq!(asset.supply, 320_000_011);
+}
+
+pub struct MockService<SDK> {
+    sdk: SDK,
+}
+
+#[service]
+impl<SDK: ServiceSDK> MockService<SDK> {
+    pub fn init(sdk: SDK) -> ProtocolResult<Self> {
+        Ok(Self { sdk })
+    }
+
+    #[cycles(290_00)]
+    #[write]
+    fn call_asset(
+        &mut self,
+        ctx: ServiceContext,
+        payload: CreateAssetPayload,
+    ) -> ProtocolResult<Asset> {
+        let payload_str = serde_json::to_string(&payload).map_err(ServiceError::JsonParse)?;
+
+        let ret = self
+            .sdk
+            .write(&ctx, "asset", "create_asset", &payload_str)?;
+
+        let asset: Asset = serde_json::from_str(&ret).unwrap();
+
+        ctx.emit_event("call create asset succeed".to_owned())
+            .unwrap();
+        Ok(asset)
+    }
+}
+
+pub struct MockServiceMapping;
+
+impl ServiceMapping for MockServiceMapping {
+    fn get_service<SDK: 'static + ServiceSDK>(
+        &self,
+        name: &str,
+        sdk: SDK,
+    ) -> ProtocolResult<Box<dyn Service>> {
+        let service = match name {
+            "mock" => Box::new(MockService::init(sdk)?) as Box<dyn Service>,
+            "asset" => Box::new(AssetService::init(sdk)?) as Box<dyn Service>,
+            _ => panic!("not found service"),
+        };
+
+        Ok(service)
+    }
+
+    fn list_service_name(&self) -> Vec<String> {
+        vec!["asset".to_owned(), "mock".to_owned()]
+    }
+}

--- a/protocol/src/traits/binding.rs
+++ b/protocol/src/traits/binding.rs
@@ -192,11 +192,23 @@ pub trait ServiceSDK {
     // Call other read-only methods of `service` and return the results
     // synchronously NOTE: You can use recursive calls, but the maximum call
     // stack is 1024
-    fn read(&self, service: &str, method: &str, payload: &str) -> ProtocolResult<&str>;
+    fn read(
+        &self,
+        ctx: &ServiceContext,
+        service: &str,
+        method: &str,
+        payload: &str,
+    ) -> ProtocolResult<String>;
 
     // Call other writable methods of `service` and return the results synchronously
     // NOTE: You can use recursive calls, but the maximum call stack is 1024
-    fn write(&mut self, service: &str, method: &str, payload: &str) -> ProtocolResult<&str>;
+    fn write(
+        &mut self,
+        ctx: &ServiceContext,
+        service: &str,
+        method: &str,
+        payload: &str,
+    ) -> ProtocolResult<String>;
 }
 
 pub trait StoreMap<Key: FixedCodec + PartialEq, Value: FixedCodec> {

--- a/protocol/src/traits/executor.rs
+++ b/protocol/src/traits/executor.rs
@@ -55,13 +55,16 @@ pub trait Executor {
     ) -> ProtocolResult<ExecResp>;
 }
 
+// `Dispatcher` provides ability to send a call message to other services
 pub trait Dispatcher {
+    // Send a call message to mutate destination service, set `readonly` to `false`
+    // Otherwise, set `true`
     fn call(&self, context: ServiceContext, readonly: bool) -> ProtocolResult<ExecResp>;
 }
 
-pub struct DispatcherHolder;
+pub struct NoopDispatcher;
 
-impl Dispatcher for DispatcherHolder {
+impl Dispatcher for NoopDispatcher {
     fn call(&self, _context: ServiceContext, _readonly: bool) -> ProtocolResult<ExecResp> {
         unimplemented!()
     }

--- a/protocol/src/traits/executor.rs
+++ b/protocol/src/traits/executor.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use crate::traits::{ServiceMapping, Storage};
-use crate::types::{Address, Bloom, MerkleRoot, Receipt, SignedTransaction, TransactionRequest};
+use crate::types::{
+    Address, Bloom, MerkleRoot, Receipt, ServiceContext, SignedTransaction, TransactionRequest,
+};
 use crate::ProtocolResult;
 
 #[derive(Debug, Clone)]
@@ -51,4 +53,16 @@ pub trait Executor {
         cycles_price: u64,
         request: &TransactionRequest,
     ) -> ProtocolResult<ExecResp>;
+}
+
+pub trait Dispatcher {
+    fn call(&self, context: ServiceContext, readonly: bool) -> ProtocolResult<ExecResp>;
+}
+
+pub struct DispatcherHolder;
+
+impl Dispatcher for DispatcherHolder {
+    fn call(&self, _context: ServiceContext, _readonly: bool) -> ProtocolResult<ExecResp> {
+        unimplemented!()
+    }
 }

--- a/protocol/src/traits/executor.rs
+++ b/protocol/src/traits/executor.rs
@@ -57,15 +57,19 @@ pub trait Executor {
 
 // `Dispatcher` provides ability to send a call message to other services
 pub trait Dispatcher {
-    // Send a call message to mutate destination service, set `readonly` to `false`
-    // Otherwise, set `true`
-    fn call(&self, context: ServiceContext, readonly: bool) -> ProtocolResult<ExecResp>;
+    fn read(&self, context: ServiceContext) -> ProtocolResult<ExecResp>;
+
+    fn write(&self, context: ServiceContext) -> ProtocolResult<ExecResp>;
 }
 
 pub struct NoopDispatcher;
 
 impl Dispatcher for NoopDispatcher {
-    fn call(&self, _context: ServiceContext, _readonly: bool) -> ProtocolResult<ExecResp> {
+    fn read(&self, _context: ServiceContext) -> ProtocolResult<ExecResp> {
+        unimplemented!()
+    }
+
+    fn write(&self, _context: ServiceContext) -> ProtocolResult<ExecResp> {
         unimplemented!()
     }
 }

--- a/protocol/src/traits/mod.rs
+++ b/protocol/src/traits/mod.rs
@@ -12,7 +12,9 @@ pub use binding::{
     ServiceState, StoreArray, StoreBool, StoreMap, StoreString, StoreUint64,
 };
 pub use consensus::{Consensus, ConsensusAdapter, MessageTarget, NodeInfo};
-pub use executor::{ExecResp, Executor, ExecutorFactory, ExecutorParams, ExecutorResp};
+pub use executor::{
+    Dispatcher, DispatcherHolder, ExecResp, Executor, ExecutorFactory, ExecutorParams, ExecutorResp,
+};
 pub use mempool::{MemPool, MemPoolAdapter, MixedTxHashes};
 pub use network::{Gossip, MessageCodec, MessageHandler, Priority, Rpc};
 pub use storage::{Storage, StorageAdapter, StorageBatchModify, StorageCategory, StorageSchema};

--- a/protocol/src/traits/mod.rs
+++ b/protocol/src/traits/mod.rs
@@ -13,7 +13,7 @@ pub use binding::{
 };
 pub use consensus::{Consensus, ConsensusAdapter, MessageTarget, NodeInfo};
 pub use executor::{
-    Dispatcher, DispatcherHolder, ExecResp, Executor, ExecutorFactory, ExecutorParams, ExecutorResp,
+    Dispatcher, ExecResp, Executor, ExecutorFactory, ExecutorParams, ExecutorResp, NoopDispatcher,
 };
 pub use mempool::{MemPool, MemPoolAdapter, MixedTxHashes};
 pub use network::{Gossip, MessageCodec, MessageHandler, Priority, Rpc};

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -35,7 +35,7 @@ use protocol::{fixed_codec::FixedCodec, ProtocolError, ProtocolResult};
 use crate::config::Config;
 use crate::MainError;
 
-pub async fn create_genesis<Mapping: ServiceMapping>(
+pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
     config: &Config,
     genesis: &Genesis,
     servive_mapping: Arc<Mapping>,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**

add framework feature: service call service

**What this PR does / why we need it**:

using ServiceSDK call another service is supported now
```rust
pub trait ServiceSDK {
    fn read(
        &self,
        ctx: &ServiceContext,
        service: &str,
        method: &str,
        payload: &str,
    ) -> ProtocolResult<String>;

    fn write(
        &mut self,
        ctx: &ServiceContext,
        service: &str,
        method: &str,
        payload: &str,
    ) -> ProtocolResult<String>;

      ... ...
}

```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
- path of tests:  framework/src/executor/tests/service_call_service.rs