### PR TITLE
refactor: modify service error handle mechanism

### DIFF
--- a/binding-macro/src/common.rs
+++ b/binding-macro/src/common.rs
@@ -1,19 +1,4 @@
-use syn::{FnArg, Pat, Path, PathArguments, Type};
-
-// expect fn foo() -> ProtocolResult<T>
-pub fn get_protocol_result_args(path: &Path) -> Option<&PathArguments> {
-    // ::<a>::<b>
-    if path.leading_colon.is_some() {
-        return None;
-    }
-
-    // ProtocolResult<T>
-    if path.segments.len() == 1 && path.segments[0].ident == "ProtocolResult" {
-        return Some(&path.segments[0].arguments);
-    }
-
-    None
-}
+use syn::{FnArg, Pat, Path, Type};
 
 pub fn get_request_context_pat(bound_name: &str, fn_arg: &FnArg) -> Option<Pat> {
     if let FnArg::Typed(pat_type) = &*fn_arg {

--- a/binding-macro/src/cycles.rs
+++ b/binding-macro/src/cycles.rs
@@ -81,7 +81,9 @@ pub fn gen_cycles_code(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         #func_vis fn #func_name#generics(#inputs) #ret {
-            #request_ident.sub_cycles(#cycles_value);
+            if !#request_ident.sub_cycles(#cycles_value) {
+                return ServiceResponse::<_>::from_error(2, "cycles macro consume cycles fialed: out of cycles".to_owned());
+            }
             #body
         }
     })

--- a/binding-macro/src/cycles.rs
+++ b/binding-macro/src/cycles.rs
@@ -81,7 +81,7 @@ pub fn gen_cycles_code(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         #func_vis fn #func_name#generics(#inputs) #ret {
-            #request_ident.sub_cycles(#cycles_value)?;
+            #request_ident.sub_cycles(#cycles_value);
             #body
         }
     })

--- a/binding-macro/src/cycles.rs
+++ b/binding-macro/src/cycles.rs
@@ -82,7 +82,7 @@ pub fn gen_cycles_code(attr: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         #func_vis fn #func_name#generics(#inputs) #ret {
             if !#request_ident.sub_cycles(#cycles_value) {
-                return ServiceResponse::<_>::from_error(2, "cycles macro consume cycles fialed: out of cycles".to_owned());
+                return ServiceResponse::<_>::from_error(3, "cycles macro consume cycles fialed: out of cycles".to_owned());
             }
             #body
         }

