### PR TITLE
change(network): output more info for debug rpc timeout

### DIFF
--- a/core/network/src/error.rs
+++ b/core/network/src/error.rs
@@ -5,6 +5,8 @@ use tentacle::{ProtocolId, SessionId};
 
 use protocol::{types::Address, ProtocolError, ProtocolErrorKind};
 
+use crate::common::ConnectedAddr;
+
 #[derive(Debug, Display)]
 pub enum ErrorKind {
     #[display(fmt = "{} offline", _0)]
@@ -40,14 +42,17 @@ pub enum ErrorKind {
     #[display(fmt = "kind: session id not found in context")]
     NoSessionId,
 
+    #[display(fmt = "kind: remote peer id not found in context")]
+    NoRemotePeerId,
+
     #[display(fmt = "kind: rpc id not found in context")]
     NoRpcId,
 
-    #[display(fmt = "kind: rpc future dropped")]
-    RpcDropped,
+    #[display(fmt = "kind: rpc future dropped {:?}", _0)]
+    RpcDropped(Option<ConnectedAddr>),
 
-    #[display(fmt = "kind: rpc timeout")]
-    RpcTimeout,
+    #[display(fmt = "kind: rpc timeout {:?}", _0)]
+    RpcTimeout(Option<ConnectedAddr>),
 
     #[display(fmt = "kind: not reactor register for {}", _0)]
     NoReactor(String),

--- a/core/network/src/message/mod.rs
+++ b/core/network/src/message/mod.rs
@@ -4,16 +4,19 @@ pub mod serde_multi;
 use derive_more::Constructor;
 use prost::Message;
 use protocol::Bytes;
-use tentacle::SessionId;
+use tentacle::{secio::PeerId, SessionId};
 
 use crate::{
+    common::ConnectedAddr,
     endpoint::Endpoint,
     error::{ErrorKind, NetworkError},
 };
 
 #[derive(Constructor)]
+#[non_exhaustive]
 pub struct RawSessionMessage {
     pub(crate) sid: SessionId,
+    pub(crate) pid: PeerId,
     pub(crate) msg: Bytes,
 }
 
@@ -49,9 +52,12 @@ impl NetworkMessage {
 }
 
 #[derive(Constructor)]
+#[non_exhaustive]
 pub struct SessionMessage {
-    pub(crate) sid: SessionId,
-    pub(crate) msg: NetworkMessage,
+    pub(crate) sid:            SessionId,
+    pub(crate) pid:            PeerId,
+    pub(crate) msg:            NetworkMessage,
+    pub(crate) connected_addr: Option<ConnectedAddr>,
 }
 
 #[cfg(test)]

--- a/core/network/src/outbound/rpc.rs
+++ b/core/network/src/outbound/rpc.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::future::{self, Either};
 use futures_timer::Delay;
+use log::warn;
 use protocol::{
     traits::{Context, MessageCodec, Priority, Rpc},
     Bytes, ProtocolResult,
@@ -79,6 +80,10 @@ where
                 ret.map_err(|_| NetworkError::from(ErrorKind::RpcDropped(connected_addr)))?
             }
             Either::Right((_unresolved, _timeout)) => {
+                if let Err(err) = self.map.take::<R>(sid, rid) {
+                    warn!("rpc: remove {}, maybe we just got response", err);
+                }
+
                 return Err(NetworkError::from(ErrorKind::RpcTimeout(connected_addr)).into());
             }
         };

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -1045,10 +1045,12 @@ impl Future for PeerManager {
             self.process_event(event);
         }
 
+        let connected_peers_addr = self.connected_peers_addr();
         debug!(
-            "network: {:?}: connected peer_addr(s): {:?}",
+            "network: {:?}: connected peer_addr(s) {}: {:?}",
             self.peer_id,
-            self.connected_peers_addr()
+            connected_peers_addr.len(),
+            connected_peers_addr
         );
 
         // Check connecting count

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -3,7 +3,7 @@ mod ident;
 mod peer;
 mod persist;
 
-use peer::{ConnectedAddr, PeerState};
+use peer::PeerState;
 use persist::{NoopPersistence, PeerPersistence, Persistence};
 
 pub use disc::DiscoveryAddrManager;
@@ -44,9 +44,10 @@ use tentacle::{
 };
 
 use crate::{
-    common::HeartBeat,
+    common::{ConnectedAddr, HeartBeat},
     error::NetworkError,
     event::{ConnectionEvent, ConnectionType, MultiUsersMessage, PeerManagerEvent, Session},
+    traits::PeerInfoQuerier,
 };
 
 const MAX_RETRY_COUNT: usize = 6;
@@ -468,6 +469,12 @@ impl PeerManagerHandle {
         debug_assert!(listen.is_some(), "listen should alway be set");
 
         listen.map(|addr| vec![addr]).unwrap_or_else(Vec::new)
+    }
+}
+
+impl PeerInfoQuerier for PeerManagerHandle {
+    fn connected_addr(&self, pid: &PeerId) -> Option<ConnectedAddr> {
+        self.inner.connected_addr(pid)
     }
 }
 

