### PR TITLE
fix(binding): store type should return Option None instead of panic

### DIFF
--- a/framework/src/binding/store/primitive.rs
+++ b/framework/src/binding/store/primitive.rs
@@ -25,7 +25,13 @@ impl<S: ServiceState> DefaultStoreBool<S> {
     fn get_(&self) -> ProtocolResult<bool> {
         let b: Option<bool> = self.state.borrow().get(&self.key)?;
 
-        b.ok_or_else(|| StoreError::GetNone.into())
+        match b {
+            Some(v) => Ok(v),
+            None => {
+                self.state.borrow_mut().insert(self.key.clone(), false)?;
+                Ok(false)
+            }
+        }
     }
 
     fn set_(&mut self, b: bool) -> ProtocolResult<()> {
@@ -62,7 +68,13 @@ impl<S: ServiceState> DefaultStoreUint64<S> {
     fn get_(&self) -> ProtocolResult<u64> {
         let u: Option<u64> = self.state.borrow().get(&self.key)?;
 
-        u.ok_or_else(|| StoreError::GetNone.into())
+        match u {
+            Some(v) => Ok(v),
+            None => {
+                self.state.borrow_mut().insert(self.key.clone(), 0u64)?;
+                Ok(0)
+            }
+        }
     }
 
     fn set_(&mut self, val: u64) -> ProtocolResult<()> {
@@ -217,7 +229,15 @@ impl<S: ServiceState> DefaultStoreString<S> {
     fn get_(&self) -> ProtocolResult<String> {
         let s: Option<String> = self.state.borrow().get(&self.key)?;
 
-        s.ok_or_else(|| StoreError::GetNone.into())
+        match s {
+            Some(v) => Ok(v),
+            None => {
+                self.state
+                    .borrow_mut()
+                    .insert(self.key.clone(), "".to_string())?;
+                Ok("".to_string())
+            }
+        }
     }
 
     fn len_(&self) -> ProtocolResult<u32> {

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -67,7 +67,10 @@ fn test_service_sdk() {
 
     sdk_array.push(Hash::digest(Bytes::from("key_1")));
 
-    assert_eq!(sdk_array.get(0), Hash::digest(Bytes::from("key_1")));
+    assert_eq!(
+        sdk_array.get(0).unwrap(),
+        Hash::digest(Bytes::from("key_1"))
+    );
 
     let mut it = sdk_array.iter();
     assert_eq!(it.next().unwrap(), (0, Hash::digest(Bytes::from("key_1"))));

--- a/framework/src/binding/tests/store.rs
+++ b/framework/src/binding/tests/store.rs
@@ -20,6 +20,7 @@ fn test_default_store_bool() {
 
     let mut sb = DefaultStoreBool::new(Rc::new(RefCell::new(state)), "test");
 
+    assert_eq!(sb.get(), false);
     sb.set(true);
     assert_eq!(sb.get(), true);
     sb.set(false);
@@ -33,6 +34,7 @@ fn test_default_store_uint64() {
 
     let mut su = DefaultStoreUint64::new(Rc::new(RefCell::new(state)), "test");
 
+    assert_eq!(su.get(), 0u64);
     su.set(8u64);
     assert_eq!(su.get(), 8u64);
 
@@ -63,6 +65,8 @@ fn test_default_store_string() {
     let rs = Rc::new(RefCell::new(state));
     let mut ss = DefaultStoreString::new(Rc::clone(&rs), "test");
 
+    assert_eq!(ss.get(), "");
+
     ss.set("");
     assert_eq!(ss.get(), "");
     assert_eq!(ss.is_empty(), true);
@@ -80,6 +84,7 @@ fn test_default_store_map() {
 
     let mut sm = DefaultStoreMap::<_, Hash, Bytes>::new(Rc::clone(&rs), "test");
 
+    assert_eq!(sm.get(&Hash::digest(Bytes::from("key_1"))).is_none(), true);
     sm.insert(Hash::digest(Bytes::from("key_1")), Bytes::from("val_1"));
     sm.insert(Hash::digest(Bytes::from("key_2")), Bytes::from("val_2"));
 
@@ -120,9 +125,12 @@ fn test_default_store_array() {
     let mut sa = DefaultStoreArray::<_, Bytes>::new(Rc::clone(&rs), "test");
 
     assert_eq!(sa.len(), 0u32);
+    assert_eq!(sa.get(0u32).is_none(), true);
 
     sa.push(Bytes::from("111"));
     sa.push(Bytes::from("222"));
+
+    assert_eq!(sa.get(3u32).is_none(), true);
 
     {
         let mut it = sa.iter();
@@ -131,11 +139,11 @@ fn test_default_store_array() {
         assert_eq!(it.next().is_none(), true);
     }
 
-    assert_eq!(sa.get(0u32), Bytes::from("111"));
-    assert_eq!(sa.get(1u32), Bytes::from("222"));
+    assert_eq!(sa.get(0u32).unwrap(), Bytes::from("111"));
+    assert_eq!(sa.get(1u32).unwrap(), Bytes::from("222"));
 
     sa.remove(0u32);
 
     assert_eq!(sa.len(), 1u32);
-    assert_eq!(sa.get(0u32), Bytes::from("222"));
+    assert_eq!(sa.get(0u32).unwrap(), Bytes::from("222"));
 }

--- a/protocol/src/traits/binding.rs
+++ b/protocol/src/traits/binding.rs
@@ -214,7 +214,7 @@ pub trait StoreMap<K: FixedCodec + PartialEq, V: FixedCodec> {
 }
 
 pub trait StoreArray<E: FixedCodec> {
-    fn get(&self, index: u32) -> E;
+    fn get(&self, index: u32) -> Option<E>;
 
     fn push(&mut self, element: E);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
fix binding `StoreType`
**What this PR does / why we need it**:
 binding store type should return Option None instead of panic when method get none
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
