### PR TITLE
feat: check size and cycle limit when insert tx into mempool

### DIFF
--- a/built-in-services/metadata/src/tests/mod.rs
+++ b/built-in-services/metadata/src/tests/mod.rs
@@ -73,6 +73,8 @@ fn mock_metadata() -> Metadata {
         prevote_ratio:   10,
         precommit_ratio: 10,
         brake_ratio:     7,
+        tx_num_limit: 20000,
+        max_tx_size: 1_073_741_824,
     }
 }
 

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -70,8 +70,9 @@ where
         ctx: Context,
         _height: u64,
         cycle_limit: u64,
+        tx_num_limit: u64,
     ) -> ProtocolResult<MixedTxHashes> {
-        self.mempool.package(ctx, cycle_limit).await
+        self.mempool.package(ctx, cycle_limit, tx_num_limit).await
     }
 
     async fn check_txs(&self, ctx: Context, check_txs: Vec<Hash>) -> ProtocolResult<()> {

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -415,8 +415,9 @@ where
         Ok(serde_json::from_str(&exec_resp.ret).expect("Decode metadata failed!"))
     }
 
-    fn set_timeout_gap(&self, _context: Context, timeout_gap: u64) {
-        self.mempool.set_timeout_gap(timeout_gap);
+    fn set_args(&self, _context: Context, timeout_gap: u64, cycles_limit: u64, max_tx_size: u64) {
+        self.mempool
+            .set_args(timeout_gap, cycles_limit, max_tx_size);
     }
 }
 

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -531,8 +531,12 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
             .await?;
 
         // update timeout_gap of mempool
-        self.adapter
-            .set_timeout_gap(Context::new(), metadata.timeout_gap);
+        self.adapter.set_args(
+            Context::new(),
+            metadata.timeout_gap,
+            metadata.cycles_limit,
+            metadata.max_tx_size,
+        );
 
         let prev_hash = Hash::digest(block.encode_fixed()?);
         self.status_agent

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -52,7 +52,12 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
 
         let (ordered_tx_hashes, propose_hashes) = self
             .adapter
-            .get_txs_from_mempool(ctx, height, current_consensus_status.cycles_limit)
+            .get_txs_from_mempool(
+                ctx,
+                height,
+                current_consensus_status.cycles_limit,
+                current_consensus_status.tx_num_limit,
+            )
             .await?
             .clap();
 

--- a/core/consensus/src/status.rs
+++ b/core/consensus/src/status.rs
@@ -108,6 +108,8 @@ pub struct CurrentConsensusStatus {
     pub prevote_ratio:      u64,
     pub precommit_ratio:    u64,
     pub brake_ratio:        u64,
+    pub tx_num_limit:       u64,
+    pub max_tx_size:        u64,
 }
 
 impl CurrentConsensusStatus {

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -331,6 +331,8 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
             prevote_ratio:      current_status.prevote_ratio,
             precommit_ratio:    current_status.precommit_ratio,
             brake_ratio:        current_status.brake_ratio,
+            tx_num_limit:       current_status.tx_num_limit,
+            max_tx_size:        current_status.max_tx_size,
             prev_hash:          block.header.pre_hash.clone(),
             height:             block.header.height,
             exec_height:        block.header.exec_height,

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -194,8 +194,12 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
             block.header.timestamp,
         )?;
 
-        self.adapter
-            .set_timeout_gap(ctx.clone(), metadata.timeout_gap);
+        self.adapter.set_args(
+            ctx.clone(),
+            metadata.timeout_gap,
+            metadata.cycles_limit,
+            metadata.max_tx_size,
+        );
 
         status_agent.update_after_sync_commit(
             block.header.height,

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -64,6 +64,8 @@ fn sync_gap_test() {
             prevote_ratio:      10,
             precommit_ratio:    10,
             brake_ratio:        3,
+            tx_num_limit:       20000,
+            max_tx_size:        1_073_741_824,
         };
         let status_agent = StatusAgent::new(status);
         let lock = Arc::new(Mutex::new(()));

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -251,11 +251,19 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             prevote_ratio:   10,
             precommit_ratio: 10,
             brake_ratio:     10,
+            tx_num_limit: 20000,
+            max_tx_size: 1_073_741_824,
         })
     }
 