--- a/core/network/src/peer_manager/peer.rs
+++ b/core/network/src/peer_manager/peer.rs
@@ -13,38 +13,10 @@ use tentacle::{
     secio::{PeerId, PublicKey},
 };
 
+use crate::common::ConnectedAddr;
+
 pub const BACKOFF_BASE: usize = 5;
 pub const VALID_ATTEMPT_INTERVAL: u64 = 4;
-
-#[derive(Debug, Display, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[display(fmt = "{}:{}", host, port)]
-pub struct ConnectedAddr {
-    host: String,
-    port: u16,
-}
-
-impl From<&Multiaddr> for ConnectedAddr {
-    fn from(multiaddr: &Multiaddr) -> Self {
-        use tentacle::multiaddr::Protocol::*;
-
-        let mut host = None;
-        let mut port = 0u16;
-
-        for comp in multiaddr.iter() {
-            match comp {
-                IP4(ip_addr) => host = Some(ip_addr.to_string()),
-                IP6(ip_addr) => host = Some(ip_addr.to_string()),
-                DNS4(dns_addr) | DNS6(dns_addr) => host = Some(dns_addr.to_string()),
-                TLS(tls_addr) => host = Some(tls_addr.to_string()),
-                TCP(p) => port = p,
-                _ => (),
-            }
-        }
-
-        let host = host.unwrap_or_else(|| multiaddr.to_string());
-        ConnectedAddr { host, port }
-    }
-}
 
 // TODO: display next_retry
 #[derive(Debug, Clone, Serialize, Deserialize, Display)]

