### PR TITLE
feat(framework): add ExecutorParams into hook method

### DIFF
--- a/binding-macro/src/common.rs
+++ b/binding-macro/src/common.rs
@@ -37,14 +37,40 @@ fn path_is_request_context(path: &Path, bound_name: &str) -> bool {
     path.segments.len() == 1 && path.segments[0].ident == bound_name
 }
 
-pub fn assert_type_servicecontext(ty: &Type) {
+pub fn assert_type(ty: &Type, ty_str: &str) {
     match ty {
         Type::Path(ty_path) => {
             let path = &ty_path.path;
             assert_eq!(path.leading_colon.is_none(), true);
             assert_eq!(path.segments.len(), 1);
-            assert_eq!(path.segments[0].ident, "ServiceContext")
+            assert_eq!(path.segments[0].ident, ty_str)
         }
-        _ => panic!("The type should be `ServiceContext"),
+        _ => panic!("asset type failed"),
+    }
+}
+
+pub fn assert_reference_type(ty: &Type, ty_str: &str) {
+    match ty {
+        Type::Reference(ref_ty) => {
+            let ty_ref = &ref_ty.elem.as_ref();
+            assert_type(ty_ref, ty_str)
+        }
+        _ => panic!("asset reference type failed"),
+    }
+}
+
+// expect &mut self
+pub fn arg_is_mutable_receiver(fn_arg: &FnArg) -> bool {
+    match fn_arg {
+        FnArg::Receiver(receiver) => receiver.reference.is_some() && receiver.mutability.is_some(),
+        _ => false,
+    }
+}
+
+// expect &self
+pub fn arg_is_immutable_receiver(fn_arg: &FnArg) -> bool {
+    match fn_arg {
+        FnArg::Receiver(receiver) => receiver.reference.is_some() && receiver.mutability.is_none(),
+        _ => false,
     }
 }

--- a/binding-macro/src/hooks.rs
+++ b/binding-macro/src/hooks.rs
@@ -1,0 +1,24 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, FnArg, ImplItemMethod};
+
+use crate::common::{arg_is_mutable_receiver, assert_reference_type};
+
+pub fn verify_hook(item: TokenStream) -> TokenStream {
+    let method_item = parse_macro_input!(item as ImplItemMethod);
+
+    let inputs = &method_item.sig.inputs;
+    assert_eq!(inputs.len(), 2);
+
+    assert!(arg_is_mutable_receiver(&inputs[0]));
+
+    match &inputs[1] {
+        FnArg::Typed(pt) => {
+            let ty = pt.ty.as_ref();
+            assert_reference_type(ty, "ExecutorParams")
+        }
+        _ => panic!("The second parameter type should be `&ExecutorParams`."),
+    }
+
+    TokenStream::from(quote! {#method_item})
+}

--- a/binding-macro/src/lib.rs
+++ b/binding-macro/src/lib.rs
@@ -2,12 +2,14 @@ extern crate proc_macro;
 
 mod common;
 mod cycles;
+mod hooks;
 mod read_write;
 mod service;
 
 use proc_macro::TokenStream;
 
 use crate::cycles::gen_cycles_code;
+use crate::hooks::verify_hook;
 use crate::read_write::verify_read_or_write;
 use crate::service::gen_service_code;
 
@@ -150,14 +152,14 @@ pub fn cycles(attr: TokenStream, item: TokenStream) -> TokenStream {
 // TODO(@yejiayu): Verify the function signature.
 #[proc_macro_attribute]
 pub fn hook_after(_: TokenStream, item: TokenStream) -> TokenStream {
-    item
+    verify_hook(item)
 }
 
 /// Marks a method so that it executes before the entire block executes.
 // TODO(@yejiayu): Verify the function signature.
 #[proc_macro_attribute]
 pub fn hook_before(_: TokenStream, item: TokenStream) -> TokenStream {
-    item
+    verify_hook(item)
 }
 
 #[rustfmt::skip]

--- a/binding-macro/src/service.rs
+++ b/binding-macro/src/service.rs
@@ -50,12 +50,12 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
     let hooks = extract_hooks(items);
     let hook_before = &hooks.before;
     let hook_before_body = match hook_before {
-        Some(hook_before) => quote! { self.#hook_before() },
+        Some(hook_before) => quote! { self.#hook_before(_params) },
         None => quote! {Ok(())},
     };
     let hook_after = &hooks.after;
     let hook_after_body = match hook_after {
-        Some(hook_after) => quote! { self.#hook_after() },
+        Some(hook_after) => quote! { self.#hook_after(_params) },
         None => quote! {Ok(())},
     };
 
@@ -77,11 +77,11 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                 #genesis_body
             }
 
-            fn hook_before_(&mut self) -> protocol::ProtocolResult<()> {
+            fn hook_before_(&mut self, _params: &ExecutorParams) -> protocol::ProtocolResult<()> {
                 #hook_before_body
             }
 
-            fn hook_after_(&mut self) -> protocol::ProtocolResult<()> {
+            fn hook_after_(&mut self, _params: &ExecutorParams) -> protocol::ProtocolResult<()> {
                 #hook_after_body
             }
 

--- a/binding-macro/tests/mod.rs
+++ b/binding-macro/tests/mod.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use protocol::fixed_codec::FixedCodec;
 use protocol::traits::{
-    Service, ServiceSDK, StoreArray, StoreBool, StoreMap, StoreString, StoreUint64,
+    ExecutorParams, Service, ServiceSDK, StoreArray, StoreBool, StoreMap, StoreString, StoreUint64,
 };
 use protocol::types::{
     Address, Epoch, Hash, Receipt, ServiceContext, ServiceContextParams, SignedTransaction,
@@ -43,6 +43,33 @@ fn test_read_and_write() {
         t.test_write_fn(context, "write").unwrap(),
         "write".to_owned()
     );
+}
+
+#[test]
+fn test_hooks() {
+    struct Tests {
+        pub epoch_id: u64,
+    };
+
+    impl Tests {
+        #[hook_after]
+        fn hook_after(&mut self, params: &ExecutorParams) -> ProtocolResult<()> {
+            self.epoch_id = params.epoch_id;
+            Ok(())
+        }
+
+        #[hook_before]
+        fn hook_before(&mut self, params: &ExecutorParams) -> ProtocolResult<()> {
+            self.epoch_id = params.epoch_id;
+            Ok(())
+        }
+    }
+
+    let mut t = Tests { epoch_id: 0 };
+    t.hook_after(&mock_executor_params()).unwrap();
+    assert_eq!(t.epoch_id, 9);
+    t.hook_before(&mock_executor_params()).unwrap();
+    assert_eq!(t.epoch_id, 9);
 }
 
 #[test]
@@ -139,13 +166,13 @@ fn test_service() {
         }
 
         #[hook_before]
-        fn custom_hook_before(&mut self) -> ProtocolResult<()> {
+        fn custom_hook_before(&mut self, _params: &ExecutorParams) -> ProtocolResult<()> {
             self.hook_before = true;
             Ok(())
         }
 
         #[hook_after]
-        fn custom_hook_after(&mut self) -> ProtocolResult<()> {
+        fn custom_hook_after(&mut self, _params: &ExecutorParams) -> ProtocolResult<()> {
             self.hook_after = true;
             Ok(())
         }
@@ -205,10 +232,10 @@ fn test_service() {
     let write_res = test_service.write_(context);
     assert_eq!(write_res.is_err(), true);
 
-    test_service.hook_before_().unwrap();
+    test_service.hook_before_(&mock_executor_params()).unwrap();
     assert_eq!(test_service.hook_before, true);
 
-    test_service.hook_after_().unwrap();
+    test_service.hook_after_(&mock_executor_params()).unwrap();
     assert_eq!(test_service.hook_after, true);
 }
 
@@ -236,13 +263,13 @@ fn test_service_none_payload() {
         }
 
         #[hook_before]
-        fn custom_hook_before(&mut self) -> ProtocolResult<()> {
+        fn custom_hook_before(&mut self, _params: &ExecutorParams) -> ProtocolResult<()> {
             self.hook_before = true;
             Ok(())
         }
 
         #[hook_after]
-        fn custom_hook_after(&mut self) -> ProtocolResult<()> {
+        fn custom_hook_after(&mut self, _params: &ExecutorParams) -> ProtocolResult<()> {
             self.hook_after = true;
             Ok(())
         }
@@ -287,10 +314,10 @@ fn test_service_none_payload() {
     let write_res = test_service.write_(context);
     assert_eq!(write_res.is_err(), true);
 
-    test_service.hook_before_().unwrap();
+    test_service.hook_before_(&mock_executor_params()).unwrap();
     assert_eq!(test_service.hook_before, true);
 
-    test_service.hook_after_().unwrap();
+    test_service.hook_after_(&mock_executor_params()).unwrap();
     assert_eq!(test_service.hook_after, true);
 }
 
@@ -313,13 +340,13 @@ fn test_service_none_response() {
         }
 
         #[hook_before]
-        fn custom_hook_before(&mut self) -> ProtocolResult<()> {
+        fn custom_hook_before(&mut self, _params: &ExecutorParams) -> ProtocolResult<()> {
             self.hook_before = true;
             Ok(())
         }
 
         #[hook_after]
-        fn custom_hook_after(&mut self) -> ProtocolResult<()> {
+        fn custom_hook_after(&mut self, _params: &ExecutorParams) -> ProtocolResult<()> {
             self.hook_after = true;
             Ok(())
         }
@@ -360,10 +387,10 @@ fn test_service_none_response() {
     let write_res = test_service.write_(context);
     assert_eq!(write_res.is_err(), true);
 
-    test_service.hook_before_().unwrap();
+    test_service.hook_before_(&mock_executor_params()).unwrap();
     assert_eq!(test_service.hook_before, true);
 
-    test_service.hook_after_().unwrap();
+    test_service.hook_after_(&mock_executor_params()).unwrap();
     assert_eq!(test_service.hook_after, true);
 }
 
@@ -384,6 +411,15 @@ fn get_context(cycles_limit: u64, service: &str, method: &str, payload: &str) ->
     };
 
     ServiceContext::new(params)
+}
+
+fn mock_executor_params() -> ExecutorParams {
+    ExecutorParams {
+        state_root:   Hash::default(),
+        epoch_id:     9,
+        timestamp:    99,
+        cycles_limit: 99999,
+    }
 }
 
 struct MockServiceSDK;

--- a/built-in-services/asset/src/lib.rs
+++ b/built-in-services/asset/src/lib.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use derive_more::{Display, From};
 
 use binding_macro::{cycles, genesis, service, write};
-use protocol::traits::{ServiceSDK, StoreMap};
+use protocol::traits::{ExecutorParams, ServiceSDK, StoreMap};
 use protocol::types::{Hash, ServiceContext};
 use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
 

--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -150,7 +150,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
         Ok(())
     }
 
-    fn hook(&mut self, hook: HookType) -> ProtocolResult<()> {
+    fn hook(&mut self, hook: HookType, exec_params: &ExecutorParams) -> ProtocolResult<()> {
         for name in self.service_mapping.list_service_name().into_iter() {
             let state = self
                 .states
@@ -163,8 +163,8 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
             let mut service = self.service_mapping.get_service(name.as_str(), sdk)?;
 
             match hook {
-                HookType::Before => service.hook_before_()?,
-                HookType::After => service.hook_after_()?,
+                HookType::Before => service.hook_before_(exec_params)?,
+                HookType::After => service.hook_after_(exec_params)?,
             };
 
             state.borrow_mut().stash()?;
@@ -274,7 +274,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
         params: &ExecutorParams,
         txs: &[SignedTransaction],
     ) -> ProtocolResult<ExecutorResp> {
-        self.hook(HookType::Before)?;
+        self.hook(HookType::Before, params)?;
 
         let mut receipts = txs
             .iter()
@@ -314,7 +314,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
             })
             .collect::<Result<Vec<Receipt>, ProtocolError>>()?;
 
-        self.hook(HookType::After)?;
+        self.hook(HookType::After, params)?;
 
         let state_root = self.commit()?;
         let mut all_cycles_used = 0;

--- a/protocol/src/traits/binding.rs
+++ b/protocol/src/traits/binding.rs
@@ -3,6 +3,7 @@ use std::iter::Iterator;
 use derive_more::{Display, From};
 
 use crate::fixed_codec::FixedCodec;
+use crate::traits::ExecutorParams;
 use crate::types::{Address, Epoch, Hash, MerkleRoot, Receipt, ServiceContext, SignedTransaction};
 use crate::{ProtocolError, ProtocolErrorKind, ProtocolResult};
 
@@ -103,12 +104,12 @@ pub trait Service {
     }
 
     // Executed before the epoch is executed.
-    fn hook_before_(&mut self) -> ProtocolResult<()> {
+    fn hook_before_(&mut self, _params: &ExecutorParams) -> ProtocolResult<()> {
         Ok(())
     }
 
     // Executed after epoch execution.
-    fn hook_after_(&mut self) -> ProtocolResult<()> {
+    fn hook_after_(&mut self, _params: &ExecutorParams) -> ProtocolResult<()> {
         Ok(())
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**

feat(framework)

**What this PR does / why we need it**:

Add `ExecutorParams` into hook method, so `Service` can get `epoch_id`, `timestamp`... in hook method

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
```rust
pub trait Service {
    // Executed before the epoch is executed.
    fn hook_before_(&mut self, params: &ExecutorParams) -> ProtocolResult<()> {
        Ok(())
    }

    // Executed after epoch execution.
    fn hook_after_(&mut self, params: &ExecutorParams) -> ProtocolResult<()> {
        Ok(())
    }
}
```