### PR TITLE
[ᚬdebug-muta] change(network): remove ProtocolResult from message handle trait

### DIFF
--- a/core/consensus/src/message.rs
+++ b/core/consensus/src/message.rs
@@ -215,7 +215,7 @@ impl<R: Rpc + 'static, S: Storage + 'static> MessageHandler for PullBlockRpcHand
         };
 
         push_block
-            .unwrap_or_else(move |e: ProtocolError| warn!("push block {}", e))
+            .unwrap_or_else(move |e: ProtocolError| warn!("[core_consensus] push block {}", e))
             .await;
     }
 }
@@ -258,7 +258,7 @@ impl<R: Rpc + 'static, S: Storage + 'static> MessageHandler for PullTxsRpcHandle
         };
 
         push_txs
-            .unwrap_or_else(move |e: ProtocolError| warn!("push txs {}", e))
+            .unwrap_or_else(move |e: ProtocolError| warn!("[core_consensus] push txs {}", e))
             .await;
     }
 }

--- a/core/mempool/src/adapter/message.rs
+++ b/core/mempool/src/adapter/message.rs
@@ -61,7 +61,7 @@ where
         .map(|_| ())
         .is_err()
         {
-            log::error!("mempool batch insert error");
+            log::error!("[core_mempool] mempool batch insert error");
         }
     }
 }
@@ -112,7 +112,7 @@ where
         };
 
         push_txs
-            .unwrap_or_else(move |err| log::warn!("process pull txs {}", err))
+            .unwrap_or_else(move |err| log::warn!("[core_mempool] push txs {}", err))
             .await;
     }
 }

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -242,9 +242,6 @@ pub enum MemPoolError {
 
     #[display(fmt = "Tx: {:?} invalid timeout", tx_hash)]
     InvalidTimeout { tx_hash: Hash },
-
-    #[display(fmt = "Batch insert error")]
-    BatchInsertErr,
 }
 
 impl Error for MemPoolError {}

--- a/core/network/src/reactor/mod.rs
+++ b/core/network/src/reactor/mod.rs
@@ -15,7 +15,7 @@ use futures::{channel::mpsc::UnboundedReceiver, future::TryFutureExt, pin_mut, s
 use log::warn;
 use protocol::{
     traits::{Context, MessageCodec, MessageHandler},
-    Bytes, ProtocolError, ProtocolResult,
+    Bytes, ProtocolError,
 };
 
 use crate::{
@@ -78,12 +78,12 @@ where
             let content = M::decode(Bytes::from(net_msg.content)).await?;
 
             match endpoint.scheme() {
-                EndpointScheme::Gossip => handler.process(ctx, content).await?,
+                EndpointScheme::Gossip => handler.process(ctx, content).await,
                 EndpointScheme::RpcCall => {
                     let rpc_endpoint = RpcEndpoint::try_from(endpoint)?;
 
                     let ctx = ctx.set_rpc_id(rpc_endpoint.rpc_id().value());
-                    handler.process(ctx, content).await?
+                    handler.process(ctx, content).await
                 }
                 EndpointScheme::RpcResponse => {
                     let rpc_endpoint = RpcEndpoint::try_from(endpoint)?;
@@ -157,7 +157,5 @@ where
 {
     type Message = M;
 
-    async fn process(&self, _: Context, _: Self::Message) -> ProtocolResult<()> {
-        Ok(())
-    }
+    async fn process(&self, _: Context, _: Self::Message) {}
 }

--- a/core/network/tests/gossip_test.rs
+++ b/core/network/tests/gossip_test.rs
@@ -12,10 +12,7 @@ use futures::{
     stream::StreamExt,
 };
 
-use protocol::{
-    traits::{Context, Gossip, MessageHandler, Priority},
-    ProtocolResult,
-};
+use protocol::traits::{Context, Gossip, MessageHandler, Priority};
 
 const END_TEST_BROADCAST: &str = "/gossip/test/message";
 const TEST_MESSAGE: &str = "spike lee action started";
@@ -52,14 +49,12 @@ impl NewsReader {
 impl MessageHandler for NewsReader {
     type Message = String;
 
-    async fn process(&self, _ctx: Context, msg: Self::Message) -> ProtocolResult<()> {
+    async fn process(&self, _ctx: Context, msg: Self::Message) {
         if !self.sent() {
             assert_eq!(&msg, TEST_MESSAGE);
             self.done_tx.unbounded_send(()).expect("news reader done");
             self.set_sent();
         }
-
-        ProtocolResult::Ok(())
     }
 }
 

--- a/protocol/src/traits/network.rs
+++ b/protocol/src/traits/network.rs
@@ -82,5 +82,5 @@ pub trait Rpc: Send + Sync {
 pub trait MessageHandler: Sync + Send + 'static {
     type Message: MessageCodec;
 
-    async fn process(&self, ctx: Context, msg: Self::Message) -> ProtocolResult<()>;
+    async fn process(&self, ctx: Context, msg: Self::Message);
 }


### PR DESCRIPTION
Error inside process logic should not be propagated to network.

<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
change

**What this PR does / why we need it**:
Remove ProtocolResult from message handle signature. Logic error should not
be progagated to network.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