--- a/core/network/src/protocols/transmitter.rs
+++ b/core/network/src/protocols/transmitter.rs
@@ -40,6 +40,7 @@ impl ServiceProtocol for Transmitter {
 
     fn received(&mut self, ctx: ProtocolContextMutRef, data: tentacle::bytes::Bytes) {
         let pubkey = ctx.session.remote_pubkey.as_ref();
+        // Peers without encryption will not able to connect to us.
         let peer_id = pubkey.expect("impossible, no public key").peer_id();
         let data = BytesMut::from(data.as_ref()).freeze();
 

--- a/core/network/src/protocols/transmitter.rs
+++ b/core/network/src/protocols/transmitter.rs
@@ -39,9 +39,11 @@ impl ServiceProtocol for Transmitter {
     }
 
     fn received(&mut self, ctx: ProtocolContextMutRef, data: tentacle::bytes::Bytes) {
+        let pubkey = ctx.session.remote_pubkey.as_ref();
+        let peer_id = pubkey.expect("impossible, no public key").peer_id();
         let data = BytesMut::from(data.as_ref()).freeze();
-        let raw_msg = RawSessionMessage::new(ctx.session.id, data);
 
+        let raw_msg = RawSessionMessage::new(ctx.session.id, peer_id, data);
         if self.msg_deliver.unbounded_send(raw_msg).is_err() {
             error!("network: transmitter: msg receiver dropped");
         }

--- a/core/network/src/reactor/mod.rs
+++ b/core/network/src/reactor/mod.rs
@@ -59,10 +59,19 @@ where
         let handler = Arc::clone(&self.handler);
         let rpc_map = Arc::clone(&self.rpc_map);
 
-        let SessionMessage { sid, msg: net_msg } = smsg;
+        let SessionMessage {
+            sid,
+            msg: net_msg,
+            pid,
+            connected_addr,
+            ..
+        } = smsg;
 
         let endpoint = net_msg.url.to_owned();
-        let mut ctx = Context::new().set_session_id(sid);
+        let mut ctx = Context::new().set_session_id(sid).set_remote_peer_id(pid);
+        if let Some(connected_addr) = connected_addr {
+            ctx = ctx.set_remote_connected_addr(connected_addr);
+        }
 
         let react = async move {
             let endpoint = net_msg.url.parse::<Endpoint>()?;

--- a/core/network/src/reactor/mod.rs
+++ b/core/network/src/reactor/mod.rs
@@ -69,8 +69,8 @@ where
 
         let endpoint = net_msg.url.to_owned();
         let mut ctx = Context::new().set_session_id(sid).set_remote_peer_id(pid);
-        if let Some(connected_addr) = connected_addr {
-            ctx = ctx.set_remote_connected_addr(connected_addr);
+        if let Some(ref connected_addr) = connected_addr {
+            ctx = ctx.set_remote_connected_addr(connected_addr.clone());
         }
 
         let react = async move {
@@ -88,8 +88,14 @@ where
                 EndpointScheme::RpcResponse => {
                     let rpc_endpoint = RpcEndpoint::try_from(endpoint)?;
                     let rpc_id = rpc_endpoint.rpc_id().value();
+
                     if !rpc_map.contains(sid, rpc_id) {
-                        warn!("network: reactor: rpc entry not found, if there's timeout message, it's ok here");
+                        let full_url = rpc_endpoint.endpoint().full_url();
+
+                        warn!(
+                            "rpc entry for {} from {:?} not found, maybe timeout",
+                            full_url, connected_addr
+                        );
                         return Ok(());
                     }
 

--- a/core/network/src/reactor/mod.rs
+++ b/core/network/src/reactor/mod.rs
@@ -87,8 +87,13 @@ where
                 }
                 EndpointScheme::RpcResponse => {
                     let rpc_endpoint = RpcEndpoint::try_from(endpoint)?;
-                    let resp_tx = rpc_map.take::<M>(sid, rpc_endpoint.rpc_id().value())?;
+                    let rpc_id = rpc_endpoint.rpc_id().value();
+                    if !rpc_map.contains(sid, rpc_id) {
+                        warn!("network: reactor: rpc entry not found, if there's timeout message, it's ok here");
+                        return Ok(());
+                    }
 
+                    let resp_tx = rpc_map.take::<M>(sid, rpc_endpoint.rpc_id().value())?;
                     if resp_tx.send(content).is_err() {
                         let end = rpc_endpoint.endpoint().full_url();
 

--- a/core/network/src/rpc_map.rs
+++ b/core/network/src/rpc_map.rs
@@ -49,6 +49,11 @@ impl RpcMap {
         done_rx
     }
 
+    pub fn contains(&self, sid: SessionId, rid: u64) -> bool {
+        let key = Key::new(sid, rid);
+        self.map.read().contains_key(&key)
+    }
+
     pub fn take<T: Send + 'static>(
         &self,
         sid: SessionId,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
change

**What this PR does / why we need it**:
- output connected address with rpc timeout and drop error
- output connected peers number when poll peer manager
- delete rpc entry in rpc map after timeout

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
