### PR TITLE
[ᚬmaster] feat(keypair): add another generate keypair arg

### DIFF
--- a/devtools/keypair/Cargo.toml
+++ b/devtools/keypair/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "muta-keypair"
 version = "0.1.0-alpha.0"
-authors = ["Eason Gao <kaoimin@qq.com>"]
+authors = ["Muta Dev <muta@nervos.org>"]
 edition = "2018"
 include = ["Cargo.toml", "src/*"]
 repository = "https://github.com/nervosnetwork/muta/tree/master/devtools/keypair"

--- a/devtools/keypair/Cargo.toml
+++ b/devtools/keypair/Cargo.toml
@@ -1,19 +1,23 @@
 [package]
-name = "keypair"
+name = "muta-keypair"
 version = "0.1.0-alpha.0"
-authors = ["zero.qn <zero.qn@outlook.com>"]
+authors = ["Eason Gao <kaoimin@qq.com>"]
 edition = "2018"
-repository = "https://github.com/nervosnetwork/muta"
+include = ["Cargo.toml", "src/*"]
+repository = "https://github.com/nervosnetwork/muta/tree/master/devtools/keypair"
+license = "MIT"
+description = "A tool to generate keypairs for muta framework"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-common-crypto = { path = "../../common/crypto" }
-protocol = { path = "../../protocol", package = "muta-protocol" }
-
-hex = "0.4"
-rand = "0.7"
-tentacle-secio = { version = "0.1", features = [ "flatc" ] }
 clap = { version = "2.33", features = ["yaml"] }
+hex = "0.4"
+ophelia-bls-amcl = "0.1"
+ophelia-secp256k1 = "0.2"
+ophelia = "0.2"
+protocol = { version = "0.1.0-alpha.0", package = "muta-protocol" }
+rand = "0.7"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
+tentacle-secio = { version = "0.1", features = [ "flatc" ] }

--- a/devtools/keypair/src/keypair.yml
+++ b/devtools/keypair/src/keypair.yml
@@ -9,3 +9,10 @@ args:
         short: n
         long: number
         default_value: "4"
+
+    - private_keys:
+        help: Generate keypairs from a given private key vector
+        short: p
+        long: private_keys
+        multiple: true
+        takes_value: true

--- a/devtools/keypair/src/main.rs
+++ b/devtools/keypair/src/main.rs
@@ -5,15 +5,15 @@ use std::convert::TryFrom;
 use std::default::Default;
 
 use clap::App;
+use ophelia::{PublicKey, ToBlsPublicKey};
+use ophelia_bls_amcl::BlsPrivateKey;
+use protocol::types::{Address, Hash};
+use protocol::BytesMut;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 use rand::{rngs::OsRng, RngCore};
 use serde::Serialize;
 use tentacle_secio::SecioKeyPair;
-use ophelia::{PublicKey, ToBlsPublicKey};
-use ophelia_bls_amcl::{BlsPrivateKey};
-use protocol::types::{Address, Hash};
-use protocol::BytesMut;
 
 #[derive(Default, Serialize, Debug)]
 struct Keypair {

--- a/devtools/keypair/src/main.rs
+++ b/devtools/keypair/src/main.rs
@@ -36,11 +36,7 @@ pub fn main() {
     let yml = load_yaml!("keypair.yml");
     let m = App::from(yml).get_matches();
     let number = value_t!(m, "number", usize).unwrap();
-    let priv_keys = if let Ok(tmp) = values_t!(m.values_of("private_keys"), String) {
-        tmp
-    } else {
-        vec![]
-    };
+    let priv_keys = values_t!(m.values_of("private_keys"), String).unwrap_or_default();
     let len = priv_keys.len();
     if len > number {
         panic!("private keys length can not be larger than number");

--- a/devtools/keypair/src/main.rs
+++ b/devtools/keypair/src/main.rs
@@ -5,8 +5,9 @@ use std::convert::TryFrom;
 use std::default::Default;
 
 use clap::App;
-use ophelia::{PublicKey, ToBlsPublicKey};
+use ophelia::{PrivateKey, PublicKey, ToBlsPublicKey, ToPublicKey};
 use ophelia_bls_amcl::BlsPrivateKey;
+use ophelia_secp256k1::Secp256k1PrivateKey;
 use protocol::types::{Address, Hash};
 use protocol::BytesMut;
 use rand::distributions::Alphanumeric;

--- a/devtools/keypair/src/main.rs
+++ b/devtools/keypair/src/main.rs
@@ -10,10 +10,8 @@ use rand::Rng;
 use rand::{rngs::OsRng, RngCore};
 use serde::Serialize;
 use tentacle_secio::SecioKeyPair;
-
-use common_crypto::{
-    BlsPrivateKey, PrivateKey, PublicKey, Secp256k1PrivateKey, ToBlsPublicKey, ToPublicKey,
-};
+use ophelia::{PublicKey, ToBlsPublicKey};
+use ophelia_bls_amcl::{BlsPrivateKey};
 use protocol::types::{Address, Hash};
 use protocol::BytesMut;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
feature

**What this PR does / why we need it**:
Add another method to generate key pairs. Now the tool can generate keypairs from a given vector of secp256k1 private keys. If the given keys number is larger than the value of argument `-n`, the program will panic.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
