### PR TITLE
chore(config): the effect of the maxconn field matches its name now

### DIFF
--- a/core/api/src/config.rs
+++ b/core/api/src/config.rs
@@ -11,9 +11,7 @@ pub struct GraphQLConfig {
     // By default http server uses number of available logical cpu as threads count.
     pub workers: usize,
 
-    // Sets the maximum per-worker number of concurrent connections.
-    // All socket listeners will stop accepting connections when this limit is reached for each
-    // worker. By default max connections is set to a 25k.
+    // Sets the maximum number of all concurrent connections.
     pub maxconn: usize,
 
     // Set the max payload size of graphql interface.

--- a/core/api/src/lib.rs
+++ b/core/api/src/lib.rs
@@ -7,6 +7,7 @@ use futures::executor::block_on;
 use juniper::http::GraphQLRequest;
 use juniper::FieldResult;
 use lazy_static::lazy_static;
+use std::cmp;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -216,7 +217,7 @@ pub async fn start_graphql<Adapter: APIAdapter + 'static>(cfg: GraphQLConfig, ad
 
     let path_graphql_uri = cfg.graphql_uri.to_owned();
     let path_graphiql_uri = cfg.graphiql_uri.to_owned();
-    let wokers = cfg.workers;
+    let workers = cfg.workers;
     let maxconn = cfg.maxconn;
     let add_listening_address = cfg.listening_address;
     let max_payload_size = cfg.max_payload_size;
@@ -234,8 +235,8 @@ pub async fn start_graphql<Adapter: APIAdapter + 'static>(cfg: GraphQLConfig, ad
             )
             .service(web::resource(&path_graphiql_uri).route(web::get().to(graphiql)))
     })
-    .workers(wokers)
-    .maxconn(maxconn)
+    .workers(workers)
+    .maxconn(cmp::max(maxconn / workers, 1))
     .bind(add_listening_address)
     .unwrap()
     .run()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**

chore

**What this PR does / why we need it**:

The configuration field name `maxconn` does not match the role, what it really does is "max conn per worker".

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
\-

**Special notes for your reviewer**:

\-