--- a/binding-macro/src/lib.rs
+++ b/binding-macro/src/lib.rs
@@ -86,7 +86,7 @@ pub fn tx_hook_after(_: TokenStream, item: TokenStream) -> TokenStream {
 ///         &self,
 ///         _ctx: ServiceContext,
 ///     ) -> ServiceResponse<String> {
-///         ServiceResponse::<String>::from_data("ok".to_owned())
+///         ServiceResponse::<String>::from_succeed("ok".to_owned())
 ///     }
 /// }
 /// ```
@@ -119,7 +119,7 @@ pub fn read(_: TokenStream, item: TokenStream) -> TokenStream {
 ///         &mut self,
 ///         _ctx: ServiceContext,
 ///     ) -> ServiceResponse<String> {
-///         ServiceResponse::<String>::from_data("ok".to_owned())
+///         ServiceResponse::<String>::from_succeed("ok".to_owned())
 ///     }
 /// }
 /// ```

--- a/binding-macro/src/lib.rs
+++ b/binding-macro/src/lib.rs
@@ -27,10 +27,8 @@ use crate::service::gen_service_code;
 ///     #[genesis]
 ///     fn init_genesis(
 ///         &mut self,
-///     ) -> ProtocolResult<()> {
+///     ) {
 ///         do_work();
-///
-///         Ok(()))
 ///     }
 /// }
 /// ```
@@ -45,10 +43,8 @@ use crate::service::gen_service_code;
 ///     fn init_genesis(
 ///         &mut self,
 ///         payload: PayloadType,
-///     ) -> ProtocolResult<()> {
+///     ) {
 ///         do_work(payload);
-///
-///         Ok(()))
 ///     }
 /// }
 /// ```
@@ -77,7 +73,7 @@ pub fn tx_hook_after(_: TokenStream, item: TokenStream) -> TokenStream {
 ///  1. Is it a struct method marked with #[service]?
 ///  2. Is visibility private?
 ///  3. Parameter signature contains `&self and ctx: ServiceContext`?
-///  4. Is the return value `ProtocolResult <T: Deserialize + Serialize>` or `ProtocolResult <()>`?
+///  4. Is the return value `ServiceResponse<T>`?
 ///
 /// # Example:
 ///
@@ -89,8 +85,8 @@ pub fn tx_hook_after(_: TokenStream, item: TokenStream) -> TokenStream {
 ///     fn test_read_fn(
 ///         &self,
 ///         _ctx: ServiceContext,
-///     ) -> ProtocolResult<String> {
-///         Ok("test read".to_owend())
+///     ) -> ServiceResponse<String> {
+///         ServiceResponse::<String>::from_data("ok".to_owned())
 ///     }
 /// }
 /// ```
@@ -110,7 +106,7 @@ pub fn read(_: TokenStream, item: TokenStream) -> TokenStream {
 ///  1. Is it a struct method marked with #[service]?
 ///  2. Is visibility private?
 ///  3. Parameter signature contains `&self and ctx: ServiceContext`?
-///  4. Is the return value `ProtocolResult <T: Deserialize + Serialize>` or `ProtocolResult <()>`?
+///  4. Is the return value `ServiceResponse<T>`?
 ///
 /// # Example:
 ///
@@ -122,8 +118,8 @@ pub fn read(_: TokenStream, item: TokenStream) -> TokenStream {
 ///     fn test_write_fn(
 ///         &mut self,
 ///         _ctx: ServiceContext,
-///     ) -> ProtocolResult<String> {
-///         Ok("test write".to_owned())
+///     ) -> ServiceResponse<String> {
+///         ServiceResponse::<String>::from_data("ok".to_owned())
 ///     }
 /// }
 /// ```

--- a/binding-macro/src/read_write.rs
+++ b/binding-macro/src/read_write.rs
@@ -1,11 +1,9 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::punctuated::Punctuated;
-use syn::{parse_macro_input, FnArg, ImplItemMethod, ReturnType, Token, Type, Visibility};
+use syn::{parse_macro_input, FnArg, ImplItemMethod, ReturnType, Token, Visibility};
 
-use crate::common::{
-    arg_is_immutable_receiver, arg_is_mutable_receiver, assert_type, get_protocol_result_args,
-};
+use crate::common::{arg_is_immutable_receiver, arg_is_mutable_receiver, assert_type};
 
 pub fn verify_read_or_write(item: TokenStream, mutable: bool) -> TokenStream {
     let method_item = parse_macro_input!(item as ImplItemMethod);

--- a/binding-macro/src/read_write.rs
+++ b/binding-macro/src/read_write.rs
@@ -58,12 +58,5 @@ fn verify_ret_type(ret_type: &ReturnType) {
         _ => panic!("The return type of read/write method must be protocol::ProtocolResult"),
     };
 
-    match real_ret_type {
-        Type::Path(type_path) => {
-            let path = &type_path.path;
-            get_protocol_result_args(&path)
-                .expect("The return type of read/write method must be protocol::ProtocolResult");
-        }
-        _ => panic!("The return type of read/write method must be protocol::ProtocolResult"),
-    }
+    assert_type(&real_ret_type, "ServiceResponse");
 }

--- a/binding-macro/src/service.rs
+++ b/binding-macro/src/service.rs
@@ -113,10 +113,13 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
 
                 match method {
                     #(#list_read_name => {
-                        let payload: #list_read_payload = serde_json::from_str(ctx.get_payload())
-                                .unwrap_or_else(|e| panic!("service macro decode payload failed: {:?}", e));
+                        let payload_res: Result<#list_read_payload, _> = serde_json::from_str(ctx.get_payload());
+                        if let Err(e) = payload_res {
+                            return ServiceResponse::<String>::from_error(1, format!("service macro decode payload failed: {:?}", e));
+                        };
+                        let payload = payload_res.unwrap();
                         let res = self.#list_read_ident(ctx, payload);
-                        if res.code == 0 {
+                        if !res.is_error() {
                             let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
@@ -128,7 +131,7 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                     },)*
                     #(#list_read_name_nonepayload => {
                         let res = self.#list_read_ident_nonepayload(ctx);
-                        if res.code == 0 {
+                        if !res.is_error() {
                             let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
@@ -148,10 +151,13 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
 
                 match method {
                     #(#list_write_name => {
-                        let payload: #list_write_payload = serde_json::from_str(ctx.get_payload())
-                                .unwrap_or_else(|e| panic!("service macro decode payload failed: {:?}", e));
+                        let payload_res: Result<#list_write_payload, _> = serde_json::from_str(ctx.get_payload());
+                        if let Err(e) = payload_res {
+                            return ServiceResponse::<String>::from_error(1, format!("service macro decode payload failed: {:?}", e));
+                        };
+                        let payload = payload_res.unwrap();
                         let res = self.#list_write_ident(ctx, payload);
-                        if res.code == 0 {
+                        if !res.is_error() {
                             let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
@@ -163,7 +169,7 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                     },)*
                     #(#list_write_name_nonepayload => {
                         let res = self.#list_write_ident_nonepayload(ctx);
-                        if res.code == 0 {
+                        if !res.is_error() {
                             let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();

--- a/binding-macro/src/service.rs
+++ b/binding-macro/src/service.rs
@@ -117,8 +117,10 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                                 .unwrap_or_else(|e| panic!("service macro decode payload failed: {:?}", e));
                         let res = self.#list_read_ident(ctx, payload);
                         if res.code == 0 {
-                            let data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
-
+                            let mut data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            if data_json == "null" {
+                                data_json = "".to_owned();
+                            }
                             ServiceResponse::<String>::from_data(data_json)
                         } else {
                             ServiceResponse::<String>::from_error(res.code, res.error.clone())
@@ -127,8 +129,10 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                     #(#list_read_name_nonepayload => {
                         let res = self.#list_read_ident_nonepayload(ctx);
                         if res.code == 0 {
-                            let data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
-
+                            let mut data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            if data_json == "null" {
+                                data_json = "".to_owned();
+                            }
                             ServiceResponse::<String>::from_data(data_json)
                         } else {
                             ServiceResponse::<String>::from_error(res.code, res.error.clone())
@@ -148,8 +152,10 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                                 .unwrap_or_else(|e| panic!("service macro decode payload failed: {:?}", e));
                         let res = self.#list_write_ident(ctx, payload);
                         if res.code == 0 {
-                            let data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
-
+                            let mut data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            if data_json == "null" {
+                                data_json = "".to_owned();
+                            }
                             ServiceResponse::<String>::from_data(data_json)
                         } else {
                             ServiceResponse::<String>::from_error(res.code, res.error.clone())
@@ -158,8 +164,10 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                     #(#list_write_name_nonepayload => {
                         let res = self.#list_write_ident_nonepayload(ctx);
                         if res.code == 0 {
-                            let data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
-
+                            let mut data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            if data_json == "null" {
+                                data_json = "".to_owned();
+                            }
                             ServiceResponse::<String>::from_data(data_json)
                         } else {
                             ServiceResponse::<String>::from_error(res.code, res.error.clone())

--- a/binding-macro/src/service.rs
+++ b/binding-macro/src/service.rs
@@ -114,8 +114,8 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                 match method {
                     #(#list_read_name => {
                         let payload_res: Result<#list_read_payload, _> = serde_json::from_str(ctx.get_payload());
-                        if let Err(e) = payload_res {
-                            return ServiceResponse::<String>::from_error(1, format!("service macro decode payload failed: {:?}", e));
+                        if payload_res.is_err() {
+                            return ServiceResponse::<String>::from_error(1, "service macro decode payload failed".to_owned());
                         };
                         let payload = payload_res.unwrap();
                         let res = self.#list_read_ident(ctx, payload);
@@ -152,8 +152,8 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                 match method {
                     #(#list_write_name => {
                         let payload_res: Result<#list_write_payload, _> = serde_json::from_str(ctx.get_payload());
-                        if let Err(e) = payload_res {
-                            return ServiceResponse::<String>::from_error(1, format!("service macro decode payload failed: {:?}", e));
+                        if payload_res.is_err() {
+                            return ServiceResponse::<String>::from_error(1, "service macro decode payload failed".to_owned());
                         };
                         let payload = payload_res.unwrap();
                         let res = self.#list_write_ident(ctx, payload);

--- a/binding-macro/src/service.rs
+++ b/binding-macro/src/service.rs
@@ -48,29 +48,29 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
     let genesis_method = find_genesis(items);
     let genesis_body = match genesis_method {
         Some(genesis_method) => get_genesis_body(&genesis_method),
-        None => quote! {Ok(())},
+        None => quote! {()},
     };
 
     let hooks = extract_hooks(items);
     let hook_before = &hooks.before;
     let hook_before_body = match hook_before {
         Some(hook_before) => quote! { self.#hook_before(_params) },
-        None => quote! {Ok(())},
+        None => quote! {()},
     };
     let hook_after = &hooks.after;
     let hook_after_body = match hook_after {
         Some(hook_after) => quote! { self.#hook_after(_params) },
-        None => quote! {Ok(())},
+        None => quote! {()},
     };
     let tx_hook_before = &hooks.tx_before;
     let tx_hook_before_body = match tx_hook_before {
         Some(tx_hook_before) => quote! { self.#tx_hook_before(_ctx) },
-        None => quote! {Ok(())},
+        None => quote! {()},
     };
     let tx_hook_after = &hooks.tx_after;
     let tx_hook_after_body = match tx_hook_after {
         Some(tx_hook_after) => quote! { self.#tx_hook_after(_ctx) },
-        None => quote! {Ok(())},
+        None => quote! {()},
     };
 
     let list_method_meta: Vec<MethodMeta> = methods.into_iter().map(extract_method_meta).collect();
@@ -87,81 +87,85 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         impl #impl_generics protocol::traits::Service for #service_ident #ty_generics #where_clause {
-            fn genesis_(&mut self, _payload: String) -> protocol::ProtocolResult<()> {
+            fn genesis_(&mut self, _payload: String) {
                 #genesis_body
             }
 
-            fn hook_before_(&mut self, _params: &ExecutorParams) -> protocol::ProtocolResult<()> {
+            fn hook_before_(&mut self, _params: &ExecutorParams) {
                 #hook_before_body
             }
 
-            fn hook_after_(&mut self, _params: &ExecutorParams) -> protocol::ProtocolResult<()> {
+            fn hook_after_(&mut self, _params: &ExecutorParams) {
                 #hook_after_body
             }
 
-            fn tx_hook_before_(&mut self, _ctx: ServiceContext) -> ProtocolResult<()> {
+            fn tx_hook_before_(&mut self, _ctx: ServiceContext) {
                 #tx_hook_before_body
             }
 
-            fn tx_hook_after_(&mut self, _ctx: ServiceContext) -> ProtocolResult<()> {
+            fn tx_hook_after_(&mut self, _ctx: ServiceContext) {
                 #tx_hook_after_body
             }
 
-            fn read_(&self, ctx: protocol::types::ServiceContext) -> protocol::ProtocolResult<String> {
+            fn read_(&self, ctx: protocol::types::ServiceContext) -> ServiceResponse<String> {
                 let service = ctx.get_service_name();
                 let method = ctx.get_service_method();
 
                 match method {
                     #(#list_read_name => {
                         let payload: #list_read_payload = serde_json::from_str(ctx.get_payload())
-                                .map_err(|e| protocol::traits::BindingMacroError::JsonParse(e))?;
-                        let res = self.#list_read_ident(ctx, payload)?;
-                        let res_str = serde_json::to_string(&res).map_err(|e| protocol::traits::BindingMacroError::JsonParse(e))?;
-                        if res_str.as_str() == "null" {
-                            Ok("".to_owned())
+                                .unwrap_or_else(|e| panic!("service macro decode payload failed: {:?}", e));
+                        let res = self.#list_read_ident(ctx, payload);
+                        if res.code == 0 {
+                            let data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+
+                            ServiceResponse::<String>::from_data(data_json)
                         } else {
-                            Ok(res_str)
+                            ServiceResponse::<String>::from_error(res.code, res.error.clone())
                         }
                     },)*
                     #(#list_read_name_nonepayload => {
-                        let res = self.#list_read_ident_nonepayload(ctx)?;
-                        let res_str = serde_json::to_string(&res).map_err(|e| protocol::traits::BindingMacroError::JsonParse(e))?;
-                        if res_str.as_str() == "null" {
-                            Ok("".to_owned())
+                        let res = self.#list_read_ident_nonepayload(ctx);
+                        if res.code == 0 {
+                            let data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+
+                            ServiceResponse::<String>::from_data(data_json)
                         } else {
-                            Ok(res_str)
+                            ServiceResponse::<String>::from_error(res.code, res.error.clone())
                         }
                     },)*
-                    _ => Err(protocol::traits::BindingMacroError::NotFoundMethod{ service: service.to_owned(), method: method.to_owned() }.into())
+                    _ => panic!("service macro not found method:{:?} of service:{:?}", method, service)
                 }
             }
 
-            fn write_(&mut self, ctx: protocol::types::ServiceContext) -> protocol::ProtocolResult<String> {
+            fn write_(&mut self, ctx: protocol::types::ServiceContext) -> ServiceResponse<String> {
                 let service = ctx.get_service_name();
                 let method = ctx.get_service_method();
 
                 match method {
                     #(#list_write_name => {
                         let payload: #list_write_payload = serde_json::from_str(ctx.get_payload())
-                                .map_err(|e| protocol::traits::BindingMacroError::JsonParse(e))?;
-                        let res = self.#list_write_ident(ctx, payload)?;
-                        let res_str = serde_json::to_string(&res).map_err(|e| protocol::traits::BindingMacroError::JsonParse(e))?;
-                        if res_str.as_str() == "null" {
-                            Ok("".to_owned())
+                                .unwrap_or_else(|e| panic!("service macro decode payload failed: {:?}", e));
+                        let res = self.#list_write_ident(ctx, payload);
+                        if res.code == 0 {
+                            let data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+
+                            ServiceResponse::<String>::from_data(data_json)
                         } else {
-                            Ok(res_str)
+                            ServiceResponse::<String>::from_error(res.code, res.error.clone())
                         }
                     },)*
                     #(#list_write_name_nonepayload => {
-                        let res = self.#list_write_ident_nonepayload(ctx)?;
-                        let res_str = serde_json::to_string(&res).map_err(|e| protocol::traits::BindingMacroError::JsonParse(e))?;
-                        if res_str.as_str() == "null" {
-                            Ok("".to_owned())
+                        let res = self.#list_write_ident_nonepayload(ctx);
+                        if res.code == 0 {
+                            let data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+
+                            ServiceResponse::<String>::from_data(data_json)
                         } else {
-                            Ok(res_str)
+                            ServiceResponse::<String>::from_error(res.code, res.error.clone())
                         }
                     },)*
-                    _ => Err(protocol::traits::BindingMacroError::NotFoundMethod{ service: service.to_owned(), method: method.to_owned() }.into())
+                    _ => panic!("service macro not found method:{:?} of service:{:?}", method, service)
                 }
             }
         }
@@ -275,7 +279,7 @@ fn get_genesis_body(item: &ImplItemMethod) -> proc_macro2::TokenStream {
 
                 quote!{
                     let payload: #payload_ident = serde_json::from_str(&_payload)
-                                    .map_err(|e| protocol::traits::BindingMacroError::JsonParse(e))?;
+                    .unwrap_or_else(|e| panic!("service macro decode payload failed: {:?}", e));
                     self.#method_name(payload)
                 }
         },

--- a/binding-macro/src/service.rs
+++ b/binding-macro/src/service.rs
@@ -117,25 +117,25 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                                 .unwrap_or_else(|e| panic!("service macro decode payload failed: {:?}", e));
                         let res = self.#list_read_ident(ctx, payload);
                         if res.code == 0 {
-                            let mut data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
                             }
-                            ServiceResponse::<String>::from_data(data_json)
+                            ServiceResponse::<String>::from_succeed(data_json)
                         } else {
-                            ServiceResponse::<String>::from_error(res.code, res.error.clone())
+                            ServiceResponse::<String>::from_error(res.code, res.error_message.clone())
                         }
                     },)*
                     #(#list_read_name_nonepayload => {
                         let res = self.#list_read_ident_nonepayload(ctx);
                         if res.code == 0 {
-                            let mut data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
                             }
-                            ServiceResponse::<String>::from_data(data_json)
+                            ServiceResponse::<String>::from_succeed(data_json)
                         } else {
-                            ServiceResponse::<String>::from_error(res.code, res.error.clone())
+                            ServiceResponse::<String>::from_error(res.code, res.error_message.clone())
                         }
                     },)*
                     _ => panic!("service macro not found method:{:?} of service:{:?}", method, service)
@@ -152,25 +152,25 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                                 .unwrap_or_else(|e| panic!("service macro decode payload failed: {:?}", e));
                         let res = self.#list_write_ident(ctx, payload);
                         if res.code == 0 {
-                            let mut data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
                             }
-                            ServiceResponse::<String>::from_data(data_json)
+                            ServiceResponse::<String>::from_succeed(data_json)
                         } else {
-                            ServiceResponse::<String>::from_error(res.code, res.error.clone())
+                            ServiceResponse::<String>::from_error(res.code, res.error_message.clone())
                         }
                     },)*
                     #(#list_write_name_nonepayload => {
                         let res = self.#list_write_ident_nonepayload(ctx);
                         if res.code == 0 {
-                            let mut data_json = serde_json::to_string(&res.data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
                             }
-                            ServiceResponse::<String>::from_data(data_json)
+                            ServiceResponse::<String>::from_succeed(data_json)
                         } else {
-                            ServiceResponse::<String>::from_error(res.code, res.error.clone())
+                            ServiceResponse::<String>::from_error(res.code, res.error_message.clone())
                         }
                     },)*
                     _ => panic!("service macro not found method:{:?} of service:{:?}", method, service)

--- a/binding-macro/src/service.rs
+++ b/binding-macro/src/service.rs
@@ -115,12 +115,12 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                     #(#list_read_name => {
                         let payload_res: Result<#list_read_payload, _> = serde_json::from_str(ctx.get_payload());
                         if payload_res.is_err() {
-                            return ServiceResponse::<String>::from_error(1, "service macro decode payload failed".to_owned());
+                            return ServiceResponse::<String>::from_error(1, "decode service payload failed".to_owned());
                         };
                         let payload = payload_res.unwrap();
                         let res = self.#list_read_ident(ctx, payload);
                         if !res.is_error() {
-                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("encode succeed_data of ServiceResponse failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
                             }
@@ -132,7 +132,7 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                     #(#list_read_name_nonepayload => {
                         let res = self.#list_read_ident_nonepayload(ctx);
                         if !res.is_error() {
-                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("encode succeed_data of ServiceResponse failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
                             }
@@ -141,7 +141,7 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                             ServiceResponse::<String>::from_error(res.code, res.error_message.clone())
                         }
                     },)*
-                    _ => panic!("service macro not found method:{:?} of service:{:?}", method, service)
+                    _ => ServiceResponse::<String>::from_error(2, format!("not found method:{:?} of service:{:?}", method, service))
                 }
             }
 
@@ -153,12 +153,12 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                     #(#list_write_name => {
                         let payload_res: Result<#list_write_payload, _> = serde_json::from_str(ctx.get_payload());
                         if payload_res.is_err() {
-                            return ServiceResponse::<String>::from_error(1, "service macro decode payload failed".to_owned());
+                            return ServiceResponse::<String>::from_error(1, "decode service payload failed".to_owned());
                         };
                         let payload = payload_res.unwrap();
                         let res = self.#list_write_ident(ctx, payload);
                         if !res.is_error() {
-                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("encode succeed_data of ServiceResponse failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
                             }
@@ -170,7 +170,7 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                     #(#list_write_name_nonepayload => {
                         let res = self.#list_write_ident_nonepayload(ctx);
                         if !res.is_error() {
-                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("service macro encode payload failed: {:?}", e));
+                            let mut data_json = serde_json::to_string(&res.succeed_data).unwrap_or_else(|e| panic!("encode succeed_data of ServiceResponse failed: {:?}", e));
                             if data_json == "null" {
                                 data_json = "".to_owned();
                             }
@@ -179,7 +179,7 @@ pub fn gen_service_code(_: TokenStream, item: TokenStream) -> TokenStream {
                             ServiceResponse::<String>::from_error(res.code, res.error_message.clone())
                         }
                     },)*
-                    _ => panic!("service macro not found method:{:?} of service:{:?}", method, service)
+                    _ => ServiceResponse::<String>::from_error(2, format!("not found method:{:?} of service:{:?}", method, service))
                 }
             }
         }
@@ -293,7 +293,7 @@ fn get_genesis_body(item: &ImplItemMethod) -> proc_macro2::TokenStream {
 
                 quote!{
                     let payload: #payload_ident = serde_json::from_str(&_payload)
-                    .unwrap_or_else(|e| panic!("service macro decode payload failed: {:?}", e));
+                    .unwrap_or_else(|e| panic!("decode genesis payload failed: {:?}", e));
                     self.#method_name(payload)
                 }
         },

--- a/binding-macro/tests/mod.rs
+++ b/binding-macro/tests/mod.rs
@@ -230,9 +230,9 @@ fn test_service() {
 
     let context = get_context(1024 * 1024, "", "test_notfound", &payload_str);
     let read_res = panic::catch_unwind(AssertUnwindSafe(|| test_service.read_(context.clone())));
-    assert_eq!(read_res.is_err(), true);
+    assert_eq!(read_res.unwrap().is_error(), true);
     let write_res = panic::catch_unwind(AssertUnwindSafe(|| test_service.write_(context)));
-    assert_eq!(write_res.is_err(), true);
+    assert_eq!(write_res.unwrap().is_error(), true);
 
     test_service.hook_before_(&mock_executor_params());
     assert_eq!(test_service.hook_before, true);
@@ -312,9 +312,9 @@ fn test_service_none_payload() {
 
     let context = get_context(1024 * 1024, "", "test_notfound", "");
     let read_res = panic::catch_unwind(AssertUnwindSafe(|| test_service.read_(context.clone())));
-    assert_eq!(read_res.is_err(), true);
+    assert_eq!(read_res.unwrap().is_error(), true);
     let write_res = panic::catch_unwind(AssertUnwindSafe(|| test_service.write_(context)));
-    assert_eq!(write_res.is_err(), true);
+    assert_eq!(write_res.unwrap().is_error(), true);
 
     test_service.hook_before_(&mock_executor_params());
     assert_eq!(test_service.hook_before, true);
@@ -381,9 +381,9 @@ fn test_service_none_response() {
 
     let context = get_context(1024 * 1024, "", "test_notfound", "");
     let read_res = panic::catch_unwind(AssertUnwindSafe(|| test_service.read_(context.clone())));
-    assert_eq!(read_res.is_err(), true);
+    assert_eq!(read_res.unwrap().is_error(), true);
     let write_res = panic::catch_unwind(AssertUnwindSafe(|| test_service.write_(context)));
-    assert_eq!(write_res.is_err(), true);
+    assert_eq!(write_res.unwrap().is_error(), true);
 
     test_service.hook_before_(&mock_executor_params());
     assert_eq!(test_service.hook_before, true);

--- a/binding-macro/tests/mod.rs
+++ b/binding-macro/tests/mod.rs
@@ -25,12 +25,12 @@ fn test_read_and_write() {
     impl Tests {
         #[read]
         fn test_read_fn(&self, _ctx: ServiceContext, _s: &str) -> ServiceResponse<String> {
-            ServiceResponse::<String>::from_data("read".to_owned())
+            ServiceResponse::<String>::from_succeed("read".to_owned())
         }
 
         #[write]
         fn test_write_fn(&mut self, _ctx: ServiceContext, _s: &str) -> ServiceResponse<String> {
-            ServiceResponse::<String>::from_data("write".to_owned())
+            ServiceResponse::<String>::from_succeed("write".to_owned())
         }
     }
 
@@ -38,10 +38,13 @@ fn test_read_and_write() {
 
     let mut t = Tests {};
     assert_eq!(
-        t.test_read_fn(context.clone(), "read").data,
+        t.test_read_fn(context.clone(), "read").succeed_data,
         "read".to_owned()
     );
-    assert_eq!(t.test_write_fn(context, "write").data, "write".to_owned());
+    assert_eq!(
+        t.test_write_fn(context, "write").succeed_data,
+        "write".to_owned()
+    );
 }
 
 #[test]
@@ -54,13 +57,13 @@ fn test_hooks() {
         #[hook_after]
         fn hook_after(&mut self, params: &ExecutorParams) -> ServiceResponse<()> {
             self.height = params.height;
-            ServiceResponse::<()>::from_data(())
+            ServiceResponse::<()>::from_succeed(())
         }
 
         #[hook_before]
         fn hook_before(&mut self, params: &ExecutorParams) -> ServiceResponse<()> {
             self.height = params.height;
-            ServiceResponse::<()>::from_data(())
+            ServiceResponse::<()>::from_succeed(())
         }
     }
 
@@ -78,20 +81,20 @@ fn test_read_and_write_with_noneparams() {
     impl Tests {
         #[read]
         fn test_read_fn(&self, _ctx: ServiceContext) -> ServiceResponse<()> {
-            ServiceResponse::<()>::from_data(())
+            ServiceResponse::<()>::from_succeed(())
         }
 
         #[write]
         fn test_write_fn(&mut self, _ctx: ServiceContext) -> ServiceResponse<()> {
-            ServiceResponse::<()>::from_data(())
+            ServiceResponse::<()>::from_succeed(())
         }
     }
 
     let context = get_context(1000, "", "", "");
 
     let mut t = Tests {};
-    assert_eq!(t.test_read_fn(context.clone()).data, ());
-    assert_eq!(t.test_write_fn(context).data, ());
+    assert_eq!(t.test_read_fn(context.clone()).succeed_data, ());
+    assert_eq!(t.test_write_fn(context).succeed_data, ());
 }
 
 #[test]
@@ -101,23 +104,23 @@ fn test_cycles() {
     impl Tests {
         #[cycles(100)]
         fn test_cycles(&self, ctx: ServiceContext) -> ServiceResponse<()> {
-            ServiceResponse::<()>::from_data(())
+            ServiceResponse::<()>::from_succeed(())
         }
 
         #[cycles(500)]
         fn test_cycles2(&self, ctx: ServiceContext) -> ServiceResponse<()> {
-            ServiceResponse::<()>::from_data(())
+            ServiceResponse::<()>::from_succeed(())
         }
     }
 
     #[cycles(200)]
     fn test_sub_cycles_fn1(ctx: ServiceContext) -> ServiceResponse<()> {
-        ServiceResponse::<()>::from_data(())
+        ServiceResponse::<()>::from_succeed(())
     }
 
     #[cycles(200)]
     fn test_sub_cycles_fn2(_foo: u64, ctx: ServiceContext) -> ServiceResponse<()> {
-        ServiceResponse::<()>::from_data(())
+        ServiceResponse::<()>::from_succeed(())
     }
 
     let t = Tests {};
@@ -182,7 +185,7 @@ fn test_service() {
                 message: "read ok".to_owned(),
             };
 
-            ServiceResponse::<TestServiceResponse>::from_data(res)
+            ServiceResponse::<TestServiceResponse>::from_succeed(res)
         }
 
         #[write]
@@ -195,7 +198,7 @@ fn test_service() {
                 message: "write ok".to_owned(),
             };
 
-            ServiceResponse::<TestServiceResponse>::from_data(res)
+            ServiceResponse::<TestServiceResponse>::from_succeed(res)
         }
     }
 
@@ -218,11 +221,11 @@ fn test_service() {
     assert_eq!(test_service.genesis_data, "genesis");
 
     let context = get_context(1024 * 1024, "", "test_write", &payload_str);
-    let write_res = test_service.write_(context).data;
+    let write_res = test_service.write_(context).succeed_data;
     assert_eq!(write_res, r#"{"message":"write ok"}"#);
 
     let context = get_context(1024 * 1024, "", "test_read", &payload_str);
-    let read_res = test_service.read_(context).data;
+    let read_res = test_service.read_(context).succeed_data;
     assert_eq!(read_res, r#"{"message":"read ok"}"#);
 
     let context = get_context(1024 * 1024, "", "test_notfound", &payload_str);
@@ -275,7 +278,7 @@ fn test_service_none_payload() {
                 message: "read ok".to_owned(),
             };
 
-            ServiceResponse::<TestServiceResponse>::from_data(res)
+            ServiceResponse::<TestServiceResponse>::from_succeed(res)
         }
 
         #[write]
@@ -284,7 +287,7 @@ fn test_service_none_payload() {
                 message: "write ok".to_owned(),
             };
 
-            ServiceResponse::<TestServiceResponse>::from_data(res)
+            ServiceResponse::<TestServiceResponse>::from_succeed(res)
         }
     }
 
@@ -300,11 +303,11 @@ fn test_service_none_payload() {
     assert_eq!(test_service.genesis_data, "genesis");
 
     let context = get_context(1024 * 1024, "", "test_write", "");
-    let write_res = test_service.write_(context).data;
+    let write_res = test_service.write_(context).succeed_data;
     assert_eq!(write_res, r#"{"message":"write ok"}"#);
 
     let context = get_context(1024 * 1024, "", "test_read", "");
-    let read_res = test_service.read_(context).data;
+    let read_res = test_service.read_(context).succeed_data;
     assert_eq!(read_res, r#"{"message":"read ok"}"#);
 
     let context = get_context(1024 * 1024, "", "test_notfound", "");
@@ -348,12 +351,12 @@ fn test_service_none_response() {
 
         #[read]
         fn test_read(&self, _ctx: ServiceContext) -> ServiceResponse<()> {
-            ServiceResponse::<()>::from_data(())
+            ServiceResponse::<()>::from_succeed(())
         }
 
         #[write]
         fn test_write(&mut self, _ctx: ServiceContext) -> ServiceResponse<()> {
-            ServiceResponse::<()>::from_data(())
+            ServiceResponse::<()>::from_succeed(())
         }
     }
 
@@ -369,11 +372,11 @@ fn test_service_none_response() {
     assert_eq!(test_service.genesis_data, "genesis");
 
     let context = get_context(1024 * 1024, "", "test_write", "");
-    let write_res = test_service.write_(context).data;
+    let write_res = test_service.write_(context).succeed_data;
     assert_eq!(write_res, "");
 
     let context = get_context(1024 * 1024, "", "test_read", "");
-    let read_res = test_service.read_(context).data;
+    let read_res = test_service.read_(context).succeed_data;
     assert_eq!(read_res, "");
 
     let context = get_context(1024 * 1024, "", "test_notfound", "");

--- a/built-in-services/asset/src/lib.rs
+++ b/built-in-services/asset/src/lib.rs
@@ -56,7 +56,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         if let Some(asset) = self.assets.get(&payload.id) {
             ServiceResponse::<Asset>::from_succeed(asset)
         } else {
-            ServiceResponse::<Asset>::from_error(1, "asset id not existed".to_owned())
+            ServiceResponse::<Asset>::from_error(101, "asset id not existed".to_owned())
         }
     }
 
@@ -69,7 +69,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
     ) -> ServiceResponse<GetBalanceResponse> {
         if !self.assets.contains(&payload.asset_id) {
             return ServiceResponse::<GetBalanceResponse>::from_error(
-                1,
+                101,
                 "asset id not existed".to_owned(),
             );
         }
@@ -100,7 +100,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
     ) -> ServiceResponse<GetAllowanceResponse> {
         if !self.assets.contains(&payload.asset_id) {
             return ServiceResponse::<GetAllowanceResponse>::from_error(
-                1,
+                101,
                 "asset id not existed".to_owned(),
             );
         }
@@ -141,14 +141,14 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let payload_res = serde_json::to_string(&payload);
 
         if let Err(e) = payload_res {
-            return ServiceResponse::<Asset>::from_error(3, format!("{:?}", e));
+            return ServiceResponse::<Asset>::from_error(103, format!("{:?}", e));
         }
         let payload_str = payload_res.unwrap();
 
         let id = Hash::digest(Bytes::from(payload_str + &caller.as_hex()));
 
         if self.assets.contains(&id) {
-            return ServiceResponse::<Asset>::from_error(2, "asset id existed".to_owned());
+            return ServiceResponse::<Asset>::from_error(102, "asset id existed".to_owned());
         }
         let asset = Asset {
             id:     id.clone(),
@@ -170,7 +170,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_res = serde_json::to_string(&asset);
 
         if let Err(e) = event_res {
-            return ServiceResponse::<Asset>::from_error(3, format!("{:?}", e));
+            return ServiceResponse::<Asset>::from_error(103, format!("{:?}", e));
         }
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
@@ -187,11 +187,11 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let to = payload.to;
 
         if !self.assets.contains(&payload.asset_id) {
-            return ServiceResponse::<()>::from_error(1, "asset id not existed".to_owned());
+            return ServiceResponse::<()>::from_error(101, "asset id not existed".to_owned());
         }
 
         if let Err(e) = self._transfer(caller.clone(), to.clone(), asset_id.clone(), value) {
-            return ServiceResponse::<()>::from_error(6, format!("{:?}", e));
+            return ServiceResponse::<()>::from_error(106, format!("{:?}", e));
         };
 
         let event = TransferEvent {
@@ -203,7 +203,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_res = serde_json::to_string(&event);
 
         if let Err(e) = event_res {
-            return ServiceResponse::<()>::from_error(3, format!("{:?}", e));
+            return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
@@ -220,11 +220,11 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let to = payload.to;
 
         if caller == to {
-            return ServiceResponse::<()>::from_error(4, "cann't approve to yourself".to_owned());
+            return ServiceResponse::<()>::from_error(104, "cann't approve to yourself".to_owned());
         }
 
         if !self.assets.contains(&payload.asset_id) {
-            return ServiceResponse::<()>::from_error(1, "asset id not existed".to_owned());
+            return ServiceResponse::<()>::from_error(101, "asset id not existed".to_owned());
         }
 
         let mut caller_asset_balance: AssetBalance = self
@@ -252,7 +252,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_res = serde_json::to_string(&event);
 
         if let Err(e) = event_res {
-            return ServiceResponse::<()>::from_error(3, format!("{:?}", e));
+            return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
@@ -274,7 +274,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let value = payload.value;
 
         if !self.assets.contains(&asset_id) {
-            return ServiceResponse::<()>::from_error(1, "asset id not existed".to_owned());
+            return ServiceResponse::<()>::from_error(101, "asset id not existed".to_owned());
         }
 
         let mut sender_asset_balance: AssetBalance = self
@@ -289,7 +289,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             .entry(caller.clone())
             .or_insert(0);
         if *sender_allowance < value {
-            return ServiceResponse::<()>::from_error(5, "insufficient balance".to_owned());
+            return ServiceResponse::<()>::from_error(105, "insufficient balance".to_owned());
         }
         let after_sender_allowance = *sender_allowance - value;
         sender_asset_balance
@@ -301,7 +301,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             .set_account_value(&sender, asset_id.clone(), sender_asset_balance);
 
         if let Err(e) = self._transfer(sender.clone(), recipient.clone(), asset_id.clone(), value) {
-            return ServiceResponse::<()>::from_error(6, format!("{:?}", e));
+            return ServiceResponse::<()>::from_error(106, format!("{:?}", e));
         };
 
         let event = TransferFromEvent {
@@ -314,7 +314,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_res = serde_json::to_string(&event);
 
         if let Err(e) = event_res {
-            return ServiceResponse::<()>::from_error(3, format!("{:?}", e));
+            return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);

--- a/built-in-services/asset/src/lib.rs
+++ b/built-in-services/asset/src/lib.rs
@@ -5,12 +5,10 @@ pub mod types;
 use std::collections::BTreeMap;
 
 use bytes::Bytes;
-use derive_more::{Display, From};
 
-use binding_macro::{cycles, genesis, service, write};
+use binding_macro::{cycles, genesis, service};
 use protocol::traits::{ExecutorParams, ServiceResponse, ServiceSDK, StoreMap};
 use protocol::types::{Address, Hash, ServiceContext};
-use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 use crate::types::{
     ApproveEvent, ApprovePayload, Asset, AssetBalance, CreateAssetPayload, GetAllowancePayload,
@@ -143,7 +141,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let payload_res = serde_json::to_string(&payload);
 
         if let Err(e) = payload_res {
-            return ServiceResponse::<Asset>::from_error(3, format!("{:?}", e).to_owned());
+            return ServiceResponse::<Asset>::from_error(3, format!("{:?}", e));
         }
         let payload_str = payload_res.unwrap();
 
@@ -172,7 +170,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_res = serde_json::to_string(&asset);
 
         if let Err(e) = event_res {
-            return ServiceResponse::<Asset>::from_error(3, format!("{:?}", e).to_owned());
+            return ServiceResponse::<Asset>::from_error(3, format!("{:?}", e));
         }
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
@@ -193,7 +191,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         }
 
         if let Err(e) = self._transfer(caller.clone(), to.clone(), asset_id.clone(), value) {
-            return ServiceResponse::<()>::from_error(6, format!("{:?}", e).to_owned());
+            return ServiceResponse::<()>::from_error(6, format!("{:?}", e));
         };
 
         let event = TransferEvent {
@@ -205,7 +203,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_res = serde_json::to_string(&event);
 
         if let Err(e) = event_res {
-            return ServiceResponse::<()>::from_error(3, format!("{:?}", e).to_owned());
+            return ServiceResponse::<()>::from_error(3, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
@@ -254,7 +252,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_res = serde_json::to_string(&event);
 
         if let Err(e) = event_res {
-            return ServiceResponse::<()>::from_error(3, format!("{:?}", e).to_owned());
+            return ServiceResponse::<()>::from_error(3, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
@@ -303,7 +301,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             .set_account_value(&sender, asset_id.clone(), sender_asset_balance);
 
         if let Err(e) = self._transfer(sender.clone(), recipient.clone(), asset_id.clone(), value) {
-            return ServiceResponse::<()>::from_error(6, format!("{:?}", e).to_owned());
+            return ServiceResponse::<()>::from_error(6, format!("{:?}", e));
         };
 
         let event = TransferFromEvent {
@@ -316,7 +314,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_res = serde_json::to_string(&event);
 
         if let Err(e) = event_res {
-            return ServiceResponse::<()>::from_error(3, format!("{:?}", e).to_owned());
+            return ServiceResponse::<()>::from_error(3, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
@@ -374,41 +372,5 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             .set_account_value(&sender, asset_id, sender_asset_balance);
 
         Ok(())
-    }
-}
-
-#[derive(Debug, Display, From)]
-pub enum ServiceError {
-    #[display(fmt = "Parsing payload to json failed {:?}", _0)]
-    JsonParse(serde_json::Error),
-
-    #[display(fmt = "Asset {:?} already exists", id)]
-    Exists {
-        id: Hash,
-    },
-
-    #[display(fmt = "Not found asset, id {:?}", id)]
-    NotFoundAsset {
-        id: Hash,
-    },
-
-    #[display(fmt = "Not found asset, expect {:?} real {:?}", expect, real)]
-    LackOfBalance {
-        expect: u64,
-        real:   u64,
-    },
-
-    U64Overflow,
-
-    RecipientIsSender,
-
-    ApproveToYourself,
-}
-
-impl std::error::Error for ServiceError {}
-
-impl From<ServiceError> for ProtocolError {
-    fn from(err: ServiceError) -> ProtocolError {
-        ProtocolError::new(ProtocolErrorKind::Service, Box::new(err))
     }
 }

--- a/built-in-services/asset/src/lib.rs
+++ b/built-in-services/asset/src/lib.rs
@@ -54,7 +54,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
     #[read]
     fn get_asset(&self, ctx: ServiceContext, payload: GetAssetPayload) -> ServiceResponse<Asset> {
         if let Some(asset) = self.assets.get(&payload.id) {
-            ServiceResponse::<Asset>::from_data(asset)
+            ServiceResponse::<Asset>::from_succeed(asset)
         } else {
             ServiceResponse::<Asset>::from_error(1, "asset id not existed".to_owned())
         }
@@ -88,7 +88,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             balance:  asset_balance.value,
         };
 
-        ServiceResponse::<GetBalanceResponse>::from_data(res)
+        ServiceResponse::<GetBalanceResponse>::from_succeed(res)
     }
 
     #[cycles(100_00)]
@@ -118,7 +118,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
                 grantee:  payload.grantee,
                 value:    *allowance,
             };
-            ServiceResponse::<GetAllowanceResponse>::from_data(res)
+            ServiceResponse::<GetAllowanceResponse>::from_succeed(res)
         } else {
             let res = GetAllowanceResponse {
                 asset_id: payload.asset_id,
@@ -126,7 +126,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
                 grantee:  payload.grantee,
                 value:    0,
             };
-            ServiceResponse::<GetAllowanceResponse>::from_data(res)
+            ServiceResponse::<GetAllowanceResponse>::from_succeed(res)
         }
     }
 
@@ -175,7 +175,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
 
-        ServiceResponse::<Asset>::from_data(asset)
+        ServiceResponse::<Asset>::from_succeed(asset)
     }
 
     #[cycles(210_00)]
@@ -208,7 +208,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
 
-        ServiceResponse::<()>::from_data(())
+        ServiceResponse::<()>::from_succeed(())
     }
 
     #[cycles(210_00)]
@@ -257,7 +257,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
 
-        ServiceResponse::<()>::from_data(())
+        ServiceResponse::<()>::from_succeed(())
     }
 
     #[cycles(210_00)]
@@ -319,7 +319,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
         let event_str = event_res.unwrap();
         ctx.emit_event(event_str);
 
-        ServiceResponse::<()>::from_data(())
+        ServiceResponse::<()>::from_succeed(())
     }
 
     fn _transfer(

--- a/built-in-services/asset/src/tests/mod.rs
+++ b/built-in-services/asset/src/tests/mod.rs
@@ -35,13 +35,13 @@ fn test_create_asset() {
             symbol: "test".to_owned(),
             supply,
         })
-        .unwrap();
+        .data;
 
     let new_asset = service
         .get_asset(context.clone(), GetAssetPayload {
             id: asset.id.clone(),
         })
-        .unwrap();
+        .data;
     assert_eq!(asset, new_asset);
 
     let balance_res = service
@@ -49,7 +49,7 @@ fn test_create_asset() {
             asset_id: asset.id.clone(),
             user:     caller,
         })
-        .unwrap();
+        .data;
     assert_eq!(balance_res.balance, supply);
     assert_eq!(balance_res.asset_id, asset.id);
 }
@@ -70,23 +70,21 @@ fn test_transfer() {
             symbol: "test".to_owned(),
             supply,
         })
-        .unwrap();
+        .data;
 
     let to_address = Address::from_hex("0x666cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
-    service
-        .transfer(context.clone(), TransferPayload {
-            asset_id: asset.id.clone(),
-            to:       to_address.clone(),
-            value:    1024,
-        })
-        .unwrap();
+    service.transfer(context.clone(), TransferPayload {
+        asset_id: asset.id.clone(),
+        to:       to_address.clone(),
+        value:    1024,
+    });
 
     let balance_res = service
         .get_balance(context, GetBalancePayload {
             asset_id: asset.id.clone(),
             user:     caller,
         })
-        .unwrap();
+        .data;
     assert_eq!(balance_res.balance, supply - 1024);
 
     let context = mock_context(cycles_limit, to_address.clone());
@@ -95,7 +93,7 @@ fn test_transfer() {
             asset_id: asset.id,
             user:     to_address,
         })
-        .unwrap();
+        .data;
     assert_eq!(balance_res.balance, 1024);
 }
 
@@ -114,16 +112,14 @@ fn test_approve() {
             symbol: "test".to_owned(),
             supply,
         })
-        .unwrap();
+        .data;
 
     let to_address = Address::from_hex("0x666cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
-    service
-        .approve(context.clone(), ApprovePayload {
-            asset_id: asset.id.clone(),
-            to:       to_address.clone(),
-            value:    1024,
-        })
-        .unwrap();
+    service.approve(context.clone(), ApprovePayload {
+        asset_id: asset.id.clone(),
+        to:       to_address.clone(),
+        value:    1024,
+    });
 
     let allowance_res = service
         .get_allowance(context, GetAllowancePayload {
@@ -131,7 +127,7 @@ fn test_approve() {
             grantor:  caller,
             grantee:  to_address.clone(),
         })
-        .unwrap();
+        .data;
     assert_eq!(allowance_res.asset_id, asset.id);
     assert_eq!(allowance_res.grantee, to_address);
     assert_eq!(allowance_res.value, 1024);
@@ -152,27 +148,23 @@ fn test_transfer_from() {
             symbol: "test".to_owned(),
             supply,
         })
-        .unwrap();
+        .data;
 
     let to_address = Address::from_hex("0x666cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
-    service
-        .approve(context.clone(), ApprovePayload {
-            asset_id: asset.id.clone(),
-            to:       to_address.clone(),
-            value:    1024,
-        })
-        .unwrap();
+    service.approve(context.clone(), ApprovePayload {
+        asset_id: asset.id.clone(),
+        to:       to_address.clone(),
+        value:    1024,
+    });
 
     let to_context = mock_context(cycles_limit, to_address.clone());
 
-    service
-        .transfer_from(to_context.clone(), TransferFromPayload {
-            asset_id:  asset.id.clone(),
-            sender:    caller.clone(),
-            recipient: to_address.clone(),
-            value:     24,
-        })
-        .unwrap();
+    service.transfer_from(to_context.clone(), TransferFromPayload {
+        asset_id:  asset.id.clone(),
+        sender:    caller.clone(),
+        recipient: to_address.clone(),
+        value:     24,
+    });
 
     let allowance_res = service
         .get_allowance(context.clone(), GetAllowancePayload {
@@ -180,7 +172,7 @@ fn test_transfer_from() {
             grantor:  caller.clone(),
             grantee:  to_address.clone(),
         })
-        .unwrap();
+        .data;
     assert_eq!(allowance_res.asset_id, asset.id.clone());
     assert_eq!(allowance_res.grantee, to_address.clone());
     assert_eq!(allowance_res.value, 1000);
@@ -190,7 +182,7 @@ fn test_transfer_from() {
             asset_id: asset.id.clone(),
             user:     caller,
         })
-        .unwrap();
+        .data;
     assert_eq!(balance_res.balance, supply - 24);
 
     let balance_res = service
@@ -198,7 +190,7 @@ fn test_transfer_from() {
             asset_id: asset.id,
             user:     to_address,
         })
-        .unwrap();
+        .data;
     assert_eq!(balance_res.balance, 24);
 }
 
@@ -219,7 +211,7 @@ fn new_asset_service() -> AssetService<
         NoopDispatcher {},
     );
 
-    AssetService::new(sdk).unwrap()
+    AssetService::new(sdk)
 }
 
 fn mock_context(cycles_limit: u64, caller: Address) -> ServiceContext {

--- a/built-in-services/asset/src/tests/mod.rs
+++ b/built-in-services/asset/src/tests/mod.rs
@@ -35,13 +35,13 @@ fn test_create_asset() {
             symbol: "test".to_owned(),
             supply,
         })
-        .data;
+        .succeed_data;
 
     let new_asset = service
         .get_asset(context.clone(), GetAssetPayload {
             id: asset.id.clone(),
         })
-        .data;
+        .succeed_data;
     assert_eq!(asset, new_asset);
 
     let balance_res = service
@@ -49,7 +49,7 @@ fn test_create_asset() {
             asset_id: asset.id.clone(),
             user:     caller,
         })
-        .data;
+        .succeed_data;
     assert_eq!(balance_res.balance, supply);
     assert_eq!(balance_res.asset_id, asset.id);
 }
@@ -70,7 +70,7 @@ fn test_transfer() {
             symbol: "test".to_owned(),
             supply,
         })
-        .data;
+        .succeed_data;
 
     let to_address = Address::from_hex("0x666cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
     service.transfer(context.clone(), TransferPayload {
@@ -84,7 +84,7 @@ fn test_transfer() {
             asset_id: asset.id.clone(),
             user:     caller,
         })
-        .data;
+        .succeed_data;
     assert_eq!(balance_res.balance, supply - 1024);
 
     let context = mock_context(cycles_limit, to_address.clone());
@@ -93,7 +93,7 @@ fn test_transfer() {
             asset_id: asset.id,
             user:     to_address,
         })
-        .data;
+        .succeed_data;
     assert_eq!(balance_res.balance, 1024);
 }
 
@@ -112,7 +112,7 @@ fn test_approve() {
             symbol: "test".to_owned(),
             supply,
         })
-        .data;
+        .succeed_data;
 
     let to_address = Address::from_hex("0x666cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
     service.approve(context.clone(), ApprovePayload {
@@ -127,7 +127,7 @@ fn test_approve() {
             grantor:  caller,
             grantee:  to_address.clone(),
         })
-        .data;
+        .succeed_data;
     assert_eq!(allowance_res.asset_id, asset.id);
     assert_eq!(allowance_res.grantee, to_address);
     assert_eq!(allowance_res.value, 1024);
@@ -148,7 +148,7 @@ fn test_transfer_from() {
             symbol: "test".to_owned(),
             supply,
         })
-        .data;
+        .succeed_data;
 
     let to_address = Address::from_hex("0x666cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
     service.approve(context.clone(), ApprovePayload {
@@ -172,7 +172,7 @@ fn test_transfer_from() {
             grantor:  caller.clone(),
             grantee:  to_address.clone(),
         })
-        .data;
+        .succeed_data;
     assert_eq!(allowance_res.asset_id, asset.id.clone());
     assert_eq!(allowance_res.grantee, to_address.clone());
     assert_eq!(allowance_res.value, 1000);
@@ -182,7 +182,7 @@ fn test_transfer_from() {
             asset_id: asset.id.clone(),
             user:     caller,
         })
-        .data;
+        .succeed_data;
     assert_eq!(balance_res.balance, supply - 24);
 
     let balance_res = service
@@ -190,7 +190,7 @@ fn test_transfer_from() {
             asset_id: asset.id,
             user:     to_address,
         })
-        .data;
+        .succeed_data;
     assert_eq!(balance_res.balance, 24);
 }
 

--- a/built-in-services/asset/src/types.rs
+++ b/built-in-services/asset/src/types.rs
@@ -78,7 +78,7 @@ pub struct GetBalancePayload {
     pub user:     Address,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct GetBalanceResponse {
     pub asset_id: Hash,
     pub user:     Address,
@@ -92,7 +92,7 @@ pub struct GetAllowancePayload {
     pub grantee:  Address,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct GetAllowanceResponse {
     pub asset_id: Hash,
     pub grantor:  Address,
@@ -100,7 +100,7 @@ pub struct GetAllowanceResponse {
     pub value:    u64,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
 pub struct Asset {
     pub id:     Hash,
     pub name:   String,

--- a/built-in-services/metadata/src/lib.rs
+++ b/built-in-services/metadata/src/lib.rs
@@ -2,7 +2,7 @@
 mod tests;
 
 use binding_macro::{cycles, genesis, service};
-use protocol::traits::{ExecutorParams, ServiceSDK};
+use protocol::traits::{ExecutorParams, ServiceResponse, ServiceSDK};
 use protocol::types::{Metadata, ServiceContext, METADATA_KEY};
 use protocol::ProtocolResult;
 
@@ -12,22 +12,22 @@ pub struct MetadataService<SDK> {
 
 #[service]
 impl<SDK: ServiceSDK> MetadataService<SDK> {
-    pub fn new(sdk: SDK) -> ProtocolResult<Self> {
-        Ok(Self { sdk })
+    pub fn new(sdk: SDK) -> Self {
+        Self { sdk }
     }
 
     #[genesis]
-    fn init_genesis(&mut self, metadata: Metadata) -> ProtocolResult<()> {
+    fn init_genesis(&mut self, metadata: Metadata) {
         self.sdk.set_value(METADATA_KEY.to_string(), metadata)
     }
 
     #[cycles(210_00)]
     #[read]
-    fn get_metadata(&self, ctx: ServiceContext) -> ProtocolResult<Metadata> {
+    fn get_metadata(&self, ctx: ServiceContext) -> ServiceResponse<Metadata> {
         let metadata: Metadata = self
             .sdk
-            .get_value(&METADATA_KEY.to_owned())?
-            .expect("Metadata should always be in the genesis block");
-        Ok(metadata)
+            .get_value(&METADATA_KEY.to_owned())
+            .expect("metadata should not be none");
+        ServiceResponse::<Metadata>::from_data(metadata)
     }
 }

--- a/built-in-services/metadata/src/lib.rs
+++ b/built-in-services/metadata/src/lib.rs
@@ -4,7 +4,6 @@ mod tests;
 use binding_macro::{cycles, genesis, service};
 use protocol::traits::{ExecutorParams, ServiceResponse, ServiceSDK};
 use protocol::types::{Metadata, ServiceContext, METADATA_KEY};
-use protocol::ProtocolResult;
 
 pub struct MetadataService<SDK> {
     sdk: SDK,

--- a/built-in-services/metadata/src/lib.rs
+++ b/built-in-services/metadata/src/lib.rs
@@ -27,6 +27,6 @@ impl<SDK: ServiceSDK> MetadataService<SDK> {
             .sdk
             .get_value(&METADATA_KEY.to_owned())
             .expect("metadata should not be none");
-        ServiceResponse::<Metadata>::from_data(metadata)
+        ServiceResponse::<Metadata>::from_succeed(metadata)
     }
 }

--- a/built-in-services/metadata/src/tests/mod.rs
+++ b/built-in-services/metadata/src/tests/mod.rs
@@ -25,7 +25,7 @@ fn test_get_metadata() {
     let init_metadata = mock_metadata();
 
     let service = new_metadata_service_with_metadata(init_metadata.clone());
-    let metadata = service.get_metadata(context).unwrap();
+    let metadata = service.get_metadata(context).data;
 
     assert_eq!(metadata, init_metadata);
 }
@@ -49,9 +49,9 @@ fn new_metadata_service_with_metadata(
         NoopDispatcher {},
     );
 
-    sdk.set_value(METADATA_KEY.to_string(), metadata).unwrap();
+    sdk.set_value(METADATA_KEY.to_string(), metadata);
 
-    MetadataService::new(sdk).unwrap()
+    MetadataService::new(sdk)
 }
 
 fn mock_metadata() -> Metadata {

--- a/built-in-services/metadata/src/tests/mod.rs
+++ b/built-in-services/metadata/src/tests/mod.rs
@@ -25,7 +25,7 @@ fn test_get_metadata() {
     let init_metadata = mock_metadata();
 
     let service = new_metadata_service_with_metadata(init_metadata.clone());
-    let metadata = service.get_metadata(context).data;
+    let metadata = service.get_metadata(context).succeed_data;
 
     assert_eq!(metadata, init_metadata);
 }

--- a/core/api/src/adapter/mod.rs
+++ b/core/api/src/adapter/mod.rs
@@ -6,7 +6,7 @@ use derive_more::Display;
 use async_trait::async_trait;
 use protocol::traits::ExecutorFactory;
 use protocol::traits::{
-    APIAdapter, Context, ExecResp, ExecutorParams, MemPool, ServiceMapping, Storage,
+    APIAdapter, Context, ExecutorParams, MemPool, ServiceMapping, ServiceResponse, Storage,
 };
 use protocol::types::{Address, Block, Hash, Receipt, SignedTransaction, TransactionRequest};
 use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
@@ -124,7 +124,7 @@ impl<
         service_name: String,
         method: String,
         payload: String,
-    ) -> ProtocolResult<ExecResp> {
+    ) -> ProtocolResult<ServiceResponse<String>> {
         let block = self.get_block_by_height(ctx.clone(), Some(height)).await?;
 
         let executor = EF::from_root(

--- a/core/api/src/lib.rs
+++ b/core/api/src/lib.rs
@@ -19,8 +19,8 @@ use protocol::traits::{APIAdapter, Context};
 
 use crate::config::GraphQLConfig;
 use crate::schema::{
-    to_signed_transaction, to_transaction, Address, Block, Bytes, ExecResp, Hash,
-    InputRawTransaction, InputTransactionEncryption, Receipt, SignedTransaction, Uint64,
+    to_signed_transaction, to_transaction, Address, Block, Bytes, Hash, InputRawTransaction,
+    InputTransactionEncryption, Receipt, ServiceResponse, SignedTransaction, Uint64,
 };
 
 lazy_static! {
@@ -94,7 +94,7 @@ impl Query {
         service_name: String,
         method: String,
         payload: String,
-    ) -> FieldResult<ExecResp> {
+    ) -> FieldResult<ServiceResponse> {
         let height = match height {
             Some(id) => id.try_into_u64()?,
             None => {
@@ -128,7 +128,7 @@ impl Query {
                 payload,
             )
             .await?;
-        Ok(ExecResp::from(exec_resp))
+        Ok(ServiceResponse::from(exec_resp))
     }
 }
 

--- a/core/api/src/schema/mod.rs
+++ b/core/api/src/schema/mod.rs
@@ -17,16 +17,18 @@ pub use transaction::{
 };
 
 #[derive(juniper::GraphQLObject, Clone)]
-pub struct ExecResp {
-    ret:      String,
-    is_error: bool,
+pub struct ServiceResponse {
+    pub code:  Uint64,
+    pub data:  String,
+    pub error: String,
 }
 
-impl From<protocol::traits::ExecResp> for ExecResp {
-    fn from(resp: protocol::traits::ExecResp) -> Self {
+impl From<protocol::traits::ServiceResponse<String>> for ServiceResponse {
+    fn from(resp: protocol::traits::ServiceResponse<String>) -> Self {
         Self {
-            ret:      resp.ret,
-            is_error: resp.is_error,
+            code:  Uint64::from(resp.code),
+            data:  resp.data,
+            error: resp.error,
         }
     }
 }

--- a/core/api/src/schema/mod.rs
+++ b/core/api/src/schema/mod.rs
@@ -18,17 +18,17 @@ pub use transaction::{
 
 #[derive(juniper::GraphQLObject, Clone)]
 pub struct ServiceResponse {
-    pub code:  Uint64,
-    pub data:  String,
-    pub error: String,
+    pub code:          Uint64,
+    pub succeed_data:  String,
+    pub error_message: String,
 }
 
 impl From<protocol::traits::ServiceResponse<String>> for ServiceResponse {
     fn from(resp: protocol::traits::ServiceResponse<String>) -> Self {
         Self {
-            code:  Uint64::from(resp.code),
-            data:  resp.data,
-            error: resp.error,
+            code:          Uint64::from(resp.code),
+            succeed_data:  resp.succeed_data,
+            error_message: resp.error_message,
         }
     }
 }

--- a/core/api/src/schema/receipt.rs
+++ b/core/api/src/schema/receipt.rs
@@ -1,4 +1,4 @@
-use crate::schema::{Hash, MerkleRoot, Uint64};
+use crate::schema::{Hash, MerkleRoot, ServiceResponse, Uint64};
 
 #[derive(juniper::GraphQLObject, Clone)]
 pub struct Receipt {
@@ -20,8 +20,7 @@ pub struct Event {
 pub struct ReceiptResponse {
     pub service_name: String,
     pub method:       String,
-    pub ret:          String,
-    pub is_error:     bool,
+    pub response:     ServiceResponse,
 }
 
 impl From<protocol::types::Receipt> for Receipt {
@@ -51,8 +50,7 @@ impl From<protocol::types::ReceiptResponse> for ReceiptResponse {
         Self {
             service_name: response.service_name,
             method:       response.method,
-            ret:          response.ret,
-            is_error:     response.is_error,
+            response:     ServiceResponse::from(response.response),
         }
     }
 }

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -383,7 +383,7 @@ where
             payload:      "".to_string(),
         })?;
 
-        Ok(serde_json::from_str(&exec_resp.data).expect("Decode metadata failed!"))
+        Ok(serde_json::from_str(&exec_resp.succeed_data).expect("Decode metadata failed!"))
     }
 
     fn set_args(&self, _context: Context, timeout_gap: u64, cycles_limit: u64, max_tx_size: u64) {

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -383,7 +383,7 @@ where
             payload:      "".to_string(),
         })?;
 
-        Ok(serde_json::from_str(&exec_resp.ret).expect("Decode metadata failed!"))
+        Ok(serde_json::from_str(&exec_resp.data).expect("Decode metadata failed!"))
     }
 
     fn set_args(&self, _context: Context, timeout_gap: u64, cycles_limit: u64, max_tx_size: u64) {

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -433,9 +433,9 @@ fn get_receipt(tx: &SignedTransaction, height: u64) -> Receipt {
             service_name: "sync".to_owned(),
             method:       "sync_exec".to_owned(),
             response:     ServiceResponse::<String> {
-                code:  0,
-                data:  "ok".to_owned(),
-                error: "".to_owned(),
+                code:          0,
+                succeed_data:  "ok".to_owned(),
+                error_message: "".to_owned(),
             },
         },
     }

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -9,7 +9,7 @@ use parking_lot::RwLock;
 use common_merkle::Merkle;
 use protocol::fixed_codec::FixedCodec;
 use protocol::traits::{CommonConsensusAdapter, Synchronization, SynchronizationAdapter};
-use protocol::traits::{Context, ExecutorParams, ExecutorResp};
+use protocol::traits::{Context, ExecutorParams, ExecutorResp, ServiceResponse};
 use protocol::types::{
     Address, Block, BlockHeader, Bytes, Hash, Hex, MerkleRoot, Metadata, Proof, RawTransaction,
     Receipt, ReceiptResponse, SignedTransaction, TransactionRequest, Validator, ValidatorExtend,
@@ -432,8 +432,11 @@ fn get_receipt(tx: &SignedTransaction, height: u64) -> Receipt {
         response: ReceiptResponse {
             service_name: "sync".to_owned(),
             method:       "sync_exec".to_owned(),
-            ret:          "".to_owned(),
-            is_error:     false,
+            response:     ServiceResponse::<String> {
+                code:  0,
+                data:  "ok".to_owned(),
+                error: "".to_owned(),
+            },
         },
     }
 }

--- a/core/storage/src/tests/mod.rs
+++ b/core/storage/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod storage;
 
 use rand::random;
 
+use protocol::traits::ServiceResponse;
 use protocol::types::{
     Address, Block, BlockHeader, Hash, Proof, RawTransaction, Receipt, ReceiptResponse,
     SignedTransaction, TransactionRequest,
@@ -49,8 +50,11 @@ fn mock_receipt(tx_hash: Hash) -> Receipt {
     let response = ReceiptResponse {
         service_name: "test".to_owned(),
         method:       "test".to_owned(),
-        ret:          "test".to_owned(),
-        is_error:     false,
+        response:     ServiceResponse::<String> {
+            code:  0,
+            data:  "ok".to_owned(),
+            error: "".to_owned(),
+        },
     };
     Receipt {
         state_root: nonce,

--- a/core/storage/src/tests/mod.rs
+++ b/core/storage/src/tests/mod.rs
@@ -51,9 +51,9 @@ fn mock_receipt(tx_hash: Hash) -> Receipt {
         service_name: "test".to_owned(),
         method:       "test".to_owned(),
         response:     ServiceResponse::<String> {
-            code:  0,
-            data:  "ok".to_owned(),
-            error: "".to_owned(),
+            code:          0,
+            succeed_data:  "ok".to_owned(),
+            error_message: "".to_owned(),
         },
     };
     Receipt {

--- a/examples/muta-chain.rs
+++ b/examples/muta-chain.rs
@@ -14,8 +14,8 @@ impl ServiceMapping for DefaultServiceMapping {
         sdk: SDK,
     ) -> ProtocolResult<Box<dyn Service>> {
         let service = match name {
-            "asset" => Box::new(AssetService::new(sdk)?) as Box<dyn Service>,
-            "metadata" => Box::new(MetadataService::new(sdk)?) as Box<dyn Service>,
+            "asset" => Box::new(AssetService::new(sdk)) as Box<dyn Service>,
+            "metadata" => Box::new(MetadataService::new(sdk)) as Box<dyn Service>,
             _ => {
                 return Err(MappingError::NotFoundService {
                     service: name.to_owned(),

--- a/framework/src/binding/sdk/mod.rs
+++ b/framework/src/binding/sdk/mod.rs
@@ -10,8 +10,8 @@ use derive_more::{Display, From};
 
 use protocol::fixed_codec::FixedCodec;
 use protocol::traits::{
-    ChainQuerier, Dispatcher, ServiceSDK, ServiceState, StoreArray, StoreBool, StoreMap,
-    StoreString, StoreUint64,
+    ChainQuerier, Dispatcher, ServiceResponse, ServiceSDK, ServiceState, StoreArray, StoreBool,
+    StoreMap, StoreString, StoreUint64,
 };
 use protocol::types::{Address, Block, Hash, Receipt, ServiceContext, SignedTransaction};
 use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
@@ -43,63 +43,53 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
     fn alloc_or_recover_map<K: 'static + FixedCodec + PartialEq, V: 'static + FixedCodec>(
         &mut self,
         var_name: &str,
-    ) -> ProtocolResult<Box<dyn StoreMap<K, V>>> {
-        Ok(Box::new(DefaultStoreMap::<S, K, V>::new(
+    ) -> Box<dyn StoreMap<K, V>> {
+        Box::new(DefaultStoreMap::<S, K, V>::new(
             Rc::clone(&self.state),
             var_name,
-        )))
+        ))
     }
 
     // Alloc or recover a `Array` by` var_name`
     fn alloc_or_recover_array<E: 'static + FixedCodec>(
         &mut self,
         var_name: &str,
-    ) -> ProtocolResult<Box<dyn StoreArray<E>>> {
-        Ok(Box::new(DefaultStoreArray::<S, E>::new(
+    ) -> Box<dyn StoreArray<E>> {
+        Box::new(DefaultStoreArray::<S, E>::new(
             Rc::clone(&self.state),
             var_name,
-        )))
+        ))
     }
 
     // Alloc or recover a `Uint64` by` var_name`
-    fn alloc_or_recover_uint64(&mut self, var_name: &str) -> ProtocolResult<Box<dyn StoreUint64>> {
-        Ok(Box::new(DefaultStoreUint64::new(
-            Rc::clone(&self.state),
-            var_name,
-        )))
+    fn alloc_or_recover_uint64(&mut self, var_name: &str) -> Box<dyn StoreUint64> {
+        Box::new(DefaultStoreUint64::new(Rc::clone(&self.state), var_name))
     }
 
     // Alloc or recover a `String` by` var_name`
-    fn alloc_or_recover_string(&mut self, var_name: &str) -> ProtocolResult<Box<dyn StoreString>> {
-        Ok(Box::new(DefaultStoreString::new(
-            Rc::clone(&self.state),
-            var_name,
-        )))
+    fn alloc_or_recover_string(&mut self, var_name: &str) -> Box<dyn StoreString> {
+        Box::new(DefaultStoreString::new(Rc::clone(&self.state), var_name))
     }
 
     // Alloc or recover a `Bool` by` var_name`
-    fn alloc_or_recover_bool(&mut self, var_name: &str) -> ProtocolResult<Box<dyn StoreBool>> {
-        Ok(Box::new(DefaultStoreBool::new(
-            Rc::clone(&self.state),
-            var_name,
-        )))
+    fn alloc_or_recover_bool(&mut self, var_name: &str) -> Box<dyn StoreBool> {
+        Box::new(DefaultStoreBool::new(Rc::clone(&self.state), var_name))
     }
 
     // Get a value from the service state by key
-    fn get_value<Key: FixedCodec, Ret: FixedCodec>(
-        &self,
-        key: &Key,
-    ) -> ProtocolResult<Option<Ret>> {
-        self.state.borrow().get(key)
+    fn get_value<Key: FixedCodec, Ret: FixedCodec>(&self, key: &Key) -> Option<Ret> {
+        self.state
+            .borrow()
+            .get(key)
+            .unwrap_or_else(|e| panic!("service sdk get value failed: {}", e))
     }
 
     // Set a value to the service state by key
-    fn set_value<Key: FixedCodec, Val: FixedCodec>(
-        &mut self,
-        key: Key,
-        val: Val,
-    ) -> ProtocolResult<()> {
-        self.state.borrow_mut().insert(key, val)
+    fn set_value<Key: FixedCodec, Val: FixedCodec>(&mut self, key: Key, val: Val) {
+        self.state
+            .borrow_mut()
+            .insert(key, val)
+            .unwrap_or_else(|e| panic!("service sdk set value failed: {}", e));
     }
 
     // Get a value from the specified address by key
@@ -107,8 +97,11 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
         &self,
         address: &Address,
         key: &Key,
-    ) -> ProtocolResult<Option<Ret>> {
-        self.state.borrow().get_account_value(address, key)
+    ) -> Option<Ret> {
+        self.state
+            .borrow()
+            .get_account_value(address, key)
+            .unwrap_or_else(|e| panic!("service sdk get account value failed: {}", e))
     }
 
     // Insert a pair of key / value to the specified address
@@ -117,27 +110,36 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
         address: &Address,
         key: Key,
         val: Val,
-    ) -> ProtocolResult<()> {
-        self.state.borrow_mut().set_account_value(address, key, val)
+    ) {
+        self.state
+            .borrow_mut()
+            .set_account_value(address, key, val)
+            .unwrap_or_else(|e| panic!("service sdk set account value failed: {}", e));
     }
 
     // Get a signed transaction by `tx_hash`
     // if not found on the chain, return None
-    fn get_transaction_by_hash(&self, tx_hash: &Hash) -> ProtocolResult<Option<SignedTransaction>> {
-        self.chain_querier.get_transaction_by_hash(tx_hash)
+    fn get_transaction_by_hash(&self, tx_hash: &Hash) -> Option<SignedTransaction> {
+        self.chain_querier
+            .get_transaction_by_hash(tx_hash)
+            .unwrap_or_else(|e| panic!("service sdk get transaction by hash failed: {}", e))
     }
 
     // Get a block by `height`
     // if not found on the chain, return None
     // When the parameter `height` is None, get the latest (executing)` block`
-    fn get_block_by_height(&self, height: Option<u64>) -> ProtocolResult<Option<Block>> {
-        self.chain_querier.get_block_by_height(height)
+    fn get_block_by_height(&self, height: Option<u64>) -> Option<Block> {
+        self.chain_querier
+            .get_block_by_height(height)
+            .unwrap_or_else(|e| panic!("service sdk get block by height failed: {}", e))
     }
 
     // Get a receipt by `tx_hash`
     // if not found on the chain, return None
-    fn get_receipt_by_hash(&self, tx_hash: &Hash) -> ProtocolResult<Option<Receipt>> {
-        self.chain_querier.get_receipt_by_hash(tx_hash)
+    fn get_receipt_by_hash(&self, tx_hash: &Hash) -> Option<Receipt> {
+        self.chain_querier
+            .get_receipt_by_hash(tx_hash)
+            .unwrap_or_else(|e| panic!("service sdk get receipt by hash failed: {}", e))
     }
 
     // Call other read-only methods of `service` and return the results
@@ -150,7 +152,7 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
         service: &str,
         method: &str,
         payload: &str,
-    ) -> ProtocolResult<String> {
+    ) -> ServiceResponse<String> {
         let ctx = ServiceContext::with_context(
             ctx,
             extra,
@@ -159,12 +161,7 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
             payload.to_string(),
         );
 
-        let result = self.dispatcher.read(ctx)?;
-        if result.is_error {
-            Err(SDKError::DispatchFailed { error: result.ret }.into())
-        } else {
-            Ok(result.ret)
-        }
+        self.dispatcher.read(ctx)
     }
 
     // Call other writable methods of `service` and return the results synchronously
@@ -176,7 +173,7 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
         service: &str,
         method: &str,
         payload: &str,
-    ) -> ProtocolResult<String> {
+    ) -> ServiceResponse<String> {
         let ctx = ServiceContext::with_context(
             ctx,
             extra,
@@ -185,12 +182,7 @@ impl<S: 'static + ServiceState, C: ChainQuerier, D: Dispatcher> ServiceSDK
             payload.to_string(),
         );
 
-        let result = self.dispatcher.write(ctx)?;
-        if result.is_error {
-            Err(SDKError::DispatchFailed { error: result.ret }.into())
-        } else {
-            Ok(result.ret)
-        }
+        self.dispatcher.write(ctx)
     }
 }
 

--- a/framework/src/binding/sdk/mod.rs
+++ b/framework/src/binding/sdk/mod.rs
@@ -14,7 +14,7 @@ use protocol::traits::{
     StoreMap, StoreString, StoreUint64,
 };
 use protocol::types::{Address, Block, Hash, Receipt, ServiceContext, SignedTransaction};
-use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
+use protocol::{ProtocolError, ProtocolErrorKind};
 
 use crate::binding::store::{
     DefaultStoreArray, DefaultStoreBool, DefaultStoreMap, DefaultStoreString, DefaultStoreUint64,

--- a/framework/src/binding/store/map.rs
+++ b/framework/src/binding/store/map.rs
@@ -94,7 +94,7 @@ impl<S: 'static + ServiceState, K: 'static + FixedCodec + PartialEq, V: 'static 
 
             self.state
                 .borrow_mut()
-                .insert(self.get_map_key(key)?, Bytes::new());
+                .insert(self.get_map_key(key)?, Bytes::new())?;
 
             Ok(Some(value))
         } else {

--- a/framework/src/binding/store/primitive.rs
+++ b/framework/src/binding/store/primitive.rs
@@ -21,18 +21,28 @@ impl<S: ServiceState> DefaultStoreBool<S> {
             key: Hash::digest(Bytes::from(var_name.to_owned() + "bool")),
         }
     }
-}
 
-impl<S: ServiceState> StoreBool for DefaultStoreBool<S> {
-    fn get(&self) -> ProtocolResult<bool> {
+    fn get_(&self) -> ProtocolResult<bool> {
         let b: Option<bool> = self.state.borrow().get(&self.key)?;
 
         b.ok_or_else(|| StoreError::GetNone.into())
     }
 
-    fn set(&mut self, b: bool) -> ProtocolResult<()> {
+    fn set_(&mut self, b: bool) -> ProtocolResult<()> {
         self.state.borrow_mut().insert(self.key.clone(), b)?;
         Ok(())
+    }
+}
+
+impl<S: ServiceState> StoreBool for DefaultStoreBool<S> {
+    fn get(&self) -> bool {
+        self.get_()
+            .unwrap_or_else(|e| panic!("StoreBool get failed: {}", e))
+    }
+
+    fn set(&mut self, b: bool) {
+        self.set_(b)
+            .unwrap_or_else(|e| panic!("StoreBool set failed: {}", e));
     }
 }
 
@@ -48,38 +58,36 @@ impl<S: ServiceState> DefaultStoreUint64<S> {
             key: Hash::digest(Bytes::from(var_name.to_owned() + "uint64")),
         }
     }
-}
 
-impl<S: ServiceState> StoreUint64 for DefaultStoreUint64<S> {
-    fn get(&self) -> ProtocolResult<u64> {
+    fn get_(&self) -> ProtocolResult<u64> {
         let u: Option<u64> = self.state.borrow().get(&self.key)?;
 
         u.ok_or_else(|| StoreError::GetNone.into())
     }
 
-    fn set(&mut self, val: u64) -> ProtocolResult<()> {
+    fn set_(&mut self, val: u64) -> ProtocolResult<()> {
         self.state.borrow_mut().insert(self.key.clone(), val)?;
         Ok(())
     }
 
     // Add val with self
     // And set the result back to self
-    fn add(&mut self, val: u64) -> ProtocolResult<()> {
-        let sv = self.get()?;
+    fn add_(&mut self, val: u64) -> ProtocolResult<()> {
+        let sv = self.get_()?;
 
         match val.overflowing_add(sv) {
-            (sum, false) => self.set(sum),
+            (sum, false) => self.set_(sum),
             _ => Err(StoreError::Overflow.into()),
         }
     }
 
     // Self minus val
     // And set the result back to self
-    fn sub(&mut self, val: u64) -> ProtocolResult<()> {
-        let sv = self.get()?;
+    fn sub_(&mut self, val: u64) -> ProtocolResult<()> {
+        let sv = self.get_()?;
 
         if sv >= val {
-            self.set(sv - val)
+            self.set_(sv - val)
         } else {
             Err(StoreError::Overflow.into())
         }
@@ -87,48 +95,102 @@ impl<S: ServiceState> StoreUint64 for DefaultStoreUint64<S> {
 
     // Multiply val with self
     // And set the result back to self
-    fn mul(&mut self, val: u64) -> ProtocolResult<()> {
-        let sv = self.get()?;
+    fn mul_(&mut self, val: u64) -> ProtocolResult<()> {
+        let sv = self.get_()?;
 
         match val.overflowing_mul(sv) {
-            (mul, false) => self.set(mul),
+            (mul, false) => self.set_(mul),
             _ => Err(StoreError::Overflow.into()),
         }
     }
 
     // Power of self
     // And set the result back to self
-    fn pow(&mut self, val: u32) -> ProtocolResult<()> {
-        let sv = self.get()?;
+    fn pow_(&mut self, val: u32) -> ProtocolResult<()> {
+        let sv = self.get_()?;
 
         match sv.overflowing_pow(val) {
-            (pow, false) => self.set(pow),
+            (pow, false) => self.set_(pow),
             _ => Err(StoreError::Overflow.into()),
         }
     }
 
     // Self divided by val
     // And set the result back to self
-    fn div(&mut self, val: u64) -> ProtocolResult<()> {
-        let sv = self.get()?;
+    fn div_(&mut self, val: u64) -> ProtocolResult<()> {
+        let sv = self.get_()?;
 
         if let 0 = val {
             Err(StoreError::Overflow.into())
         } else {
-            self.set(sv / val)
+            self.set_(sv / val)
         }
     }
 
     // Remainder of self
     // And set the result back to self
-    fn rem(&mut self, val: u64) -> ProtocolResult<()> {
-        let sv = self.get()?;
+    fn rem_(&mut self, val: u64) -> ProtocolResult<()> {
+        let sv = self.get_()?;
 
         if let 0 = val {
             Err(StoreError::Overflow.into())
         } else {
-            self.set(sv % val)
+            self.set_(sv % val)
         }
+    }
+}
+
+impl<S: ServiceState> StoreUint64 for DefaultStoreUint64<S> {
+    fn get(&self) -> u64 {
+        self.get_()
+            .unwrap_or_else(|e| panic!("StoreUint64 get failed: {}", e))
+    }
+
+    fn set(&mut self, val: u64) {
+        self.set_(val)
+            .unwrap_or_else(|e| panic!("StoreUint64 set failed: {}", e));
+    }
+
+    // Add val with self
+    // And set the result back to self
+    fn add(&mut self, val: u64) {
+        self.add_(val)
+            .unwrap_or_else(|e| panic!("StoreUint64 add value failed: {}", e));
+    }
+
+    // Self minus val
+    // And set the result back to self
+    fn sub(&mut self, val: u64) {
+        self.sub_(val)
+            .unwrap_or_else(|e| panic!("StoreUint64 sub value failed: {}", e));
+    }
+
+    // Multiply val with self
+    // And set the result back to self
+    fn mul(&mut self, val: u64) {
+        self.mul_(val)
+            .unwrap_or_else(|e| panic!("StoreUint64 mul value failed: {}", e));
+    }
+
+    // Power of self
+    // And set the result back to self
+    fn pow(&mut self, val: u32) {
+        self.pow_(val)
+            .unwrap_or_else(|e| panic!("StoreUint64 pow value failed: {}", e));
+    }
+
+    // Self divided by val
+    // And set the result back to self
+    fn div(&mut self, val: u64) {
+        self.div_(val)
+            .unwrap_or_else(|e| panic!("StoreUint64 div value failed: {}", e));
+    }
+
+    // Remainder of self
+    // And set the result back to self
+    fn rem(&mut self, val: u64) {
+        self.rem_(val)
+            .unwrap_or_else(|e| panic!("StoreUint64 rem value failed: {}", e));
     }
 }
 
@@ -144,27 +206,47 @@ impl<S: ServiceState> DefaultStoreString<S> {
             key: Hash::digest(Bytes::from(var_name.to_owned() + "string")),
         }
     }
-}
 
-impl<S: ServiceState> StoreString for DefaultStoreString<S> {
-    fn set(&mut self, val: &str) -> ProtocolResult<()> {
+    fn set_(&mut self, val: &str) -> ProtocolResult<()> {
         self.state
             .borrow_mut()
             .insert(self.key.clone(), val.to_string())?;
         Ok(())
     }
 
-    fn get(&self) -> ProtocolResult<String> {
+    fn get_(&self) -> ProtocolResult<String> {
         let s: Option<String> = self.state.borrow().get(&self.key)?;
 
         s.ok_or_else(|| StoreError::GetNone.into())
     }
 
-    fn len(&self) -> ProtocolResult<u32> {
-        self.get().map(|s| s.len() as u32)
+    fn len_(&self) -> ProtocolResult<u32> {
+        self.get_().map(|s| s.len() as u32)
     }
 
-    fn is_empty(&self) -> ProtocolResult<bool> {
-        self.get().map(|s| s.is_empty())
+    fn is_empty_(&self) -> ProtocolResult<bool> {
+        self.get_().map(|s| s.is_empty())
+    }
+}
+
+impl<S: ServiceState> StoreString for DefaultStoreString<S> {
+    fn get(&self) -> String {
+        self.get_()
+            .unwrap_or_else(|e| panic!("StoreString get failed: {}", e))
+    }
+
+    fn set(&mut self, val: &str) {
+        self.set_(val)
+            .unwrap_or_else(|e| panic!("StoreString set failed: {}", e));
+    }
+
+    fn len(&self) -> u32 {
+        self.len_()
+            .unwrap_or_else(|e| panic!("StoreString get length failed: {}", e))
+    }
+
+    fn is_empty(&self) -> bool {
+        self.is_empty_()
+            .unwrap_or_else(|e| panic!("StoreString get is_empty failed: {}", e))
     }
 }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -230,9 +230,9 @@ pub fn mock_receipt_response() -> ReceiptResponse {
         service_name: "mock-service".to_owned(),
         method:       "mock-method".to_owned(),
         response:     ServiceResponse::<String> {
-            code:  0,
-            data:  "ok".to_owned(),
-            error: "".to_owned(),
+            code:          0,
+            succeed_data:  "ok".to_owned(),
+            error_message: "".to_owned(),
         },
     }
 }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use cita_trie::MemoryDB;
 
-use protocol::traits::{NoopDispatcher, ServiceSDK, Storage};
+use protocol::traits::{NoopDispatcher, ServiceResponse, ServiceSDK, Storage};
 use protocol::types::{
     Address, Block, BlockHeader, Event, Hash, MerkleRoot, Proof, RawTransaction, Receipt,
     ReceiptResponse, SignedTransaction, TransactionRequest, Validator,
@@ -29,27 +29,25 @@ fn test_service_sdk() {
     let mut sdk = DefalutServiceSDK::new(Rc::clone(&rs), Rc::new(cq), NoopDispatcher {});
 
     // test sdk store bool
-    let mut sdk_bool = sdk.alloc_or_recover_bool("test_bool").unwrap();
-    sdk_bool.set(true).unwrap();
-    assert_eq!(sdk_bool.get().unwrap(), true);
+    let mut sdk_bool = sdk.alloc_or_recover_bool("test_bool");
+    sdk_bool.set(true);
+    assert_eq!(sdk_bool.get(), true);
 
     // test sdk store string
-    let mut sdk_string = sdk.alloc_or_recover_string("test_string").unwrap();
-    sdk_string.set("hello").unwrap();
-    assert_eq!(sdk_string.get().unwrap(), "hello".to_owned());
+    let mut sdk_string = sdk.alloc_or_recover_string("test_string");
+    sdk_string.set("hello");
+    assert_eq!(sdk_string.get(), "hello".to_owned());
 
     // test sdk store uint64
-    let mut sdk_uint64 = sdk.alloc_or_recover_uint64("test_uint64").unwrap();
-    sdk_uint64.set(99).unwrap();
-    assert_eq!(sdk_uint64.get().unwrap(), 99);
+    let mut sdk_uint64 = sdk.alloc_or_recover_uint64("test_uint64");
+    sdk_uint64.set(99);
+    assert_eq!(sdk_uint64.get(), 99);
 
     // test sdk map
-    let mut sdk_map = sdk.alloc_or_recover_map::<Hash, Bytes>("test_map").unwrap();
-    assert_eq!(sdk_map.is_empty().unwrap(), true);
+    let mut sdk_map = sdk.alloc_or_recover_map::<Hash, Bytes>("test_map");
+    assert_eq!(sdk_map.is_empty(), true);
 
-    sdk_map
-        .insert(Hash::digest(Bytes::from("key_1")), Bytes::from("val_1"))
-        .unwrap();
+    sdk_map.insert(Hash::digest(Bytes::from("key_1")), Bytes::from("val_1"));
 
     assert_eq!(
         sdk_map.get(&Hash::digest(Bytes::from("key_1"))).unwrap(),
@@ -64,48 +62,41 @@ fn test_service_sdk() {
     assert_eq!(it.next().is_none(), true);
 
     // test sdk array
-    let mut sdk_array = sdk.alloc_or_recover_array::<Hash>("test_array").unwrap();
-    assert_eq!(sdk_array.is_empty().unwrap(), true);
+    let mut sdk_array = sdk.alloc_or_recover_array::<Hash>("test_array");
+    assert_eq!(sdk_array.is_empty(), true);
 
-    sdk_array.push(Hash::digest(Bytes::from("key_1"))).unwrap();
+    sdk_array.push(Hash::digest(Bytes::from("key_1")));
 
-    assert_eq!(
-        sdk_array.get(0).unwrap(),
-        Hash::digest(Bytes::from("key_1"))
-    );
+    assert_eq!(sdk_array.get(0), Hash::digest(Bytes::from("key_1")));
 
     let mut it = sdk_array.iter();
     assert_eq!(it.next().unwrap(), (0, Hash::digest(Bytes::from("key_1"))));
     assert_eq!(it.next().is_none(), true);
 
     // test get/set account value
-    sdk.set_account_value(&mock_address(), Bytes::from("ak"), Bytes::from("av"))
-        .unwrap();
+    sdk.set_account_value(&mock_address(), Bytes::from("ak"), Bytes::from("av"));
     let account_value: Bytes = sdk
         .get_account_value(&mock_address(), &Bytes::from("ak"))
-        .unwrap()
         .unwrap();
     assert_eq!(Bytes::from("av"), account_value);
 
     // test get/set value
-    sdk.set_value(Bytes::from("ak"), Bytes::from("av")).unwrap();
-    let value: Bytes = sdk.get_value(&Bytes::from("ak")).unwrap().unwrap();
+    sdk.set_value(Bytes::from("ak"), Bytes::from("av"));
+    let value: Bytes = sdk.get_value(&Bytes::from("ak")).unwrap();
     assert_eq!(Bytes::from("av"), value);
 
     // test query chain
     let tx_data = sdk
         .get_transaction_by_hash(&Hash::digest(Bytes::from("param")))
-        .unwrap()
         .unwrap();
     assert_eq!(mock_signed_tx(), tx_data);
 
     let receipt_data = sdk
         .get_receipt_by_hash(&Hash::digest(Bytes::from("param")))
-        .unwrap()
         .unwrap();
     assert_eq!(mock_receipt(), receipt_data);
 
-    let block_data = sdk.get_block_by_height(Some(1)).unwrap().unwrap();
+    let block_data = sdk.get_block_by_height(Some(1)).unwrap();
     assert_eq!(mock_block(1), block_data);
 }
 
@@ -238,8 +229,11 @@ pub fn mock_receipt_response() -> ReceiptResponse {
     ReceiptResponse {
         service_name: "mock-service".to_owned(),
         method:       "mock-method".to_owned(),
-        ret:          "mock-ret".to_owned(),
-        is_error:     false,
+        response:     ServiceResponse::<String> {
+            code:  0,
+            data:  "ok".to_owned(),
+            error: "".to_owned(),
+        },
     }
 }
 

--- a/framework/src/binding/tests/store.rs
+++ b/framework/src/binding/tests/store.rs
@@ -20,10 +20,10 @@ fn test_default_store_bool() {
 
     let mut sb = DefaultStoreBool::new(Rc::new(RefCell::new(state)), "test");
 
-    sb.set(true).unwrap();
-    assert_eq!(sb.get().unwrap(), true);
-    sb.set(false).unwrap();
-    assert_eq!(sb.get().unwrap(), false);
+    sb.set(true);
+    assert_eq!(sb.get(), true);
+    sb.set(false);
+    assert_eq!(sb.get(), false);
 }
 
 #[test]
@@ -33,26 +33,26 @@ fn test_default_store_uint64() {
 
     let mut su = DefaultStoreUint64::new(Rc::new(RefCell::new(state)), "test");
 
-    su.set(8u64).unwrap();
-    assert_eq!(su.get().unwrap(), 8u64);
+    su.set(8u64);
+    assert_eq!(su.get(), 8u64);
 
-    su.add(12u64).unwrap();
-    assert_eq!(su.get().unwrap(), 20u64);
+    su.add(12u64);
+    assert_eq!(su.get(), 20u64);
 
-    su.sub(10u64).unwrap();
-    assert_eq!(su.get().unwrap(), 10u64);
+    su.sub(10u64);
+    assert_eq!(su.get(), 10u64);
 
-    su.mul(8u64).unwrap();
-    assert_eq!(su.get().unwrap(), 80u64);
+    su.mul(8u64);
+    assert_eq!(su.get(), 80u64);
 
-    su.div(10u64).unwrap();
-    assert_eq!(su.get().unwrap(), 8u64);
+    su.div(10u64);
+    assert_eq!(su.get(), 8u64);
 
-    su.pow(2u32).unwrap();
-    assert_eq!(su.get().unwrap(), 64u64);
+    su.pow(2u32);
+    assert_eq!(su.get(), 64u64);
 
-    su.rem(5u64).unwrap();
-    assert_eq!(su.get().unwrap(), 4u64);
+    su.rem(5u64);
+    assert_eq!(su.get(), 4u64);
 }
 
 #[test]
@@ -63,13 +63,13 @@ fn test_default_store_string() {
     let rs = Rc::new(RefCell::new(state));
     let mut ss = DefaultStoreString::new(Rc::clone(&rs), "test");
 
-    ss.set("").unwrap();
-    assert_eq!(ss.get().unwrap(), "");
-    assert_eq!(ss.is_empty().unwrap(), true);
+    ss.set("");
+    assert_eq!(ss.get(), "");
+    assert_eq!(ss.is_empty(), true);
 
-    ss.set("ok").unwrap();
-    assert_eq!(ss.get().unwrap(), String::from("ok"));
-    assert_eq!(ss.len().unwrap(), 2u32);
+    ss.set("ok");
+    assert_eq!(ss.get(), String::from("ok"));
+    assert_eq!(ss.len(), 2u32);
 }
 
 #[test]
@@ -80,10 +80,8 @@ fn test_default_store_map() {
 
     let mut sm = DefaultStoreMap::<_, Hash, Bytes>::new(Rc::clone(&rs), "test");
 
-    sm.insert(Hash::digest(Bytes::from("key_1")), Bytes::from("val_1"))
-        .unwrap();
-    sm.insert(Hash::digest(Bytes::from("key_2")), Bytes::from("val_2"))
-        .unwrap();
+    sm.insert(Hash::digest(Bytes::from("key_1")), Bytes::from("val_1"));
+    sm.insert(Hash::digest(Bytes::from("key_2")), Bytes::from("val_2"));
 
     {
         let mut it = sm.iter();
@@ -109,11 +107,8 @@ fn test_default_store_map() {
 
     sm.remove(&Hash::digest(Bytes::from("key_1"))).unwrap();
 
-    assert_eq!(
-        sm.contains(&Hash::digest(Bytes::from("key_1"))).unwrap(),
-        false
-    );
-    assert_eq!(sm.len().unwrap(), 1u32)
+    assert_eq!(sm.contains(&Hash::digest(Bytes::from("key_1"))), false);
+    assert_eq!(sm.len(), 1u32)
 }
 
 #[test]
@@ -124,10 +119,10 @@ fn test_default_store_array() {
 
     let mut sa = DefaultStoreArray::<_, Bytes>::new(Rc::clone(&rs), "test");
 
-    assert_eq!(sa.len().unwrap(), 0u32);
+    assert_eq!(sa.len(), 0u32);
 
-    sa.push(Bytes::from("111")).unwrap();
-    sa.push(Bytes::from("222")).unwrap();
+    sa.push(Bytes::from("111"));
+    sa.push(Bytes::from("222"));
 
     {
         let mut it = sa.iter();
@@ -136,11 +131,11 @@ fn test_default_store_array() {
         assert_eq!(it.next().is_none(), true);
     }
 
-    assert_eq!(sa.get(0u32).unwrap(), Bytes::from("111"));
-    assert_eq!(sa.get(1u32).unwrap(), Bytes::from("222"));
+    assert_eq!(sa.get(0u32), Bytes::from("111"));
+    assert_eq!(sa.get(1u32), Bytes::from("222"));
 
-    sa.remove(0u32).unwrap();
+    sa.remove(0u32);
 
-    assert_eq!(sa.len().unwrap(), 1u32);
-    assert_eq!(sa.get(0u32).unwrap(), Bytes::from("222"));
+    assert_eq!(sa.len(), 1u32);
+    assert_eq!(sa.get(0u32), Bytes::from("222"));
 }

--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -87,9 +87,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
             panic::catch_unwind(AssertUnwindSafe(|| {
                 service.genesis_(params.payload.clone())
             }))
-            .map_err(|e| {
-                ProtocolError::from(ExecutorError::InitService(format!("{:?}", e).to_owned()))
-            })?;
+            .map_err(|e| ProtocolError::from(ExecutorError::InitService(format!("{:?}", e))))?;
 
             state.borrow_mut().stash()?;
         }
@@ -255,7 +253,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
                         continue;
                     } else {
                         log::error!("inner chain error occurred when calling service: {:?}", e);
-                        let s = format!("{:?}", e).to_owned();
+                        let s = format!("{:?}", e);
                         return Err(ExecutorError::CallService(s).into());
                     }
                 }
@@ -403,9 +401,8 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
             params,
             request,
         )?;
-        panic::catch_unwind(AssertUnwindSafe(|| self.call(context, ExecType::Read))).map_err(|e| {
-            ProtocolError::from(ExecutorError::QueryService(format!("{:?}", e).to_owned()))
-        })
+        panic::catch_unwind(AssertUnwindSafe(|| self.call(context, ExecType::Read)))
+            .map_err(|e| ProtocolError::from(ExecutorError::QueryService(format!("{:?}", e))))
     }
 }
 

--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -6,6 +6,7 @@ pub use factory::ServiceExecutorFactory;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::panic::{self, AssertUnwindSafe};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -14,8 +15,8 @@ use derive_more::{Display, From};
 
 use bytes::BytesMut;
 use protocol::traits::{
-    Dispatcher, ExecResp, Executor, ExecutorParams, ExecutorResp, NoopDispatcher, ServiceMapping,
-    ServiceState, Storage,
+    Dispatcher, Executor, ExecutorParams, ExecutorResp, NoopDispatcher, ServiceMapping,
+    ServiceResponse, ServiceState, Storage,
 };
 use protocol::types::{
     Address, Bloom, BloomInput, Hash, MerkleRoot, Receipt, ReceiptResponse, ServiceContext,
@@ -31,6 +32,7 @@ enum HookType {
     After,
 }
 
+#[derive(Clone)]
 enum ExecType {
     Read,
     Write,
@@ -82,7 +84,12 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
                 DefalutServiceSDK::new(Rc::clone(state), Rc::clone(&querier), NoopDispatcher {});
 
             let mut service = mapping.get_service(&params.name, sdk)?;
-            service.genesis_(params.payload.clone())?;
+            panic::catch_unwind(AssertUnwindSafe(|| {
+                service.genesis_(params.payload.clone())
+            }))
+            .map_err(|e| {
+                ProtocolError::from(ExecutorError::InitService(format!("{:?}", e).to_owned()))
+            })?;
 
             state.borrow_mut().stash()?;
         }
@@ -156,8 +163,12 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
             let mut service = self.service_mapping.get_service(name.as_str(), sdk)?;
 
             let hook_ret = match hook {
-                HookType::Before => service.hook_before_(exec_params),
-                HookType::After => service.hook_after_(exec_params),
+                HookType::Before => {
+                    panic::catch_unwind(AssertUnwindSafe(|| service.hook_before_(exec_params)))
+                }
+                HookType::After => {
+                    panic::catch_unwind(AssertUnwindSafe(|| service.hook_after_(exec_params)))
+                }
             };
 
             if hook_ret.is_err() {
@@ -217,17 +228,38 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
         Ok(ServiceContext::new(ctx_params))
     }
 
-    fn catch_call(&self, context: ServiceContext, exec_type: ExecType) -> ExecResp {
-        let res = match exec_type {
-            ExecType::Read => self.call(context, exec_type),
-            ExecType::Write => self.call_with_tx_hooks(context, exec_type),
-        };
-        match res {
-            Ok(resp) => resp,
-            Err(e) => ExecResp {
-                ret:      e.to_string(),
-                is_error: true,
-            },
+    fn catch_call(
+        &mut self,
+        context: ServiceContext,
+        exec_type: ExecType,
+    ) -> ProtocolResult<ServiceResponse<String>> {
+        let mut retry_count = 0;
+        loop {
+            retry_count += 1;
+            let result = match exec_type {
+                ExecType::Read => panic::catch_unwind(AssertUnwindSafe(|| {
+                    self.call(context.clone(), exec_type.clone())
+                })),
+                ExecType::Write => panic::catch_unwind(AssertUnwindSafe(|| {
+                    self.call_with_tx_hooks(context.clone(), exec_type.clone())
+                })),
+            };
+            match result {
+                Ok(r) => {
+                    self.stash()?;
+                    return Ok(r);
+                }
+                Err(e) => {
+                    self.revert_cache()?;
+                    if retry_count < 2 {
+                        continue;
+                    } else {
+                        log::error!("inner chain error occurred when calling service: {:?}", e);
+                        let s = format!("{:?}", e).to_owned();
+                        return Err(ExecutorError::CallService(s).into());
+                    }
+                }
+            }
         }
     }
 
@@ -235,44 +267,47 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
         &self,
         context: ServiceContext,
         exec_type: ExecType,
-    ) -> ProtocolResult<ExecResp> {
+    ) -> ServiceResponse<String> {
         let mut tx_hook_services = vec![];
         for name in self.service_mapping.list_service_name().into_iter() {
-            let sdk = self.get_sdk(&name)?;
-            let tx_hook_service = self.service_mapping.get_service(name.as_str(), sdk)?;
+            let sdk = self
+                .get_sdk(&name)
+                .unwrap_or_else(|e| panic!("get target service sdk failed: {}", e));
+            let tx_hook_service = self
+                .service_mapping
+                .get_service(name.as_str(), sdk)
+                .unwrap_or_else(|e| panic!("get target service sdk failed: {}", e));
             tx_hook_services.push(tx_hook_service);
         }
+        // TODO: If tx_hook_before_ failed, we should not exec the tx.
+        // Need a mechanism for this.
         for tx_hook_service in tx_hook_services.iter_mut() {
-            tx_hook_service.tx_hook_before_(context.clone())?;
+            tx_hook_service.tx_hook_before_(context.clone());
         }
         let original_res = self.call(context.clone(), exec_type);
         // TODO: If the tx fails, status tx_hook_after_ changes will also be reverted.
         // It may not be what the developer want.
         // Need a new mechanism for this.
         for tx_hook_service in tx_hook_services.iter_mut() {
-            tx_hook_service.tx_hook_after_(context.clone())?;
+            tx_hook_service.tx_hook_after_(context.clone());
         }
         original_res
     }
 
-    fn call(&self, context: ServiceContext, exec_type: ExecType) -> ProtocolResult<ExecResp> {
-        let sdk = self.get_sdk(context.get_service_name())?;
+    fn call(&self, context: ServiceContext, exec_type: ExecType) -> ServiceResponse<String> {
+        let sdk = self
+            .get_sdk(context.get_service_name())
+            .unwrap_or_else(|e| panic!("get target service sdk failed: {}", e));
 
         let mut service = self
             .service_mapping
-            .get_service(context.get_service_name(), sdk)?;
+            .get_service(context.get_service_name(), sdk)
+            .unwrap_or_else(|e| panic!("get target service failed: {}", e));
 
-        let result = match exec_type {
+        match exec_type {
             ExecType::Read => service.read_(context),
             ExecType::Write => service.write_(context),
-        };
-
-        let (ret, is_error) = match result {
-            Ok(ret) => (ret, false),
-            Err(e) => (e.to_string(), true),
-        };
-
-        Ok(ExecResp { ret, is_error })
+        }
     }
 
     fn logs_bloom(&self, receipts: &[Receipt]) -> Bloom {
@@ -316,13 +351,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
                     &stx.raw.request,
                 )?;
 
-                let exec_resp = self.catch_call(context.clone(), ExecType::Write);
-
-                if exec_resp.is_error {
-                    self.revert_cache()?;
-                } else {
-                    self.stash()?;
-                };
+                let exec_resp = self.catch_call(context.clone(), ExecType::Write)?;
 
                 Ok(Receipt {
                     state_root:  MerkleRoot::from_empty(),
@@ -333,8 +362,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
                     response:    ReceiptResponse {
                         service_name: context.get_service_name().to_owned(),
                         method:       context.get_service_method().to_owned(),
-                        ret:          exec_resp.ret,
-                        is_error:     exec_resp.is_error,
+                        response:     exec_resp,
                     },
                 })
             })
@@ -365,7 +393,7 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
         caller: &Address,
         cycles_price: u64,
         request: &TransactionRequest,
-    ) -> ProtocolResult<ExecResp> {
+    ) -> ProtocolResult<ServiceResponse<String>> {
         let context = self.get_context(
             None,
             None,
@@ -375,18 +403,20 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
             params,
             request,
         )?;
-        self.call(context, ExecType::Read)
+        panic::catch_unwind(AssertUnwindSafe(|| self.call(context, ExecType::Read))).map_err(|e| {
+            ProtocolError::from(ExecutorError::QueryService(format!("{:?}", e).to_owned()))
+        })
     }
 }
 
 impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMapping> Dispatcher
     for ServiceExecutor<S, DB, Mapping>
 {
-    fn read(&self, context: ServiceContext) -> ProtocolResult<ExecResp> {
+    fn read(&self, context: ServiceContext) -> ServiceResponse<String> {
         self.call(context, ExecType::Read)
     }
 
-    fn write(&self, context: ServiceContext) -> ProtocolResult<ExecResp> {
+    fn write(&self, context: ServiceContext) -> ServiceResponse<String> {
         self.call(context, ExecType::Write)
     }
 }
@@ -395,13 +425,19 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
 pub enum ExecutorError {
     #[display(fmt = "service {:?} was not found", service)]
     NotFoundService { service: String },
-
     #[display(fmt = "service {:?} method {:?} was not found", service, method)]
     NotFoundMethod { service: String, method: String },
-
     #[display(fmt = "Parsing payload to json failed {:?}", _0)]
     JsonParse(serde_json::Error),
+
+    #[display(fmt = "Init service genesis failed: {:?}", _0)]
+    InitService(String),
+    #[display(fmt = "Query service failed: {:?}", _0)]
+    QueryService(String),
+    #[display(fmt = "Call service failed: {:?}", _0)]
+    CallService(String),
 }
+
 impl std::error::Error for ExecutorError {}
 
 impl From<ExecutorError> for ProtocolError {

--- a/framework/src/executor/tests/mod.rs
+++ b/framework/src/executor/tests/mod.rs
@@ -60,7 +60,7 @@ fn test_create_genesis() {
                 .to_owned(),
     };
     let res = executor.read(&params, &caller, 1, &request).unwrap();
-    let resp: GetBalanceResponse = serde_json::from_str(&res.ret).unwrap();
+    let resp: GetBalanceResponse = serde_json::from_str(&res.data).unwrap();
 
     assert_eq!(resp.balance, 320_000_011);
 }
@@ -100,8 +100,8 @@ fn test_exec() {
     let executor_resp = executor.exec(&params, &txs).unwrap();
     let receipt = &executor_resp.receipts[0];
 
-    assert_eq!(receipt.response.is_error, false);
-    let asset: Asset = serde_json::from_str(&receipt.response.ret).unwrap();
+    assert_eq!(receipt.response.response.code, 0);
+    let asset: Asset = serde_json::from_str(&receipt.response.response.data).unwrap();
     assert_eq!(asset.name, "MutaToken2");
     assert_eq!(asset.symbol, "MT2");
     assert_eq!(asset.supply, 320_000_011);
@@ -150,7 +150,7 @@ fn test_tx_hook() {
     let txs = vec![stx.clone()];
     let executor_resp = executor.exec(&params, &txs).unwrap();
     let receipt = &executor_resp.receipts[0];
-    assert_eq!(receipt.response.is_error, false);
+    assert_eq!(receipt.response.response.code, 0);
     assert_eq!(receipt.events.len(), 0);
 
     // tx hook
@@ -163,7 +163,7 @@ fn test_tx_hook() {
     let txs = vec![stx.clone()];
     let executor_resp = executor.exec(&params, &txs).unwrap();
     let receipt = &executor_resp.receipts[0];
-    assert_eq!(receipt.response.is_error, false);
+    assert_eq!(receipt.response.response.code, 0);
     assert_eq!(receipt.events.len(), 2);
     assert_eq!(&receipt.events[0].data, "test_tx_hook_before invoked");
     assert_eq!(&receipt.events[1].data, "test_tx_hook_after invoked");
@@ -179,7 +179,7 @@ fn test_tx_hook() {
     let txs = vec![stx];
     let executor_resp = executor.exec(&params, &txs).unwrap();
     let receipt = &executor_resp.receipts[0];
-    assert_eq!(receipt.response.is_error, false);
+    assert_eq!(receipt.response.response.code, 0);
     assert_eq!(receipt.events.len(), 2);
     assert_eq!(&receipt.events[0].data, "test_tx_hook_before invoked");
     assert_eq!(&receipt.events[1].data, "test_tx_hook_after invoked");
@@ -257,9 +257,9 @@ impl ServiceMapping for MockServiceMapping {
         sdk: SDK,
     ) -> ProtocolResult<Box<dyn Service>> {
         let service = match name {
-            "asset" => Box::new(AssetService::new(sdk)?) as Box<dyn Service>,
-            "metadata" => Box::new(MetadataService::new(sdk)?) as Box<dyn Service>,
-            "test" => Box::new(TestService::new(sdk)?) as Box<dyn Service>,
+            "asset" => Box::new(AssetService::new(sdk)) as Box<dyn Service>,
+            "metadata" => Box::new(MetadataService::new(sdk)) as Box<dyn Service>,
+            "test" => Box::new(TestService::new(sdk)) as Box<dyn Service>,
             _ => panic!("not found service"),
         };
 

--- a/framework/src/executor/tests/mod.rs
+++ b/framework/src/executor/tests/mod.rs
@@ -60,7 +60,7 @@ fn test_create_genesis() {
                 .to_owned(),
     };
     let res = executor.read(&params, &caller, 1, &request).unwrap();
-    let resp: GetBalanceResponse = serde_json::from_str(&res.data).unwrap();
+    let resp: GetBalanceResponse = serde_json::from_str(&res.succeed_data).unwrap();
 
     assert_eq!(resp.balance, 320_000_011);
 }
@@ -101,7 +101,7 @@ fn test_exec() {
     let receipt = &executor_resp.receipts[0];
 
     assert_eq!(receipt.response.response.code, 0);
-    let asset: Asset = serde_json::from_str(&receipt.response.response.data).unwrap();
+    let asset: Asset = serde_json::from_str(&receipt.response.response.succeed_data).unwrap();
     assert_eq!(asset.name, "MutaToken2");
     assert_eq!(asset.symbol, "MT2");
     assert_eq!(asset.supply, 320_000_011);

--- a/framework/src/executor/tests/service_call_service.rs
+++ b/framework/src/executor/tests/service_call_service.rs
@@ -85,7 +85,7 @@ fn test_service_call_service() {
     );
 
     assert_eq!(receipt.response.response.code, 0);
-    let asset: Asset = serde_json::from_str(&receipt.response.response.data).unwrap();
+    let asset: Asset = serde_json::from_str(&receipt.response.response.succeed_data).unwrap();
     assert_eq!(asset.name, "TestCallAsset");
     assert_eq!(asset.symbol, "TCA");
     assert_eq!(asset.supply, 320_000_011);
@@ -114,10 +114,10 @@ impl<SDK: ServiceSDK> MockService<SDK> {
             .sdk
             .write(&ctx, None, "asset", "create_asset", &payload_str);
 
-        let asset: Asset = serde_json::from_str(&ret.data).unwrap();
+        let asset: Asset = serde_json::from_str(&ret.succeed_data).unwrap();
 
         ctx.emit_event("call create asset succeed".to_owned());
-        ServiceResponse::<Asset>::from_data(asset)
+        ServiceResponse::<Asset>::from_succeed(asset)
     }
 }
 

--- a/framework/src/executor/tests/test_service.rs
+++ b/framework/src/executor/tests/test_service.rs
@@ -43,7 +43,7 @@ impl<SDK: ServiceSDK> TestService<SDK> {
     ) -> ServiceResponse<TestReadResponse> {
         let value: String = self.sdk.get_value(&payload.key).unwrap_or_default();
         let res = TestReadResponse { value };
-        ServiceResponse::<TestReadResponse>::from_data(res)
+        ServiceResponse::<TestReadResponse>::from_succeed(res)
     }
 
     #[cycles(210_00)]
@@ -54,7 +54,7 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         payload: TestWritePayload,
     ) -> ServiceResponse<TestWriteResponse> {
         self.sdk.set_value(payload.key, payload.value);
-        ServiceResponse::<TestWriteResponse>::from_data(TestWriteResponse {})
+        ServiceResponse::<TestWriteResponse>::from_succeed(TestWriteResponse {})
     }
 
     #[cycles(210_00)]
@@ -67,7 +67,7 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         let payload_str = serde_json::to_string(&payload).unwrap();
         self.sdk
             .write(&ctx, None, "test", "test_write", &payload_str);
-        ServiceResponse::<TestWriteResponse>::from_data(TestWriteResponse {})
+        ServiceResponse::<TestWriteResponse>::from_succeed(TestWriteResponse {})
     }
 
     #[tx_hook_before]

--- a/framework/src/executor/tests/test_service.rs
+++ b/framework/src/executor/tests/test_service.rs
@@ -1,10 +1,8 @@
-use derive_more::{Display, From};
 use serde::{Deserialize, Serialize};
 
 use binding_macro::{cycles, service, tx_hook_after, tx_hook_before};
-use protocol::traits::{ExecutorParams, ServiceSDK};
+use protocol::traits::{ExecutorParams, ServiceResponse, ServiceSDK};
 use protocol::types::ServiceContext;
-use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 pub struct TestService<SDK> {
     sdk: SDK,
@@ -15,7 +13,7 @@ pub struct TestReadPayload {
     pub key: String,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct TestReadResponse {
     pub value: String,
 }
@@ -27,13 +25,13 @@ pub struct TestWritePayload {
     pub extra: String,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct TestWriteResponse {}
 
 #[service]
 impl<SDK: ServiceSDK> TestService<SDK> {
-    pub fn new(sdk: SDK) -> ProtocolResult<Self> {
-        Ok(Self { sdk })
+    pub fn new(sdk: SDK) -> Self {
+        Self { sdk }
     }
 
     #[cycles(100_00)]
@@ -42,9 +40,10 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         &self,
         ctx: ServiceContext,
         payload: TestReadPayload,
-    ) -> ProtocolResult<TestReadResponse> {
-        let value: String = self.sdk.get_value(&payload.key)?.unwrap_or_default();
-        Ok(TestReadResponse { value })
+    ) -> ServiceResponse<TestReadResponse> {
+        let value: String = self.sdk.get_value(&payload.key).unwrap_or_default();
+        let res = TestReadResponse { value };
+        ServiceResponse::<TestReadResponse>::from_data(res)
     }
 
     #[cycles(210_00)]
@@ -53,9 +52,9 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         &mut self,
         ctx: ServiceContext,
         payload: TestWritePayload,
-    ) -> ProtocolResult<TestWriteResponse> {
-        self.sdk.set_value(payload.key, payload.value)?;
-        Ok(TestWriteResponse {})
+    ) -> ServiceResponse<TestWriteResponse> {
+        self.sdk.set_value(payload.key, payload.value);
+        ServiceResponse::<TestWriteResponse>::from_data(TestWriteResponse {})
     }
 
     #[cycles(210_00)]
@@ -64,41 +63,28 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         &mut self,
         ctx: ServiceContext,
         payload: TestWritePayload,
-    ) -> ProtocolResult<TestWriteResponse> {
+    ) -> ServiceResponse<TestWriteResponse> {
         let payload_str = serde_json::to_string(&payload).unwrap();
         self.sdk
-            .write(&ctx, None, "test", "test_write", &payload_str)?;
-        Ok(TestWriteResponse {})
+            .write(&ctx, None, "test", "test_write", &payload_str);
+        ServiceResponse::<TestWriteResponse>::from_data(TestWriteResponse {})
     }
 
     #[tx_hook_before]
-    fn test_tx_hook_before(&mut self, ctx: ServiceContext) -> ProtocolResult<()> {
+    fn test_tx_hook_before(&mut self, ctx: ServiceContext) {
         if ctx.get_service_name() == "test"
             && ctx.get_payload().to_owned().contains("test_hook_before")
         {
-            ctx.emit_event("test_tx_hook_before invoked".to_owned())?;
+            ctx.emit_event("test_tx_hook_before invoked".to_owned());
         }
-        Ok(())
     }
 
     #[tx_hook_after]
-    fn test_tx_hook_after(&mut self, ctx: ServiceContext) -> ProtocolResult<()> {
+    fn test_tx_hook_after(&mut self, ctx: ServiceContext) {
         if ctx.get_service_name() == "test"
             && ctx.get_payload().to_owned().contains("test_hook_after")
         {
-            ctx.emit_event("test_tx_hook_after invoked".to_owned())?;
+            ctx.emit_event("test_tx_hook_after invoked".to_owned());
         }
-        Ok(())
-    }
-}
-
-#[derive(Debug, Display, From)]
-pub enum ServiceError {}
-
-impl std::error::Error for ServiceError {}
-
-impl From<ServiceError> for ProtocolError {
-    fn from(err: ServiceError) -> ProtocolError {
-        ProtocolError::new(ProtocolErrorKind::Service, Box::new(err))
     }
 }

--- a/protocol/src/codec/receipt.rs
+++ b/protocol/src/codec/receipt.rs
@@ -49,10 +49,10 @@ pub struct ReceiptResponse {
     pub code: u64,
 
     #[prost(bytes, tag = "4")]
-    pub data: Vec<u8>,
+    pub succeed_data: Vec<u8>,
 
     #[prost(bytes, tag = "5")]
-    pub error: Vec<u8>,
+    pub error_message: Vec<u8>,
 }
 
 #[derive(Clone, Message)]
@@ -73,11 +73,11 @@ pub struct Event {
 impl From<receipt::ReceiptResponse> for ReceiptResponse {
     fn from(response: receipt::ReceiptResponse) -> ReceiptResponse {
         ReceiptResponse {
-            service_name: response.service_name.as_bytes().to_vec(),
-            method:       response.method.as_bytes().to_vec(),
-            code:         response.response.code,
-            data:         response.response.data.as_bytes().to_vec(),
-            error:        response.response.error.as_bytes().to_vec(),
+            service_name:  response.service_name.as_bytes().to_vec(),
+            method:        response.method.as_bytes().to_vec(),
+            code:          response.response.code,
+            succeed_data:  response.response.succeed_data.as_bytes().to_vec(),
+            error_message: response.response.error_message.as_bytes().to_vec(),
         }
     }
 }
@@ -91,9 +91,11 @@ impl TryFrom<ReceiptResponse> for receipt::ReceiptResponse {
                 .map_err(CodecError::FromStringUtf8)?,
             method:       String::from_utf8(response.method).map_err(CodecError::FromStringUtf8)?,
             response:     ServiceResponse {
-                code:  response.code,
-                data:  String::from_utf8(response.data).map_err(CodecError::FromStringUtf8)?,
-                error: String::from_utf8(response.error).map_err(CodecError::FromStringUtf8)?,
+                code:          response.code,
+                succeed_data:  String::from_utf8(response.succeed_data)
+                    .map_err(CodecError::FromStringUtf8)?,
+                error_message: String::from_utf8(response.error_message)
+                    .map_err(CodecError::FromStringUtf8)?,
             },
         })
     }

--- a/protocol/src/codec/receipt.rs
+++ b/protocol/src/codec/receipt.rs
@@ -6,6 +6,7 @@ use prost::Message;
 use crate::{
     codec::{primitive::Hash, CodecError, ProtocolCodecSync},
     field, impl_default_bytes_codec_for,
+    traits::ServiceResponse,
     types::primitive as protocol_primitive,
     types::receipt as protocol_receipt,
     ProtocolError, ProtocolResult,
@@ -44,11 +45,14 @@ pub struct ReceiptResponse {
     #[prost(bytes, tag = "2")]
     pub method: Vec<u8>,
 
-    #[prost(bytes, tag = "3")]
-    pub ret: Vec<u8>,
+    #[prost(uint64, tag = "3")]
+    pub code: u64,
 
-    #[prost(bool, tag = "4")]
-    pub is_error: bool,
+    #[prost(bytes, tag = "4")]
+    pub data: Vec<u8>,
+
+    #[prost(bytes, tag = "5")]
+    pub error: Vec<u8>,
 }
 
 #[derive(Clone, Message)]
@@ -71,8 +75,9 @@ impl From<receipt::ReceiptResponse> for ReceiptResponse {
         ReceiptResponse {
             service_name: response.service_name.as_bytes().to_vec(),
             method:       response.method.as_bytes().to_vec(),
-            ret:          response.ret.as_bytes().to_vec(),
-            is_error:     response.is_error,
+            code:         response.response.code,
+            data:         response.response.data.as_bytes().to_vec(),
+            error:        response.response.error.as_bytes().to_vec(),
         }
     }
 }
@@ -85,8 +90,11 @@ impl TryFrom<ReceiptResponse> for receipt::ReceiptResponse {
             service_name: String::from_utf8(response.service_name)
                 .map_err(CodecError::FromStringUtf8)?,
             method:       String::from_utf8(response.method).map_err(CodecError::FromStringUtf8)?,
-            ret:          String::from_utf8(response.ret).map_err(CodecError::FromStringUtf8)?,
-            is_error:     response.is_error,
+            response:     ServiceResponse {
+                code:  response.code,
+                data:  String::from_utf8(response.data).map_err(CodecError::FromStringUtf8)?,
+                error: String::from_utf8(response.error).map_err(CodecError::FromStringUtf8)?,
+            },
         })
     }
 }

--- a/protocol/src/fixed_codec/receipt.rs
+++ b/protocol/src/fixed_codec/receipt.rs
@@ -48,8 +48,8 @@ impl rlp::Encodable for ReceiptResponse {
     fn rlp_append(&self, s: &mut rlp::RlpStream) {
         s.begin_list(5)
             .append(&self.response.code)
-            .append(&self.response.data)
-            .append(&self.response.error)
+            .append(&self.response.succeed_data)
+            .append(&self.response.error_message)
             .append(&self.method)
             .append(&self.service_name);
     }
@@ -62,15 +62,19 @@ impl rlp::Decodable for ReceiptResponse {
         }
 
         let code = r.at(0)?.as_val()?;
-        let data = r.at(1)?.as_val()?;
-        let error = r.at(2)?.as_val()?;
+        let succeed_data = r.at(1)?.as_val()?;
+        let error_message = r.at(2)?.as_val()?;
         let method = r.at(3)?.as_val()?;
         let service_name = r.at(4)?.as_val()?;
 
         Ok(ReceiptResponse {
             service_name,
             method,
-            response: ServiceResponse { code, data, error },
+            response: ServiceResponse {
+                code,
+                succeed_data,
+                error_message,
+            },
         })
     }
 }

--- a/protocol/src/fixed_codec/tests/mod.rs
+++ b/protocol/src/fixed_codec/tests/mod.rs
@@ -40,9 +40,9 @@ pub fn mock_receipt_response() -> ReceiptResponse {
         service_name: "mock-service".to_owned(),
         method:       "mock-method".to_owned(),
         response:     ServiceResponse::<String> {
-            code:  0,
-            data:  "ok".to_owned(),
-            error: "".to_owned(),
+            code:          0,
+            succeed_data:  "ok".to_owned(),
+            error_message: "".to_owned(),
         },
     }
 }

--- a/protocol/src/fixed_codec/tests/mod.rs
+++ b/protocol/src/fixed_codec/tests/mod.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use num_traits::FromPrimitive;
 use rand::random;
 
+use crate::traits::ServiceResponse;
 use crate::types::block::{Block, BlockHeader, Pill, Proof, Validator};
 use crate::types::primitive::{Address, Balance, Hash, MerkleRoot};
 use crate::types::receipt::{Event, Receipt, ReceiptResponse};
@@ -38,8 +39,11 @@ pub fn mock_receipt_response() -> ReceiptResponse {
     ReceiptResponse {
         service_name: "mock-service".to_owned(),
         method:       "mock-method".to_owned(),
-        ret:          "mock-ret".to_owned(),
-        is_error:     false,
+        response:     ServiceResponse::<String> {
+            code:  0,
+            data:  "ok".to_owned(),
+            error: "".to_owned(),
+        },
     }
 }
 

--- a/protocol/src/traits/api.rs
+++ b/protocol/src/traits/api.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::traits::{Context, ExecResp};
+use crate::traits::{Context, ServiceResponse};
 use crate::types::{Address, Block, Hash, Receipt, SignedTransaction};
 use crate::ProtocolResult;
 
@@ -33,5 +33,5 @@ pub trait APIAdapter: Send + Sync {
         service_name: String,
         method: String,
         payload: String,
-    ) -> ProtocolResult<ExecResp>;
+    ) -> ProtocolResult<ServiceResponse<String>>;
 }

--- a/protocol/src/traits/binding.rs
+++ b/protocol/src/traits/binding.rs
@@ -4,25 +4,9 @@ use bytes::Bytes;
 use derive_more::{Display, From};
 
 use crate::fixed_codec::FixedCodec;
-use crate::traits::ExecutorParams;
+use crate::traits::{ExecutorParams, ServiceResponse};
 use crate::types::{Address, Block, Hash, MerkleRoot, Receipt, ServiceContext, SignedTransaction};
 use crate::{ProtocolError, ProtocolErrorKind, ProtocolResult};
-
-#[derive(Debug, Display, From)]
-pub enum BindingMacroError {
-    #[display(fmt = "service {:?} method {:?} was not found", service, method)]
-    NotFoundMethod { service: String, method: String },
-
-    #[display(fmt = "Parsing payload to json failed {:?}", _0)]
-    JsonParse(serde_json::Error),
-}
-impl std::error::Error for BindingMacroError {}
-
-impl From<BindingMacroError> for ProtocolError {
-    fn from(err: BindingMacroError) -> ProtocolError {
-        ProtocolError::new(ProtocolErrorKind::BindingMacro, Box::new(err))
-    }
-}
 
 pub trait ServiceMapping: Send + Sync {
     fn get_service<SDK: 'static + ServiceSDK>(
@@ -100,31 +84,22 @@ pub trait AdmissionControl {
 // - write: provide some writable functions for users or other services to call
 pub trait Service {
     // Executed to create genesis states when starting chain
-    fn genesis_(&mut self, _payload: String) -> ProtocolResult<()> {
-        Ok(())
-    }
+    fn genesis_(&mut self, _payload: String) {}
 
-    // Executed before the block is executed.
-    fn hook_before_(&mut self, _params: &ExecutorParams) -> ProtocolResult<()> {
-        Ok(())
-    }
+    // Called before block execution
+    fn hook_before_(&mut self, _params: &ExecutorParams) {}
 
-    // Executed after block execution.
-    fn hook_after_(&mut self, _params: &ExecutorParams) -> ProtocolResult<()> {
-        Ok(())
-    }
+    // Called after block execution
+    fn hook_after_(&mut self, _params: &ExecutorParams) {}
 
-    fn tx_hook_before_(&mut self, _ctx: ServiceContext) -> ProtocolResult<()> {
-        Ok(())
-    }
+    // Called before tx execution
+    fn tx_hook_before_(&mut self, _ctx: ServiceContext) {}
+    // Called after tx execution
+    fn tx_hook_after_(&mut self, _ctx: ServiceContext) {}
 
-    fn tx_hook_after_(&mut self, _ctx: ServiceContext) -> ProtocolResult<()> {
-        Ok(())
-    }
+    fn write_(&mut self, ctx: ServiceContext) -> ServiceResponse<String>;
 
-    fn write_(&mut self, ctx: ServiceContext) -> ProtocolResult<String>;
-
-    fn read_(&self, ctx: ServiceContext) -> ProtocolResult<String>;
+    fn read_(&self, ctx: ServiceContext) -> ServiceResponse<String>;
 }
 
 // `ServiceSDK` provides multiple rich interfaces for `service` developers
@@ -148,40 +123,35 @@ pub trait ServiceSDK {
     fn alloc_or_recover_map<Key: 'static + FixedCodec + PartialEq, Val: 'static + FixedCodec>(
         &mut self,
         var_name: &str,
-    ) -> ProtocolResult<Box<dyn StoreMap<Key, Val>>>;
+    ) -> Box<dyn StoreMap<Key, Val>>;
 
     // Alloc or recover a `Array` by` var_name`
     fn alloc_or_recover_array<Elm: 'static + FixedCodec>(
         &mut self,
         var_name: &str,
-    ) -> ProtocolResult<Box<dyn StoreArray<Elm>>>;
+    ) -> Box<dyn StoreArray<Elm>>;
 
     // Alloc or recover a `Uint64` by` var_name`
-    fn alloc_or_recover_uint64(&mut self, var_name: &str) -> ProtocolResult<Box<dyn StoreUint64>>;
+    fn alloc_or_recover_uint64(&mut self, var_name: &str) -> Box<dyn StoreUint64>;
 
     // Alloc or recover a `String` by` var_name`
-    fn alloc_or_recover_string(&mut self, var_name: &str) -> ProtocolResult<Box<dyn StoreString>>;
+    fn alloc_or_recover_string(&mut self, var_name: &str) -> Box<dyn StoreString>;
 
     // Alloc or recover a `Bool` by` var_name`
-    fn alloc_or_recover_bool(&mut self, var_name: &str) -> ProtocolResult<Box<dyn StoreBool>>;
+    fn alloc_or_recover_bool(&mut self, var_name: &str) -> Box<dyn StoreBool>;
 
     // Get a value from the service state by key
-    fn get_value<Key: FixedCodec, Ret: FixedCodec>(&self, key: &Key)
-        -> ProtocolResult<Option<Ret>>;
+    fn get_value<Key: FixedCodec, Ret: FixedCodec>(&self, key: &Key) -> Option<Ret>;
 
     // Set a value to the service state by key
-    fn set_value<Key: FixedCodec, Val: FixedCodec>(
-        &mut self,
-        key: Key,
-        val: Val,
-    ) -> ProtocolResult<()>;
+    fn set_value<Key: FixedCodec, Val: FixedCodec>(&mut self, key: Key, val: Val);
 
     // Get a value from the specified address by key
     fn get_account_value<Key: FixedCodec, Ret: FixedCodec>(
         &self,
         address: &Address,
         key: &Key,
-    ) -> ProtocolResult<Option<Ret>>;
+    ) -> Option<Ret>;
 
     // Insert a pair of key / value to the specified address
     fn set_account_value<Key: FixedCodec, Val: FixedCodec>(
@@ -189,20 +159,20 @@ pub trait ServiceSDK {
         address: &Address,
         key: Key,
         val: Val,
-    ) -> ProtocolResult<()>;
+    );
 
     // Get a signed transaction by `tx_hash`
     // if not found on the chain, return None
-    fn get_transaction_by_hash(&self, tx_hash: &Hash) -> ProtocolResult<Option<SignedTransaction>>;
+    fn get_transaction_by_hash(&self, tx_hash: &Hash) -> Option<SignedTransaction>;
 
     // Get a block by `height`
     // if not found on the chain, return None
     // When the parameter `height` is None, get the latest (executing)` block`
-    fn get_block_by_height(&self, height: Option<u64>) -> ProtocolResult<Option<Block>>;
+    fn get_block_by_height(&self, height: Option<u64>) -> Option<Block>;
 
     // Get a receipt by `tx_hash`
     // if not found on the chain, return None
-    fn get_receipt_by_hash(&self, tx_hash: &Hash) -> ProtocolResult<Option<Receipt>>;
+    fn get_receipt_by_hash(&self, tx_hash: &Hash) -> Option<Receipt>;
 
     // Call other read-only methods of `service` and return the results
     // synchronously NOTE: You can use recursive calls, but the maximum call
@@ -214,7 +184,7 @@ pub trait ServiceSDK {
         service: &str,
         method: &str,
         payload: &str,
-    ) -> ProtocolResult<String>;
+    ) -> ServiceResponse<String>;
 
     // Call other writable methods of `service` and return the results synchronously
     // NOTE: You can use recursive calls, but the maximum call stack is 1024
@@ -225,81 +195,81 @@ pub trait ServiceSDK {
         service: &str,
         method: &str,
         payload: &str,
-    ) -> ProtocolResult<String>;
+    ) -> ServiceResponse<String>;
 }
 
-pub trait StoreMap<Key: FixedCodec + PartialEq, Value: FixedCodec> {
-    fn get(&self, key: &Key) -> ProtocolResult<Value>;
+pub trait StoreMap<K: FixedCodec + PartialEq, V: FixedCodec> {
+    fn get(&self, key: &K) -> Option<V>;
 
-    fn contains(&self, key: &Key) -> ProtocolResult<bool>;
+    fn contains(&self, key: &K) -> bool;
 
-    fn insert(&mut self, key: Key, value: Value) -> ProtocolResult<()>;
+    fn insert(&mut self, key: K, value: V);
 
-    fn remove(&mut self, key: &Key) -> ProtocolResult<()>;
+    fn remove(&mut self, key: &K) -> Option<V>;
 
-    fn len(&self) -> ProtocolResult<u32>;
+    fn len(&self) -> u32;
 
-    fn is_empty(&self) -> ProtocolResult<bool>;
+    fn is_empty(&self) -> bool;
 
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&Key, Value)> + 'a>;
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&K, V)> + 'a>;
 }
 
-pub trait StoreArray<Elm: FixedCodec> {
-    fn get(&self, index: u32) -> ProtocolResult<Elm>;
+pub trait StoreArray<E: FixedCodec> {
+    fn get(&self, index: u32) -> E;
 
-    fn push(&mut self, element: Elm) -> ProtocolResult<()>;
+    fn push(&mut self, element: E);
 
-    fn remove(&mut self, index: u32) -> ProtocolResult<()>;
+    fn remove(&mut self, index: u32);
 
-    fn len(&self) -> ProtocolResult<u32>;
+    fn len(&self) -> u32;
 
-    fn is_empty(&self) -> ProtocolResult<bool>;
+    fn is_empty(&self) -> bool;
 
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (u32, Elm)> + 'a>;
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (u32, E)> + 'a>;
 }
 
 pub trait StoreUint64 {
-    fn get(&self) -> ProtocolResult<u64>;
+    fn get(&self) -> u64;
 
-    fn set(&mut self, val: u64) -> ProtocolResult<()>;
+    fn set(&mut self, val: u64);
 
     // Add val with self
     // And set the result back to self
-    fn add(&mut self, val: u64) -> ProtocolResult<()>;
+    fn add(&mut self, val: u64);
 
     // Self minus val
     // And set the result back to self
-    fn sub(&mut self, val: u64) -> ProtocolResult<()>;
+    fn sub(&mut self, val: u64);
 
     // Multiply val with self
     // And set the result back to self
-    fn mul(&mut self, val: u64) -> ProtocolResult<()>;
+    fn mul(&mut self, val: u64);
 
     // Power of self
     // And set the result back to self
-    fn pow(&mut self, val: u32) -> ProtocolResult<()>;
+    fn pow(&mut self, val: u32);
 
     // Self divided by val
     // And set the result back to self
-    fn div(&mut self, val: u64) -> ProtocolResult<()>;
+    fn div(&mut self, val: u64);
 
     // Remainder of self
     // And set the result back to self
-    fn rem(&mut self, val: u64) -> ProtocolResult<()>;
+    fn rem(&mut self, val: u64);
 }
 
 pub trait StoreString {
-    fn get(&self) -> ProtocolResult<String>;
+    fn get(&self) -> String;
 
-    fn set(&mut self, val: &str) -> ProtocolResult<()>;
+    fn set(&mut self, val: &str);
 
-    fn len(&self) -> ProtocolResult<u32>;
+    fn len(&self) -> u32;
 
-    fn is_empty(&self) -> ProtocolResult<bool>;
+    fn is_empty(&self) -> bool;
 }
 
 pub trait StoreBool {
-    fn get(&self) -> ProtocolResult<bool>;
+    fn get(&self) -> bool;
 
-    fn set(&mut self, b: bool) -> ProtocolResult<()>;
+    fn set(&mut self, b: bool);
 }

--- a/protocol/src/traits/binding.rs
+++ b/protocol/src/traits/binding.rs
@@ -1,12 +1,11 @@
 use std::iter::Iterator;
 
 use bytes::Bytes;
-use derive_more::{Display, From};
 
 use crate::fixed_codec::FixedCodec;
 use crate::traits::{ExecutorParams, ServiceResponse};
 use crate::types::{Address, Block, Hash, MerkleRoot, Receipt, ServiceContext, SignedTransaction};
-use crate::{ProtocolError, ProtocolErrorKind, ProtocolResult};
+use crate::ProtocolResult;
 
 pub trait ServiceMapping: Send + Sync {
     fn get_service<SDK: 'static + ServiceSDK>(

--- a/protocol/src/traits/executor.rs
+++ b/protocol/src/traits/executor.rs
@@ -24,32 +24,34 @@ pub struct ExecutorParams {
 
 #[derive(Debug, Clone, Default)]
 pub struct ServiceResponse<T: Default> {
-    pub code:  u64,
-    pub data:  T,
-    pub error: String,
+    pub code:          u64,
+    pub succeed_data:  T,
+    pub error_message: String,
 }
 
 impl<T: Default> ServiceResponse<T> {
-    pub fn from_error(code: u64, error: String) -> Self {
+    pub fn from_error(code: u64, error_message: String) -> Self {
         Self {
             code,
-            data: T::default(),
-            error,
+            succeed_data: T::default(),
+            error_message,
         }
     }
 
-    pub fn from_data(data: T) -> Self {
+    pub fn from_succeed(succeed_data: T) -> Self {
         Self {
             code: 0,
-            data,
-            error: "".to_owned(),
+            succeed_data,
+            error_message: "".to_owned(),
         }
     }
 }
 
 impl<T: Default + PartialEq> PartialEq for ServiceResponse<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.code == other.code && self.data == other.data && self.error == other.error
+        self.code == other.code
+            && self.succeed_data == other.succeed_data
+            && self.error_message == other.error_message
     }
 }
 

--- a/protocol/src/traits/executor.rs
+++ b/protocol/src/traits/executor.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
-
 use crate::traits::{ServiceMapping, Storage};
 use crate::types::{
     Address, Bloom, MerkleRoot, Receipt, ServiceContext, SignedTransaction, TransactionRequest,

--- a/protocol/src/traits/executor.rs
+++ b/protocol/src/traits/executor.rs
@@ -45,6 +45,10 @@ impl<T: Default> ServiceResponse<T> {
             error_message: "".to_owned(),
         }
     }
+
+    pub fn is_error(&self) -> bool {
+        self.code != 0
+    }
 }
 
 impl<T: Default + PartialEq> PartialEq for ServiceResponse<T> {

--- a/protocol/src/traits/mod.rs
+++ b/protocol/src/traits/mod.rs
@@ -8,15 +8,16 @@ mod storage;
 
 pub use api::APIAdapter;
 pub use binding::{
-    AdmissionControl, BindingMacroError, ChainQuerier, Service, ServiceMapping, ServiceSDK,
-    ServiceState, StoreArray, StoreBool, StoreMap, StoreString, StoreUint64,
+    AdmissionControl, ChainQuerier, Service, ServiceMapping, ServiceSDK, ServiceState, StoreArray,
+    StoreBool, StoreMap, StoreString, StoreUint64,
 };
 pub use consensus::{
     CommonConsensusAdapter, Consensus, ConsensusAdapter, MessageTarget, NodeInfo, Synchronization,
     SynchronizationAdapter,
 };
 pub use executor::{
-    Dispatcher, ExecResp, Executor, ExecutorFactory, ExecutorParams, ExecutorResp, NoopDispatcher,
+    Dispatcher, Executor, ExecutorFactory, ExecutorParams, ExecutorResp, NoopDispatcher,
+    ServiceResponse,
 };
 pub use mempool::{MemPool, MemPoolAdapter, MixedTxHashes};
 pub use network::{Gossip, MessageCodec, MessageHandler, Priority, Rpc};

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -23,7 +23,7 @@ pub const GENESIS_HEIGHT: u64 = 0;
 const HASH_LEN: usize = 32;
 
 // Should started with 0x
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct Hex(String);
 
 impl Hex {
@@ -198,7 +198,7 @@ impl fmt::Debug for Hash {
 /// Address length.
 const ADDRESS_LEN: usize = 20;
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub struct Address([u8; ADDRESS_LEN]);
 
 impl Serialize for Address {
@@ -288,7 +288,7 @@ impl fmt::Debug for Address {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Default, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Metadata {
     pub chain_id:        Hash,
     pub common_ref:      Hex,
@@ -305,7 +305,7 @@ pub struct Metadata {
     pub max_tx_size:     u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
 pub struct ValidatorExtend {
     pub bls_pub_key:    Hex,
     pub address:        Address,

--- a/protocol/src/types/receipt.rs
+++ b/protocol/src/types/receipt.rs
@@ -1,3 +1,4 @@
+use crate::traits::ServiceResponse;
 use crate::types::{Hash, MerkleRoot};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,6 +21,5 @@ pub struct Receipt {
 pub struct ReceiptResponse {
     pub service_name: String,
     pub method:       String,
-    pub ret:          String,
-    pub is_error:     bool,
+    pub response:     ServiceResponse<String>,
 }

--- a/protocol/src/types/service_context.rs
+++ b/protocol/src/types/service_context.rs
@@ -3,10 +3,9 @@ use std::rc::Rc;
 
 use bytes::Bytes;
 use derive_more::{Display, From};
-use serde::{Deserialize, Serialize};
 
 use crate::types::{Address, Event, Hash};
-use crate::{ProtocolError, ProtocolErrorKind, ProtocolResult};
+use crate::{ProtocolError, ProtocolErrorKind};
 
 #[derive(Debug, Clone)]
 pub struct ServiceContextParams {
@@ -194,7 +193,7 @@ mod tests {
         };
         let ctx = ServiceContext::new(params);
 
-        ctx.sub_cycles(8).unwrap();
+        ctx.sub_cycles(8);
         assert_eq!(ctx.get_cycles_used(), 18);
 
         assert_eq!(ctx.get_cycles_limit(), 100);

--- a/protocol/src/types/service_context.rs
+++ b/protocol/src/types/service_context.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use bytes::Bytes;
 use derive_more::{Display, From};
+use serde::{Deserialize, Serialize};
 
 use crate::types::{Address, Event, Hash};
 use crate::{ProtocolError, ProtocolErrorKind, ProtocolResult};
@@ -96,12 +97,11 @@ impl ServiceContext {
         self.events.borrow().clone()
     }
 
-    pub fn sub_cycles(&self, cycles: u64) -> ProtocolResult<()> {
+    pub fn sub_cycles(&self, cycles: u64) {
         if self.get_cycles_used() + cycles <= self.cycles_limit {
             *self.cycles_used.borrow_mut() = self.get_cycles_used() + cycles;
-            Ok(())
         } else {
-            Err(ServiceContextError::OutOfCycles.into())
+            panic!("out of cycles");
         }
     }
 
@@ -145,13 +145,11 @@ impl ServiceContext {
         self.timestamp
     }
 
-    pub fn emit_event(&self, message: String) -> ProtocolResult<()> {
+    pub fn emit_event(&self, message: String) {
         self.events.borrow_mut().push(Event {
             service: self.service_name.clone(),
             data:    message,
-        });
-
-        Ok(())
+        })
     }
 }
 

--- a/protocol/src/types/service_context.rs
+++ b/protocol/src/types/service_context.rs
@@ -96,11 +96,12 @@ impl ServiceContext {
         self.events.borrow().clone()
     }
 
-    pub fn sub_cycles(&self, cycles: u64) {
+    pub fn sub_cycles(&self, cycles: u64) -> bool {
         if self.get_cycles_used() + cycles <= self.cycles_limit {
             *self.cycles_used.borrow_mut() = self.get_cycles_used() + cycles;
+            true
         } else {
-            panic!("out of cycles");
+            false
         }
     }
 

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -236,7 +236,8 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         )
         .await?;
 
-    let metadata: Metadata = serde_json::from_str(&exec_resp.ret).expect("Decode metadata failed!");
+    let metadata: Metadata =
+        serde_json::from_str(&exec_resp.data).expect("Decode metadata failed!");
 
     // set args in mempool
     mempool.set_args(

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -237,7 +237,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .await?;
 
     let metadata: Metadata =
-        serde_json::from_str(&exec_resp.data).expect("Decode metadata failed!");
+        serde_json::from_str(&exec_resp.succeed_data).expect("Decode metadata failed!");
 
     // set args in mempool
     mempool.set_args(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**

refactor

**What this PR does / why we need it**:

refactor error handle mechanism to distinguish inner chain error from service error

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
- Had not used `Bytes` to replace `String` after thinking twice
Payload and response are still `String`, which is easier to read. 
This can be discussed.
- Service call return `ServiceResponse<T>` type
```rust
#[derive(Debug, Clone, Default)]
pub struct ServiceResponse<T: Default> {
    pub code:  u64,
    pub succeed_data:  T,
    pub error_message: String,
}
```
- Breaking change for api
```rust
#[derive(juniper::GraphQLObject, Clone)]
pub struct ServiceResponse {
    pub code:  Uint64,
    pub succeed_data:  String,
    pub error_message: String,
}
```
- Pay attention to the catch panic logic of executor
help me check it and make it right
- TODO: the return type of service hook is not token into account in this PR, need to be refactored next step