### PR TITLE
[ᚬdebug-muta] fix(sync): Check the height again after lock

### DIFF
--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -45,6 +45,10 @@ impl<Adapter: SynchronizationAdapter> Synchronization for OverlordSynchronizatio
 
         let current_height = self.adapter.get_current_height(ctx.clone()).await?;
 
+        if remote_height <= current_height {
+            return Ok(());
+        }
+
         log::info!(
             "[synchronization]: start, remote block height {:?} current block height {:?}",
             remote_height,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
fix

**What this PR does / why we need it**:
Check the height again after lock to make sure the node doesn't into sync again.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