-    /// Set timeout_gap in mempool.
-    fn set_timeout_gap(&self, _context: Context, _timeout_gap: u64) {}
+    fn set_args(
+        &self,
+        _context: Context,
+        _timeout_gap: u64,
+        _cycles_limit: u64,
+        _max_tx_size: u64,
+    ) {
+    }
 }
 
 fn gen_remote_tx_hashmap(list: Vec<RichBlock>) -> SafeHashMap<Hash, SignedTransaction> {

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -105,7 +105,12 @@ where
         Ok(())
     }
 
-    async fn package(&self, ctx: Context, cycle_limit: u64) -> ProtocolResult<MixedTxHashes> {
+    async fn package(
+        &self,
+        ctx: Context,
+        cycles_limit: u64,
+        tx_num_limit: u64,
+    ) -> ProtocolResult<MixedTxHashes> {
         let current_height = self.adapter.get_latest_height(ctx.clone()).await?;
         log::info!(
             "[mempool]: {:?} txs in map and {:?} txs in queue while package",
@@ -113,7 +118,8 @@ where
             self.tx_cache.queue_len(),
         );
         self.tx_cache.package(
-            cycle_limit,
+            cycles_limit,
+            tx_num_limit,
             current_height,
             current_height + self.timeout_gap.load(Ordering::Relaxed),
         )

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -199,14 +199,39 @@ where
         Ok(())
     }
 
-    fn set_timeout_gap(&self, timeout_gap: u64) {
-        self.adapter.set_timeout_gap(timeout_gap);
+    fn set_args(&self, timeout_gap: u64, cycles_limit: u64, max_tx_size: u64) {
+        self.adapter
+            .set_args(timeout_gap, cycles_limit, max_tx_size);
         self.timeout_gap.store(timeout_gap, Ordering::Relaxed);
     }
 }
 
 #[derive(Debug, Display)]
 pub enum MemPoolError {
+    #[display(
+        fmt = "Tx: {:?} exceeds size limit, now: {}, limit: {} Bytes",
+        tx_hash,
+        size,
+        max_tx_size
+    )]
+    ExceedSizeLimit {
+        tx_hash:     Hash,
+        max_tx_size: u64,
+        size:        u64,
+    },
+
+    #[display(
+        fmt = "Tx: {:?} exceeds cycle limit, tx: {}, config: {}",
+        tx_hash,
+        cycles_limit_tx,
+        cycles_limit_config
+    )]
+    ExceedCyclesLimit {
+        tx_hash:             Hash,
+        cycles_limit_config: u64,
+        cycles_limit_tx:     u64,
+    },
+
     #[display(fmt = "Tx: {:?} inserts failed", tx_hash)]
     Insert { tx_hash: Hash },
 

