### PR TITLE
refactor(mempool): Improve mempool's performance close to 100%

### DIFF
--- a/core/mempool/src/map.rs
+++ b/core/mempool/src/map.rs
@@ -82,7 +82,7 @@ where
 }
 
 fn get_index(hash: &Hash) -> usize {
-    (hash.0[0] >> 4) as usize
+    (hash.as_bytes()[0] >> 4) as usize
 }
 
 struct Bucket<V> {

--- a/core/mempool/src/map.rs
+++ b/core/mempool/src/map.rs
@@ -95,12 +95,7 @@ where
     V: Send + Sync + Clone,
 {
     fn insert(&self, hash: Hash, value: V) -> Option<V> {
-        let mut lock_data = self.store.write();
-        if lock_data.contains_key(&hash) {
-            Some(value)
-        } else {
-            lock_data.insert(hash, value)
-        }
+        self.store.write().insert(hash, value)
     }
 
     fn contains_key(&self, tx_hash: &Hash) -> bool {

--- a/core/mempool/src/tx_cache.rs
+++ b/core/mempool/src/tx_cache.rs
@@ -526,7 +526,7 @@ mod tests {
         let tx_wrapper_1 = TxWrapper::new(tx.clone());
         map.insert(tx.tx_hash.clone(), Arc::new(tx_wrapper_1));
         let shared_tx_1 = map.get(&tx.tx_hash).unwrap();
-        assert!(shared_tx_1.is_removed());
+        assert!(!shared_tx_1.is_removed());
     }
 
     #[bench]

--- a/core/mempool/src/tx_cache.rs
+++ b/core/mempool/src/tx_cache.rs
@@ -173,7 +173,7 @@ impl TxCache {
             }
         }
         // Dividing set removed and remove into two loops is to avoid lock competition.
-        self.map.deletes(tx_hashes);
+        self.map.remove_batch(tx_hashes);
         self.flush_incumbent_queue(current_height, timeout);
     }
 
@@ -242,7 +242,7 @@ impl TxCache {
             }
         }
         // Remove timeout tx in map
-        self.map.deletes(&timeout_tx_hashes);
+        self.map.remove_batch(&timeout_tx_hashes);
 
         Ok(MixedTxHashes {
             order_tx_hashes,
@@ -376,7 +376,7 @@ impl TxCache {
             }
         }
         // Remove timeout tx in map
-        self.map.deletes(&timeout_tx_hashes);
+        self.map.remove_batch(&timeout_tx_hashes);
     }
 
     fn switch_queue_role(&self) -> QueueRole {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**

Performance

**What this PR does / why we need it**:

Origin benchmark:

```
test map::tests::bench_map_insert          ... bench:     158,499 ns/iter (+/- 4,657)
```

After remove pre-judgment before insert

```
test map::tests::bench_map_insert          ... bench:     122,443 ns/iter (+/- 4,326)
```

After rewrite `get_index()`

```
test map::tests::bench_map_insert          ... bench:      80,451 ns/iter (+/- 3,151)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
