### PR TITLE
feat(framework): add extra: Option<Bytes> to ServiceContext

### DIFF
--- a/binding-macro/tests/mod.rs
+++ b/binding-macro/tests/mod.rs
@@ -408,7 +408,7 @@ fn get_context(cycles_limit: u64, service: &str, method: &str, payload: &str) ->
         service_name: service.to_owned(),
         service_method: method.to_owned(),
         service_payload: payload.to_owned(),
-        extra: Bytes::default(),
+        extra: None,
         events: Rc::new(RefCell::new(vec![])),
     };
 
@@ -522,6 +522,7 @@ impl ServiceSDK for MockServiceSDK {
     fn read(
         &self,
         _ctx: &ServiceContext,
+        _extra: Option<Bytes>,
         _service: &str,
         _method: &str,
         _payload: &str,
@@ -534,6 +535,7 @@ impl ServiceSDK for MockServiceSDK {
     fn write(
         &mut self,
         _ctx: &ServiceContext,
+        _extra: Option<Bytes>,
         _service: &str,
         _method: &str,
         _payload: &str,

--- a/binding-macro/tests/mod.rs
+++ b/binding-macro/tests/mod.rs
@@ -5,6 +5,7 @@ extern crate binding_macro;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 use protocol::fixed_codec::FixedCodec;
@@ -407,6 +408,7 @@ fn get_context(cycles_limit: u64, service: &str, method: &str, payload: &str) ->
         service_name: service.to_owned(),
         service_method: method.to_owned(),
         service_payload: payload.to_owned(),
+        extra: Bytes::default(),
         events: Rc::new(RefCell::new(vec![])),
     };
 

--- a/built-in-services/asset/src/tests/mod.rs
+++ b/built-in-services/asset/src/tests/mod.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use cita_trie::MemoryDB;
 
 use framework::binding::sdk::{DefalutServiceSDK, DefaultChainQuerier};
@@ -125,7 +124,7 @@ fn mock_context(cycles_limit: u64, caller: Address) -> ServiceContext {
         service_name: "service_name".to_owned(),
         service_method: "service_method".to_owned(),
         service_payload: "service_payload".to_owned(),
-        extra: Bytes::default(),
+        extra: None,
         events: Rc::new(RefCell::new(vec![])),
     };
 

--- a/built-in-services/asset/src/tests/mod.rs
+++ b/built-in-services/asset/src/tests/mod.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use cita_trie::MemoryDB;
 
 use framework::binding::sdk::{DefalutServiceSDK, DefaultChainQuerier};
@@ -124,6 +125,7 @@ fn mock_context(cycles_limit: u64, caller: Address) -> ServiceContext {
         service_name: "service_name".to_owned(),
         service_method: "service_method".to_owned(),
         service_payload: "service_payload".to_owned(),
+        extra: Bytes::default(),
         events: Rc::new(RefCell::new(vec![])),
     };
 

--- a/framework/src/binding/sdk/mod.rs
+++ b/framework/src/binding/sdk/mod.rs
@@ -5,6 +5,7 @@ pub use chain_querier::{ChainQueryError, DefaultChainQuerier};
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use bytes::Bytes;
 use derive_more::{Display, From};
 
 use protocol::fixed_codec::FixedCodec;
@@ -145,12 +146,14 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
     fn read(
         &self,
         ctx: &ServiceContext,
+        extra: Option<Bytes>,
         service: &str,
         method: &str,
         payload: &str,
     ) -> ProtocolResult<String> {
         let ctx = ServiceContext::with_context(
             ctx,
+            extra,
             service.to_string(),
             method.to_string(),
             payload.to_string(),
@@ -169,12 +172,14 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
     fn write(
         &mut self,
         ctx: &ServiceContext,
+        extra: Option<Bytes>,
         service: &str,
         method: &str,
         payload: &str,
     ) -> ProtocolResult<String> {
         let ctx = ServiceContext::with_context(
             ctx,
+            extra,
             service.to_string(),
             method.to_string(),
             payload.to_string(),

--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use cita_trie::DB as TrieDB;
 use derive_more::{Display, From};
 
-use bytes::{Bytes, BytesMut};
+use bytes::BytesMut;
 use protocol::traits::{
     Dispatcher, ExecResp, Executor, ExecutorParams, ExecutorResp, NoopDispatcher, ServiceMapping,
     ServiceState, Storage,
@@ -213,7 +213,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
             service_name: request.service_name.to_owned(),
             service_method: request.method.to_owned(),
             service_payload: request.payload.to_owned(),
-            extra: Bytes::default(),
+            extra: None,
             events: Rc::new(RefCell::new(vec![])),
         };
 

--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use cita_trie::DB as TrieDB;
 use derive_more::{Display, From};
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use protocol::traits::{
     Dispatcher, ExecResp, Executor, ExecutorParams, ExecutorResp, NoopDispatcher, ServiceMapping,
     ServiceState, Storage,
@@ -213,6 +213,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
             service_name: request.service_name.to_owned(),
             service_method: request.method.to_owned(),
             service_payload: request.payload.to_owned(),
+            extra: Bytes::default(),
             events: Rc::new(RefCell::new(vec![])),
         };
 

--- a/framework/src/executor/tests/service_call_service.rs
+++ b/framework/src/executor/tests/service_call_service.rs
@@ -109,7 +109,7 @@ impl<SDK: ServiceSDK> MockService<SDK> {
 
         let ret = self
             .sdk
-            .write(&ctx, "asset", "create_asset", &payload_str)?;
+            .write(&ctx, None, "asset", "create_asset", &payload_str)?;
 
         let asset: Asset = serde_json::from_str(&ret).unwrap();
 

--- a/protocol/src/traits/binding.rs
+++ b/protocol/src/traits/binding.rs
@@ -1,5 +1,6 @@
 use std::iter::Iterator;
 
+use bytes::Bytes;
 use derive_more::{Display, From};
 
 use crate::fixed_codec::FixedCodec;
@@ -201,6 +202,7 @@ pub trait ServiceSDK {
     fn read(
         &self,
         ctx: &ServiceContext,
+        extra: Option<Bytes>,
         service: &str,
         method: &str,
         payload: &str,
@@ -211,6 +213,7 @@ pub trait ServiceSDK {
     fn write(
         &mut self,
         ctx: &ServiceContext,
+        extra: Option<Bytes>,
         service: &str,
         method: &str,
         payload: &str,

--- a/protocol/src/types/service_context.rs
+++ b/protocol/src/types/service_context.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use bytes::Bytes;
 use derive_more::{Display, From};
 
 use crate::types::{Address, Event, Hash};
@@ -18,6 +19,7 @@ pub struct ServiceContextParams {
     pub service_name:    String,
     pub service_method:  String,
     pub service_payload: String,
+    pub extra:           Bytes,
     pub timestamp:       u64,
     pub events:          Rc<RefCell<Vec<Event>>>,
 }
@@ -34,6 +36,7 @@ pub struct ServiceContext {
     service_name:    String,
     service_method:  String,
     service_payload: String,
+    extra:           Bytes,
     timestamp:       u64,
     events:          Rc<RefCell<Vec<Event>>>,
 }
@@ -51,6 +54,7 @@ impl ServiceContext {
             service_name:    params.service_name,
             service_method:  params.service_method,
             service_payload: params.service_payload,
+            extra:           params.extra,
             timestamp:       params.timestamp,
             events:          params.events,
         }
@@ -73,6 +77,7 @@ impl ServiceContext {
             service_name,
             service_method,
             service_payload,
+            extra: context.extra.clone(),
             timestamp: context.get_timestamp(),
             events: Rc::clone(&context.events),
         }
@@ -131,6 +136,14 @@ impl ServiceContext {
         &self.service_payload
     }
 
+    pub fn get_extra(&self) -> Bytes {
+        self.extra.clone()
+    }
+
+    pub fn set_extra(&mut self, extra: Bytes) {
+        self.extra = extra
+    }
+
     pub fn get_timestamp(&self) -> u64 {
         self.timestamp
     }
@@ -181,6 +194,7 @@ mod tests {
             service_name:    "service_name".to_owned(),
             service_method:  "service_method".to_owned(),
             service_payload: "service_payload".to_owned(),
+            extra:           bytes::Bytes::default(),
             events:          Rc::new(RefCell::new(vec![])),
         };
         let ctx = ServiceContext::new(params);

--- a/protocol/src/types/service_context.rs
+++ b/protocol/src/types/service_context.rs
@@ -19,7 +19,7 @@ pub struct ServiceContextParams {
     pub service_name:    String,
     pub service_method:  String,
     pub service_payload: String,
-    pub extra:           Bytes,
+    pub extra:           Option<Bytes>,
     pub timestamp:       u64,
     pub events:          Rc<RefCell<Vec<Event>>>,
 }
@@ -36,7 +36,7 @@ pub struct ServiceContext {
     service_name:    String,
     service_method:  String,
     service_payload: String,
-    extra:           Bytes,
+    extra:           Option<Bytes>,
     timestamp:       u64,
     events:          Rc<RefCell<Vec<Event>>>,
 }
@@ -62,6 +62,7 @@ impl ServiceContext {
 
     pub fn with_context(
         context: &ServiceContext,
+        extra: Option<Bytes>,
         service_name: String,
         service_method: String,
         service_payload: String,
@@ -77,7 +78,7 @@ impl ServiceContext {
             service_name,
             service_method,
             service_payload,
-            extra: context.extra.clone(),
+            extra,
             timestamp: context.get_timestamp(),
             events: Rc::clone(&context.events),
         }
@@ -136,12 +137,8 @@ impl ServiceContext {
         &self.service_payload
     }
 
-    pub fn get_extra(&self) -> Bytes {
+    pub fn get_extra(&self) -> Option<Bytes> {
         self.extra.clone()
-    }
-
-    pub fn set_extra(&mut self, extra: Bytes) {
-        self.extra = extra
     }
 
     pub fn get_timestamp(&self) -> u64 {
@@ -194,7 +191,7 @@ mod tests {
             service_name:    "service_name".to_owned(),
             service_method:  "service_method".to_owned(),
             service_payload: "service_payload".to_owned(),
-            extra:           bytes::Bytes::default(),
+            extra:           None,
             events:          Rc::new(RefCell::new(vec![])),
         };
         let ctx = ServiceContext::new(params);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**

feat(framework)

**What this PR does / why we need it**:

Add `extra: Option<Bytes>` into `ServiceContext`

`Service` call `Service` may need this

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
```rust
pub struct ServiceContext {
...
extra: Option<Bytes>,
...
}

impl ServiceContext {
    pub fn get_extra(&self) -> Option<Bytes> {
        self.extra.clone()
    }
}

pub trait ServiceSDK {
    fn read(
        &self,
        ctx: &ServiceContext,
        extra: Option<Bytes>,
        service: &str,
        method: &str,
        payload: &str,
    ) -> ProtocolResult<String>;

    fn write(
        &mut self,
        ctx: &ServiceContext,
        extra: Option<Bytes>,
        service: &str,
        method: &str,
        payload: &str,
    ) -> ProtocolResult<String>;
}
```