--- a/core/mempool/src/tests/mempool.rs
+++ b/core/mempool/src/tests/mempool.rs
@@ -80,7 +80,7 @@ fn test_package() {
     package!(normal(100, 200, 100, 100));
 
     // 3. 2 * tx_num_limit < pool_size
-    package!(normal(100, 201, 100, 101));
+    package!(normal(100, 201, 100, 100));
 
     // 4. current_height >= tx.timeout
     package!(timeout(50, CURRENT_HEIGHT, 10, 0));

--- a/core/mempool/src/tests/mempool.rs
+++ b/core/mempool/src/tests/mempool.rs
@@ -133,7 +133,7 @@ fn test_flush() {
     let remove_hashes: Vec<Hash> = remove_txs.iter().map(|tx| tx.tx_hash.clone()).collect();
     exec_flush(remove_hashes, Arc::clone(&mempool));
     assert_eq!(mempool.get_tx_cache().len(), 432);
-    assert_eq!(mempool.get_tx_cache().queue_len(), 555);
+    assert_eq!(mempool.get_tx_cache().queue_len(), 432);
     exec_package(Arc::clone(&mempool), CYCLE_LIMIT, TX_NUM_LIMIT);
     assert_eq!(mempool.get_tx_cache().queue_len(), 432);
     assert_eq!(callback_cache.len(), 0);

--- a/core/mempool/src/tests/mempool.rs
+++ b/core/mempool/src/tests/mempool.rs
@@ -17,7 +17,12 @@ macro_rules! insert {
         insert!(inner($valid * 10, 1, $valid, $invalid, $output));
     };
     (inner($pool_size: expr, $repeat: expr, $valid: expr, $invalid: expr, $output: expr)) => {
-        let mempool = Arc::new(new_mempool($pool_size, TIMEOUT_GAP));
+        let mempool = Arc::new(new_mempool(
+            $pool_size,
+            TIMEOUT_GAP,
+            CYCLE_LIMIT,
+            MAX_TX_SIZE,
+        ));
         let txs = mock_txs($valid, $invalid, TIMEOUT);
         for _ in 0..$repeat {
             concurrent_insert(txs.clone(), Arc::clone(&mempool));
@@ -50,7 +55,12 @@ macro_rules! package {
         package!(inner($insert, $timeout_gap, $timeout, $insert, $expect, 0));
     };
     (inner($cycle_limit: expr, $timeout_gap: expr, $timeout: expr, $insert: expr, $expect_order: expr, $expect_propose: expr)) => {
-        let mempool = &Arc::new(new_mempool($insert * 10, $timeout_gap));
+        let mempool = &Arc::new(new_mempool(
+            $insert * 10,
+            $timeout_gap,
+            CYCLE_LIMIT,
+            MAX_TX_SIZE,
+        ));
         let txs = mock_txs($insert, 0, $timeout);
         concurrent_insert(txs.clone(), Arc::clone(mempool));
         let mixed_tx_hashes = exec_package(Arc::clone(mempool), $cycle_limit);
@@ -70,7 +80,7 @@ fn test_package() {
     package!(normal(100, 200, 100, 100));
 
     // 3. 2 * cycle_limit < pool_size
-    package!(normal(100, 201, 100, 100));
+    package!(normal(100, 201, 100, 101));
 
     // 4. current_height >= tx.timeout
     package!(timeout(50, CURRENT_HEIGHT, 10, 0));

--- a/core/mempool/src/tests/mempool.rs
+++ b/core/mempool/src/tests/mempool.rs
@@ -41,9 +41,9 @@ fn test_insert() {
 }
 
 macro_rules! package {
-    (normal($cycle_limit: expr, $insert: expr, $expect_order: expr, $expect_propose: expr)) => {
+    (normal($tx_num_limit: expr, $insert: expr, $expect_order: expr, $expect_propose: expr)) => {
         package!(inner(
-            $cycle_limit,
+            $tx_num_limit,
             TIMEOUT_GAP,
             TIMEOUT,
             $insert,
@@ -54,7 +54,7 @@ macro_rules! package {
     (timeout($timeout_gap: expr, $timeout: expr, $insert: expr, $expect: expr)) => {
         package!(inner($insert, $timeout_gap, $timeout, $insert, $expect, 0));
     };
-    (inner($cycle_limit: expr, $timeout_gap: expr, $timeout: expr, $insert: expr, $expect_order: expr, $expect_propose: expr)) => {
+    (inner($tx_num_limit: expr, $timeout_gap: expr, $timeout: expr, $insert: expr, $expect_order: expr, $expect_propose: expr)) => {
         let mempool = &Arc::new(new_mempool(
             $insert * 10,
             $timeout_gap,
@@ -63,7 +63,7 @@ macro_rules! package {
         ));
         let txs = mock_txs($insert, 0, $timeout);
         concurrent_insert(txs.clone(), Arc::clone(mempool));
-        let mixed_tx_hashes = exec_package(Arc::clone(mempool), $cycle_limit);
+        let mixed_tx_hashes = exec_package(Arc::clone(mempool), CYCLE_LIMIT, $tx_num_limit);
         assert_eq!(mixed_tx_hashes.order_tx_hashes.len(), $expect_order);
         assert_eq!(mixed_tx_hashes.propose_tx_hashes.len(), $expect_propose);
     };
@@ -71,15 +71,15 @@ macro_rules! package {
 
 #[test]
 fn test_package() {
-    // 1. pool_size <= cycle_limit
+    // 1. pool_size <= tx_num_limit
     package!(normal(100, 50, 50, 0));
     package!(normal(100, 100, 100, 0));
 
-    // 2. cycle_limit < pool_size <= 2 * cycle_limit
+    // 2. tx_num_limit < pool_size <= 2 * tx_num_limit
     package!(normal(100, 101, 100, 1));
     package!(normal(100, 200, 100, 100));
 
-    // 3. 2 * cycle_limit < pool_size
+    // 3. 2 * tx_num_limit < pool_size
     package!(normal(100, 201, 100, 101));
 
     // 4. current_height >= tx.timeout
@@ -102,14 +102,14 @@ fn test_package_order_consistent_with_insert_order() {
     let txs = &default_mock_txs(100);
     txs.iter()
         .for_each(|signed_tx| exec_insert(signed_tx, Arc::clone(mempool)));
-    let mixed_tx_hashes = exec_package(Arc::clone(mempool), CYCLE_LIMIT);
+    let mixed_tx_hashes = exec_package(Arc::clone(mempool), CYCLE_LIMIT, TX_NUM_LIMIT);
     assert!(check_order_consistant(&mixed_tx_hashes, txs));
 
     // flush partial txs and test order consistency
     let (remove_txs, reserve_txs) = txs.split_at(50);
     let remove_hashes: Vec<Hash> = remove_txs.iter().map(|tx| tx.tx_hash.clone()).collect();
     exec_flush(remove_hashes, Arc::clone(mempool));
-    let mixed_tx_hashes = exec_package(Arc::clone(mempool), CYCLE_LIMIT);
+    let mixed_tx_hashes = exec_package(Arc::clone(mempool), CYCLE_LIMIT, TX_NUM_LIMIT);
     assert!(check_order_consistant(&mixed_tx_hashes, reserve_txs));
 }
 
@@ -134,7 +134,7 @@ fn test_flush() {
     exec_flush(remove_hashes, Arc::clone(&mempool));
     assert_eq!(mempool.get_tx_cache().len(), 432);
     assert_eq!(mempool.get_tx_cache().queue_len(), 555);
-    exec_package(Arc::clone(&mempool), CYCLE_LIMIT);
+    exec_package(Arc::clone(&mempool), CYCLE_LIMIT, TX_NUM_LIMIT);
     assert_eq!(mempool.get_tx_cache().queue_len(), 432);
     assert_eq!(callback_cache.len(), 0);
 
@@ -206,7 +206,7 @@ fn bench_package(b: &mut Bencher) {
     let txs = default_mock_txs(50_000);
     concurrent_insert(txs, Arc::clone(&mempool));
     b.iter(|| {
-        exec_package(Arc::clone(&mempool), CYCLE_LIMIT);
+        exec_package(Arc::clone(&mempool), CYCLE_LIMIT, TX_NUM_LIMIT);
     });
 }
 
@@ -218,7 +218,7 @@ fn bench_flush(b: &mut Bencher) {
     b.iter(|| {
         concurrent_insert(txs.clone(), Arc::clone(mempool));
         exec_flush(remove_hashes.clone(), Arc::clone(mempool));
-        exec_package(Arc::clone(mempool), CYCLE_LIMIT);
+        exec_package(Arc::clone(mempool), CYCLE_LIMIT, TX_NUM_LIMIT);
     });
 }
 

--- a/core/mempool/src/tests/mod.rs
+++ b/core/mempool/src/tests/mod.rs
@@ -25,6 +25,7 @@ use protocol::{Bytes, ProtocolResult};
 use crate::{HashMemPool, MemPoolError};
 
 const CYCLE_LIMIT: u64 = 1_000_000;
+const TX_NUM_LIMIT: u64 = 10_000;
 const CURRENT_HEIGHT: u64 = 999;
 const POOL_SIZE: usize = 100_000;
 const MAX_TX_SIZE: u64 = 1024; // 1KB
@@ -177,8 +178,17 @@ fn exec_flush(remove_hashes: Vec<Hash>, mempool: Arc<HashMemPool<HashMemPoolAdap
     });
 }
 
-fn exec_package(mempool: Arc<HashMemPool<HashMemPoolAdapter>>, cycle_limit: u64) -> MixedTxHashes {
-    executor::block_on(async { mempool.package(Context::new(), cycle_limit).await.unwrap() })
+fn exec_package(
+    mempool: Arc<HashMemPool<HashMemPoolAdapter>>,
+    cycle_limit: u64,
+    tx_num_limit: u64,
+) -> MixedTxHashes {
+    executor::block_on(async {
+        mempool
+            .package(Context::new(), cycle_limit, tx_num_limit)
+            .await
+            .unwrap()
+    })
 }
 
 fn exec_ensure_order_txs(require_hashes: Vec<Hash>, mempool: Arc<HashMemPool<HashMemPoolAdapter>>) {

--- a/core/mempool/src/tests/mod.rs
+++ b/core/mempool/src/tests/mod.rs
@@ -24,9 +24,10 @@ use protocol::{Bytes, ProtocolResult};
 
 use crate::{HashMemPool, MemPoolError};
 
-const CYCLE_LIMIT: u64 = 10_000;
+const CYCLE_LIMIT: u64 = 1_000_000;
 const CURRENT_HEIGHT: u64 = 999;
 const POOL_SIZE: usize = 100_000;
+const MAX_TX_SIZE: u64 = 1024; // 1KB
 const TIMEOUT: u64 = 1000;
 const TIMEOUT_GAP: u64 = 100;
 const TX_CYCLE: u64 = 1;
@@ -81,7 +82,7 @@ impl MemPoolAdapter for HashMemPoolAdapter {
         Ok(CURRENT_HEIGHT)
     }
 
-    fn set_timeout_gap(&self, _timeout_gap: u64) {}
+    fn set_args(&self, _timeout_gap: u64, _cycles_limit: u64, _max_tx_size: u64) {}
 }
 
 pub fn default_mock_txs(size: usize) -> Vec<SignedTransaction> {
@@ -99,13 +100,18 @@ fn mock_txs(valid_size: usize, invalid_size: usize, timeout: u64) -> Vec<SignedT
 }
 
 fn default_mempool() -> HashMemPool<HashMemPoolAdapter> {
-    new_mempool(POOL_SIZE, TIMEOUT_GAP)
+    new_mempool(POOL_SIZE, TIMEOUT_GAP, CYCLE_LIMIT, MAX_TX_SIZE)
 }
 
-fn new_mempool(pool_size: usize, timeout_gap: u64) -> HashMemPool<HashMemPoolAdapter> {
+fn new_mempool(
+    pool_size: usize,
+    timeout_gap: u64,
+    cycles_limit: u64,
+    max_tx_size: u64,
+) -> HashMemPool<HashMemPoolAdapter> {
     let adapter = HashMemPoolAdapter::new();
     let mempool = HashMemPool::new(pool_size, adapter);
-    mempool.set_timeout_gap(timeout_gap);
+    mempool.set_args(timeout_gap, cycles_limit, max_tx_size);
     mempool
 }
 

--- a/core/mempool/src/tx_cache.rs
+++ b/core/mempool/src/tx_cache.rs
@@ -225,7 +225,7 @@ impl TxCache {
                 tx_count += 1;
                 if tx_count > tx_num_limit {
                     stage = stage.next();
-                    tx_count = 0;
+                    tx_count = 1;
                 }
 
                 match stage {

--- a/core/mempool/src/tx_cache.rs
+++ b/core/mempool/src/tx_cache.rs
@@ -178,6 +178,7 @@ impl TxCache {
 
     pub fn package(
         &self,
+        _cycles_limit: u64,
         tx_num_limit: u64,
         current_height: u64,
         timeout: u64,
@@ -367,6 +368,7 @@ mod tests {
     const BYTES_LEN: usize = 10;
     const TX_NUM: usize = 1000;
     const TX_CYCLE: u64 = 1;
+    const TX_NUM_LIMIT: u64 = 20000;
     const CYCLE_LIMIT: u64 = 500;
     const CURRENT_H: u64 = 100;
     const TIMEOUT: u64 = 150;
@@ -431,7 +433,7 @@ mod tests {
         let tx_cache_clone = Arc::<TxCache>::clone(tx_cache);
         thread::spawn(move || {
             tx_cache_clone
-                .package(CYCLE_LIMIT, CURRENT_H, TIMEOUT)
+                .package(CYCLE_LIMIT, TX_NUM_LIMIT, CURRENT_H, TIMEOUT)
                 .unwrap();
         })
     }
@@ -531,7 +533,9 @@ mod tests {
         let tx_cache = TxCache::new(POOL_SIZE);
         concurrent_insert(txs, &tx_cache);
         b.iter(|| {
-            let mixed_tx_hashes = tx_cache.package(CYCLE_LIMIT, CURRENT_H, TIMEOUT).unwrap();
+            let mixed_tx_hashes = tx_cache
+                .package(TX_NUM_LIMIT, CYCLE_LIMIT, CURRENT_H, TIMEOUT)
+                .unwrap();
             assert_eq!(
                 mixed_tx_hashes.order_tx_hashes.len(),
                 (CYCLE_LIMIT / TX_CYCLE) as usize

--- a/core/mempool/src/tx_cache.rs
+++ b/core/mempool/src/tx_cache.rs
@@ -178,7 +178,7 @@ impl TxCache {
 
     pub fn package(
         &self,
-        cycle_limit: u64,
+        tx_num_limit: u64,
         current_height: u64,
         timeout: u64,
     ) -> ProtocolResult<MixedTxHashes> {
@@ -188,7 +188,7 @@ impl TxCache {
         let mut propose_tx_hashes = Vec::new();
         let mut timeout_tx_hashes = Vec::new();
 
-        let mut cycle_count: u64 = 0;
+        let mut tx_count: u64 = 0;
         let mut stage = Stage::OrderTxs;
 
         loop {
@@ -215,12 +215,10 @@ impl TxCache {
                 {
                     continue;
                 }
-                // Accumulate cycles. The order_tx_hashes and the propose_tx_hashes both collect
-                // transactions under cycle limit.
-                cycle_count += shared_tx.tx.raw.cycles_limit;
-                if cycle_count > cycle_limit {
+                tx_count += 1;
+                if tx_count > tx_num_limit {
                     stage = stage.next();
-                    cycle_count = shared_tx.tx.raw.cycles_limit;
+                    tx_count = 0;
                 }
 
                 match stage {

--- a/devtools/chain/genesis.toml
+++ b/devtools/chain/genesis.toml
@@ -20,7 +20,7 @@ payload = '''
     "chain_id": "b6a4d7da21443f5e816e8700eea87610e6d769657d6b8ec73028457bf2ca4036",
     "common_ref": "703873635a6b51513451",
     "timeout_gap": 20,
-    "cycles_limit": 999999999999,
+    "cycles_limit": 1000000,
     "cycles_price": 1,
     "interval": 3000,
     "verifier_list": [
@@ -34,6 +34,8 @@ payload = '''
     "propose_ratio": 15,
     "prevote_ratio": 10,
     "precommit_ratio": 10,
-    "brake_ratio": 7
+    "brake_ratio": 7,
+    "tx_num_limit": 20000,
+    "max_tx_size": 1024
 }
 '''

--- a/protocol/src/fixed_codec/primitive.rs
+++ b/protocol/src/fixed_codec/primitive.rs
@@ -122,7 +122,7 @@ impl rlp::Decodable for Address {
 
 impl rlp::Encodable for Metadata {
     fn rlp_append(&self, s: &mut rlp::RlpStream) {
-        s.begin_list(11)
+        s.begin_list(13)
             .append(&self.chain_id)
             .append(&self.common_ref)
             .append(&self.timeout_gap)
@@ -133,7 +133,9 @@ impl rlp::Encodable for Metadata {
             .append(&self.propose_ratio)
             .append(&self.prevote_ratio)
             .append(&self.precommit_ratio)
-            .append(&self.brake_ratio);
+            .append(&self.brake_ratio)
+            .append(&self.tx_num_limit)
+            .append(&self.max_tx_size);
     }
 }
 
@@ -150,6 +152,8 @@ impl rlp::Decodable for Metadata {
         let prevote_ratio: u64 = r.at(8)?.as_val()?;
         let precommit_ratio: u64 = r.at(9)?.as_val()?;
         let brake_ratio: u64 = r.at(10)?.as_val()?;
+        let tx_num_limit: u64 = r.at(11)?.as_val()?;
+        let max_tx_size: u64 = r.at(12)?.as_val()?;
 
         Ok(Self {
             chain_id,
@@ -163,6 +167,8 @@ impl rlp::Decodable for Metadata {
             prevote_ratio,
             precommit_ratio,
             brake_ratio,
+            tx_num_limit,
+            max_tx_size,
         })
     }
 }

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -114,8 +114,7 @@ pub trait CommonConsensusAdapter: Send + Sync {
         timestamp: u64,
     ) -> ProtocolResult<Metadata>;
 
-    /// Set timeout_gap in mempool.
-    fn set_timeout_gap(&self, context: Context, timeout_gap: u64);
+    fn set_args(&self, _context: Context, timeout_gap: u64, cycles_limit: u64, max_tx_size: u64);
 }
 
 #[async_trait]

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -127,6 +127,7 @@ pub trait ConsensusAdapter: CommonConsensusAdapter + Send + Sync {
         ctx: Context,
         height: u64,
         cycle_limit: u64,
+        tx_num_limit: u64,
     ) -> ProtocolResult<MixedTxHashes>;
 
     /// Check the correctness of the given transactions.

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -114,7 +114,7 @@ pub trait CommonConsensusAdapter: Send + Sync {
         timestamp: u64,
     ) -> ProtocolResult<Metadata>;
 
-    fn set_args(&self, _context: Context, timeout_gap: u64, cycles_limit: u64, max_tx_size: u64);
+    fn set_args(&self, context: Context, timeout_gap: u64, cycles_limit: u64, max_tx_size: u64);
 }
 
 #[async_trait]

--- a/protocol/src/traits/mempool.rs
+++ b/protocol/src/traits/mempool.rs
@@ -20,7 +20,12 @@ impl MixedTxHashes {
 pub trait MemPool: Send + Sync {
     async fn insert(&self, ctx: Context, tx: SignedTransaction) -> ProtocolResult<()>;
 
-    async fn package(&self, ctx: Context, cycle_limit: u64) -> ProtocolResult<MixedTxHashes>;
+    async fn package(
+        &self,
+        ctx: Context,
+        cycles_limit: u64,
+        tx_num_limit: u64,
+    ) -> ProtocolResult<MixedTxHashes>;
 
     async fn flush(&self, ctx: Context, tx_hashes: Vec<Hash>) -> ProtocolResult<()>;
 

--- a/protocol/src/traits/mempool.rs
+++ b/protocol/src/traits/mempool.rs
@@ -42,7 +42,7 @@ pub trait MemPool: Send + Sync {
         propose_tx_hashes: Vec<Hash>,
     ) -> ProtocolResult<()>;
 
-    fn set_timeout_gap(&self, timeout_gap: u64);
+    fn set_args(&self, timeout_gap: u64, cycles_limit: u64, max_tx_size: u64);
 }
 
 #[async_trait]
@@ -63,5 +63,5 @@ pub trait MemPoolAdapter: Send + Sync {
 
     async fn get_latest_height(&self, ctx: Context) -> ProtocolResult<u64>;
 
-    fn set_timeout_gap(&self, timeout_gap: u64);
+    fn set_args(&self, timeout_gap: u64, cycles_limit: u64, max_tx_size: u64);
 }

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -237,6 +237,8 @@ pub struct Metadata {
     pub prevote_ratio:   u64,
     pub precommit_ratio: u64,
     pub brake_ratio:     u64,
+    pub tx_num_limit:    u64,
+    pub max_tx_size:     u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -209,8 +209,12 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
 
     let metadata: Metadata = serde_json::from_str(&exec_resp.ret).expect("Decode metadata failed!");
 
-    // set timeout_gap in mempool
-    mempool.set_timeout_gap(metadata.timeout_gap);
+    // set args in mempool
+    mempool.set_args(
+        metadata.timeout_gap,
+        metadata.cycles_limit,
+        metadata.max_tx_size,
+    );
 
     // register broadcast new transaction
     network_service.register_endpoint_handler(

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -270,6 +270,8 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
             prevote_ratio:      metadata.prevote_ratio,
             precommit_ratio:    metadata.precommit_ratio,
             brake_ratio:        metadata.brake_ratio,
+            tx_num_limit:       metadata.tx_num_limit,
+            max_tx_size:        metadata.max_tx_size,
         }
     } else {
         let wal_info = storage.load_muta_wal().await.expect("Load muta wal error");


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
New feature.

**What this PR does / why we need it**:
- Add tx size check to prevent attacking by composing big tx
- Add tx_num_limit to genesis, and it will pack at most this number of tx into a block.
- Change the meaning of cycles_limit in genesis. It becomes the limit of every tx instead of the whole block.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
