### PR TITLE
feat(service):add account service for multi sig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { version = "0.2", features = ["macros", "rt-core", "rt-util", "signal",
 asset = { path = "built-in-services/asset"}
 metadata = { path = "built-in-services/metadata"}
 util = { path = "built-in-services/util"}
+account = { path = "built-in-services/account" }
 
 [workspace]
 members = [

--- a/built-in-services/account/Cargo.toml
+++ b/built-in-services/account/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "account"
+version = "0.1.0-alpha.0"
+authors = ["Muta Dev <muta@nervos.org>"]
+edition = "2018"
+repository = "https://github.com/nervosnetwork/muta"
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+binding-macro = { path = "../../binding-macro" }
+protocol = { path = "../../protocol", package = "muta-protocol" }
+hasher = { version="0.1", features = ["hash-keccak"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+rlp = "0.4"
+bytes = "0.5"
+derive_more = "0.15"
+byteorder = "1.3"
+common-crypto = { path = "../../common/crypto" }
+hex = "0.4"
+rand = "0.7"
+
+[dev-dependencies]
+cita_trie = "2.0"
+async-trait = "0.1"
+framework = { path = "../../framework" }

--- a/built-in-services/account/src/lib.rs
+++ b/built-in-services/account/src/lib.rs
@@ -1,0 +1,146 @@
+use crate::types::{
+    Account, GenerateAccountPayload, GenerateAccountResponse, GetAccountPayload, PayloadAccount,
+    Permission, VerifyPayload, VerifyResponse, ACCOUNT_TYPE_PUBLIC_KEY, MAX_PERMISSION_ACCOUNTS,
+};
+use binding_macro::{cycles, service};
+use bytes::Bytes;
+use hasher::{Hasher, HasherKeccak};
+use protocol::traits::{ExecutorParams, ServiceResponse, ServiceSDK};
+use protocol::types::{Address, Hash, ServiceContext};
+
+#[cfg(test)]
+mod tests;
+pub mod types;
+
+pub struct AccountService<SDK> {
+    sdk: SDK,
+}
+
+#[service]
+impl<SDK: ServiceSDK> AccountService<SDK> {
+    pub fn new(mut sdk: SDK) -> Self {
+        Self { sdk }
+    }
+
+    #[cycles(100_00)]
+    #[read]
+    fn verify(
+        &self,
+        ctx: ServiceContext,
+        payload: VerifyPayload,
+    ) -> ServiceResponse<VerifyResponse> {
+        ServiceResponse::<VerifyResponse>::from_error(
+            110,
+            "accounts length must be [1,16]".to_owned(),
+        )
+    }
+
+    #[cycles(100_00)]
+    #[read]
+    fn get_account_from_address(
+        &self,
+        ctx: ServiceContext,
+        payload: GetAccountPayload,
+    ) -> ServiceResponse<GenerateAccountResponse> {
+        let permission = self
+            .sdk
+            .get_account_value(&payload.user, &0u8)
+            .unwrap_or(Permission {
+                accounts:  Vec::<Account>::new(),
+                threshold: 0,
+            });
+
+        if permission.threshold == 0 {
+            return ServiceResponse::<GenerateAccountResponse>::from_error(
+                110,
+                "account not existed".to_owned(),
+            );
+        }
+
+        let mut accounts = Vec::<PayloadAccount>::new();
+        for item in &permission.accounts {
+            accounts.push(PayloadAccount {
+                address: item.address.clone(),
+                weight:  item.weight,
+            });
+        }
+
+        let response = GenerateAccountResponse {
+            accounts,
+            threshold: permission.threshold,
+            address: payload.user.clone(),
+        };
+
+        ServiceResponse::<GenerateAccountResponse>::from_succeed(response)
+    }
+
+    #[cycles(210_00)]
+    #[write]
+    fn generate_account(
+        &mut self,
+        ctx: ServiceContext,
+        payload: GenerateAccountPayload,
+    ) -> ServiceResponse<GenerateAccountResponse> {
+        if payload.accounts.len() == 0 || payload.accounts.len() > MAX_PERMISSION_ACCOUNTS as usize
+        {
+            return ServiceResponse::<GenerateAccountResponse>::from_error(
+                110,
+                "accounts length must be [1,16]".to_owned(),
+            );
+        }
+
+        let mut weight_all = 0;
+        let mut accounts = Vec::<Account>::new();
+        for item in &payload.accounts {
+            weight_all += item.weight;
+            accounts.push(Account {
+                address:       item.address.clone(),
+                account_type:  ACCOUNT_TYPE_PUBLIC_KEY,
+                permission_id: 0,
+                weight:        item.weight,
+            });
+        }
+
+        if weight_all < payload.threshold || payload.threshold == 0 {
+            return ServiceResponse::<GenerateAccountResponse>::from_error(
+                110,
+                "accounts weight or threshold not valid".to_owned(),
+            );
+        }
+
+        let tx_hash = ctx.get_tx_hash().unwrap();
+
+        let keccak = HasherKeccak::new();
+        let addr_hash = Hash::from_bytes(Bytes::from(keccak.digest(&tx_hash.as_bytes())));
+        if addr_hash.is_err() {
+            return ServiceResponse::<GenerateAccountResponse>::from_error(
+                111,
+                "generate addr_hash from tx_hash failed".to_owned(),
+            );
+        }
+
+        let addr = Address::from_hash(addr_hash.unwrap());
+        if addr.is_err() {
+            return ServiceResponse::<GenerateAccountResponse>::from_error(
+                111,
+                "generate address from tx_hash failed".to_owned(),
+            );
+        }
+
+        let address = addr.unwrap();
+        let permission = Permission {
+            accounts,
+            threshold: payload.threshold,
+        };
+
+        self.sdk.set_account_value(&address, 0u8, permission);
+
+        let response = GenerateAccountResponse {
+            address:   address.clone(),
+            accounts:  payload.accounts,
+            threshold: payload.threshold,
+        };
+
+        ServiceResponse::<GenerateAccountResponse>::from_succeed(response)
+    }
+}

--- a/built-in-services/account/src/lib.rs
+++ b/built-in-services/account/src/lib.rs
@@ -83,7 +83,7 @@ impl<SDK: ServiceSDK> AccountService<SDK> {
         let permission = permission_res.unwrap();
         let mut weight_sum = 0;
         let size = permission.accounts.len();
-        let mut hash_account = [false; MAX_PERMISSION_ACCOUNTS as usize];
+        let mut has_account = [false; MAX_PERMISSION_ACCOUNTS as usize];
 
         for i in 0..wit.signatures.len() {
             let res = verify_single_sig(&payload.tx_hash, &wit.signatures[i], &wit.pubkeys[i]);
@@ -92,11 +92,11 @@ impl<SDK: ServiceSDK> AccountService<SDK> {
             }
 
             for (k, item) in permission.accounts.iter().enumerate().take(size) {
-                if hash_account[k] {
+                if has_account[k] {
                     continue;
                 }
                 if item.address.eq(&res.succeed_data.address) {
-                    hash_account[k] = true;
+                    has_account[k] = true;
                     weight_sum += item.weight;
                     break;
                 }

--- a/built-in-services/account/src/tests/mod.rs
+++ b/built-in-services/account/src/tests/mod.rs
@@ -1,0 +1,162 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use cita_trie::MemoryDB;
+use rand::rngs::OsRng;
+
+use async_trait::async_trait;
+use common_crypto::{
+    Crypto, PrivateKey, PublicKey, Secp256k1, Secp256k1PrivateKey, Signature, ToPublicKey,
+};
+
+use framework::binding::sdk::{DefalutServiceSDK, DefaultChainQuerier};
+use framework::binding::state::{GeneralServiceState, MPTTrie};
+use protocol::traits::{NoopDispatcher, Storage};
+use protocol::types::{
+    Address, Block, Hash, Hex, Proof, Receipt, ServiceContext, ServiceContextParams,
+    SignedTransaction,
+};
+
+use protocol::{types::Bytes, ProtocolResult};
+
+use crate::types::{
+    Account, GenerateAccountPayload, GenerateAccountResponse, GetAccountPayload, PayloadAccount,
+};
+use crate::AccountService;
+
+#[test]
+fn test_generate() {
+    let cycles_limit = 1024 * 1024 * 1024; // 1073741824
+    let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
+    let context = mock_context(cycles_limit, caller.clone());
+    let mut service = new_account_service();
+
+    let mut accounts = Vec::<PayloadAccount>::new();
+    accounts.push(PayloadAccount {
+        address: caller.clone(),
+        weight:  1,
+    });
+
+    accounts.push(PayloadAccount {
+        address: caller.clone(),
+        weight:  1,
+    });
+
+    accounts.push(PayloadAccount {
+        address: caller.clone(),
+        weight:  1,
+    });
+
+    let res = service.generate_account(context.clone(), GenerateAccountPayload {
+        accounts,
+        threshold: 2,
+    });
+
+    let addr = res.succeed_data.address.clone();
+    let res_get = service.get_account_from_address(context, GetAccountPayload { user: addr });
+
+    println!("{:#?}", res);
+    println!("{:#?}", res_get);
+}
+
+fn new_account_service() -> AccountService<
+    DefalutServiceSDK<
+        GeneralServiceState<MemoryDB>,
+        DefaultChainQuerier<MockStorage>,
+        NoopDispatcher,
+    >,
+> {
+    let chain_db = DefaultChainQuerier::new(Arc::new(MockStorage {}));
+    let trie = MPTTrie::new(Arc::new(MemoryDB::new(false)));
+    let state = GeneralServiceState::new(trie);
+
+    let sdk = DefalutServiceSDK::new(
+        Rc::new(RefCell::new(state)),
+        Rc::new(chain_db),
+        NoopDispatcher {},
+    );
+
+    AccountService::new(sdk)
+}
+
+fn mock_context(cycles_limit: u64, caller: Address) -> ServiceContext {
+    let params = ServiceContextParams {
+        tx_hash: Some(Hash::from_empty()),
+        nonce: None,
+        cycles_limit,
+        cycles_price: 1,
+        cycles_used: Rc::new(RefCell::new(0)),
+        caller,
+        height: 1,
+        timestamp: 0,
+        service_name: "service_name".to_owned(),
+        service_method: "service_method".to_owned(),
+        service_payload: "service_payload".to_owned(),
+        extra: None,
+        events: Rc::new(RefCell::new(vec![])),
+    };
+
+    ServiceContext::new(params)
+}
+
+struct MockStorage;
+
+#[async_trait]
+impl Storage for MockStorage {
+    async fn insert_transactions(&self, _: Vec<SignedTransaction>) -> ProtocolResult<()> {
+        unimplemented!()
+    }
+
+    async fn insert_block(&self, _: Block) -> ProtocolResult<()> {
+        unimplemented!()
+    }
+
+    async fn insert_receipts(&self, _: Vec<Receipt>) -> ProtocolResult<()> {
+        unimplemented!()
+    }
+
+    async fn update_latest_proof(&self, _: Proof) -> ProtocolResult<()> {
+        unimplemented!()
+    }
+
+    async fn get_transaction_by_hash(&self, _: Hash) -> ProtocolResult<SignedTransaction> {
+        unimplemented!()
+    }
+
+    async fn get_transactions(&self, _: Vec<Hash>) -> ProtocolResult<Vec<SignedTransaction>> {
+        unimplemented!()
+    }
+
+    async fn get_latest_block(&self) -> ProtocolResult<Block> {
+        unimplemented!()
+    }
+
+    async fn get_block_by_height(&self, _: u64) -> ProtocolResult<Block> {
+        unimplemented!()
+    }
+
+    async fn get_block_by_hash(&self, _: Hash) -> ProtocolResult<Block> {
+        unimplemented!()
+    }
+
+    async fn get_receipt(&self, _: Hash) -> ProtocolResult<Receipt> {
+        unimplemented!()
+    }
+
+    async fn get_receipts(&self, _: Vec<Hash>) -> ProtocolResult<Vec<Receipt>> {
+        unimplemented!()
+    }
+
+    async fn get_latest_proof(&self) -> ProtocolResult<Proof> {
+        unimplemented!()
+    }
+
+    async fn update_overlord_wal(&self, _info: Bytes) -> ProtocolResult<()> {
+        unimplemented!()
+    }
+
+    async fn load_overlord_wal(&self) -> ProtocolResult<Bytes> {
+        unimplemented!()
+    }
+}

--- a/built-in-services/account/src/tests/mod.rs
+++ b/built-in-services/account/src/tests/mod.rs
@@ -113,7 +113,7 @@ fn test_generate() {
 
     let mut res_single = service.verify_signature(context.clone(), VerifyPayload {
         tx_hash: tx_hash.clone(),
-        witness: Bytes::from(wit_str),
+        witness: wit_str.clone(),
     });
     assert_eq!(res_single.is_error(), true);
     println!("single sig1, expected not verified\r\n {:#?}", res_single);
@@ -130,7 +130,7 @@ fn test_generate() {
 
     res_single = service.verify_signature(context.clone(), VerifyPayload {
         tx_hash: tx_hash.clone(),
-        witness: Bytes::from(wit_str),
+        witness: wit_str.clone(),
     });
     assert_eq!(res_single.is_error(), false);
     println!("single sig1, expect verified\r\n {:#?}", res_single);
@@ -147,7 +147,7 @@ fn test_generate() {
 
     res_single = service.verify_signature(context.clone(), VerifyPayload {
         tx_hash: tx_hash.clone(),
-        witness: Bytes::from(wit_str),
+        witness: wit_str,
     });
     assert_eq!(res_single.is_error(), true);
     println!("single sig1-pk2, expect not verified\r\n {:#?}", res_single);
@@ -164,7 +164,7 @@ fn test_generate() {
 
     let res_multi_1 = service.verify_signature(context.clone(), VerifyPayload {
         tx_hash: tx_hash.clone(),
-        witness: Bytes::from(wit1_str),
+        witness: wit1_str,
     });
     assert_eq!(res_multi_1.is_error(), false);
     println!("{:#?}", res_multi_1);
@@ -181,7 +181,7 @@ fn test_generate() {
 
     let res_multi_2 = service.verify_signature(context.clone(), VerifyPayload {
         tx_hash: tx_hash.clone(),
-        witness: Bytes::from(wit2_str),
+        witness: wit2_str,
     });
     assert_eq!(res_multi_2.is_error(), true);
     println!("{:#?}", res_multi_2);
@@ -198,7 +198,7 @@ fn test_generate() {
 
     let res_multi_3 = service.verify_signature(context.clone(), VerifyPayload {
         tx_hash: tx_hash.clone(),
-        witness: Bytes::from(wit3_str),
+        witness: wit3_str,
     });
     assert_eq!(res_multi_3.is_error(), false);
     println!("{:#?}", res_multi_3);
@@ -215,7 +215,7 @@ fn test_generate() {
 
     let res_multi_4 = service.verify_signature(context, VerifyPayload {
         tx_hash,
-        witness: Bytes::from(wit4_str),
+        witness: wit4_str,
     });
     assert_eq!(res_multi_4.is_error(), true);
     println!("{:#?}", res_multi_4);

--- a/built-in-services/account/src/types.rs
+++ b/built-in-services/account/src/types.rs
@@ -1,0 +1,116 @@
+use serde::{Deserialize, Serialize};
+
+use bytes::Bytes;
+use protocol::fixed_codec::{FixedCodec, FixedCodecError};
+use protocol::types::{Address, Hash, Hex};
+use protocol::ProtocolResult;
+
+pub const ACCOUNT_TYPE_PUBLIC_KEY: u8 = 0;
+pub const ACCOUNT_TYPE_MULTI_SIG: u8 = 1;
+pub const MAX_PERMISSION_ACCOUNTS: u8 = 16;
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct VerifyPayload {
+    pub hash:    Hash,
+    pub sig:     Hex,
+    pub pub_key: Hex,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+pub struct VerifyResponse {
+    pub is_ok: bool,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct GetAccountPayload {
+    pub user: Address,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct GenerateAccountPayload {
+    pub accounts:  Vec<PayloadAccount>,
+    pub threshold: u8,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+pub struct GenerateAccountResponse {
+    pub accounts:  Vec<PayloadAccount>,
+    pub threshold: u8,
+    pub address:   Address,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct PayloadAccount {
+    pub address: Address,
+    pub weight:  u8,
+}
+
+pub struct Permission {
+    pub accounts:  Vec<Account>,
+    pub threshold: u8,
+}
+
+pub struct Account {
+    pub address:       Address,
+    pub account_type:  u8,
+    pub permission_id: u8,
+    pub weight:        u8,
+}
+
+impl rlp::Encodable for Account {
+    fn rlp_append(&self, s: &mut rlp::RlpStream) {
+        s.begin_list(4)
+            .append(&self.address)
+            .append(&self.account_type)
+            .append(&self.permission_id)
+            .append(&self.weight);
+    }
+}
+
+impl rlp::Decodable for Account {
+    fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
+        Ok(Account {
+            address:       rlp::decode(rlp.at(0)?.as_raw())?,
+            account_type:  rlp.at(1)?.as_val()?,
+            permission_id: rlp.at(2)?.as_val()?,
+            weight:        rlp.at(3)?.as_val()?,
+        })
+    }
+}
+
+impl FixedCodec for Account {
+    fn encode_fixed(&self) -> ProtocolResult<Bytes> {
+        Ok(Bytes::from(rlp::encode(self)))
+    }
+
+    fn decode_fixed(bytes: Bytes) -> ProtocolResult<Self> {
+        Ok(rlp::decode(bytes.as_ref()).map_err(FixedCodecError::from)?)
+    }
+}
+
+impl rlp::Encodable for Permission {
+    fn rlp_append(&self, s: &mut rlp::RlpStream) {
+        s.begin_list(2)
+            .append_list(&self.accounts)
+            .append(&self.threshold);
+    }
+}
+
+impl rlp::Decodable for Permission {
+    fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
+        Ok(Permission {
+            accounts:  rlp::decode_list(rlp.at(0)?.as_raw()),
+            threshold: rlp.at(1)?.as_val()?,
+        })
+    }
+}
+
+impl FixedCodec for Permission {
+    fn encode_fixed(&self) -> ProtocolResult<Bytes> {
+        Ok(Bytes::from(rlp::encode(self)))
+    }
+
+    fn decode_fixed(bytes: Bytes) -> ProtocolResult<Self> {
+        Ok(rlp::decode(bytes.as_ref()).map_err(FixedCodecError::from)?)
+    }
+}

--- a/built-in-services/account/src/types.rs
+++ b/built-in-services/account/src/types.rs
@@ -11,14 +11,13 @@ pub const MAX_PERMISSION_ACCOUNTS: u8 = 16;
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct VerifyPayload {
-    pub hash:    Hash,
-    pub sig:     Hex,
-    pub pub_key: Hex,
+    pub tx_hash: Hash,
+    pub witness: Bytes,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct VerifyResponse {
-    pub is_ok: bool,
+    pub address: Address,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -55,6 +54,14 @@ pub struct Account {
     pub account_type:  u8,
     pub permission_id: u8,
     pub weight:        u8,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Witness {
+    pub pubkeys:        Vec<Hex>,
+    pub signatures:     Vec<Hex>,
+    pub signature_type: u8,
+    pub sender:         Address,
 }
 
 impl rlp::Encodable for Account {

--- a/built-in-services/account/src/types.rs
+++ b/built-in-services/account/src/types.rs
@@ -12,7 +12,7 @@ pub const MAX_PERMISSION_ACCOUNTS: u8 = 16;
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct VerifyPayload {
     pub tx_hash: Hash,
-    pub witness: Bytes,
+    pub witness: String,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
@@ -33,9 +33,7 @@ pub struct GenerateAccountPayload {
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct GenerateAccountResponse {
-    pub accounts:  Vec<PayloadAccount>,
-    pub threshold: u8,
-    pub address:   Address,
+    pub address: Address,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/examples/muta-chain.rs
+++ b/examples/muta-chain.rs
@@ -1,3 +1,4 @@
+use account::AccountService;
 use asset::AssetService;
 use derive_more::{Display, From};
 use metadata::MetadataService;
@@ -18,6 +19,7 @@ impl ServiceMapping for DefaultServiceMapping {
             "asset" => Box::new(AssetService::new(sdk)) as Box<dyn Service>,
             "metadata" => Box::new(MetadataService::new(sdk)) as Box<dyn Service>,
             "util" => Box::new(UtilService::new(sdk)) as Box<dyn Service>,
+            "account" => Box::new(AccountService::new(sdk)) as Box<dyn Service>,
             _ => {
                 return Err(MappingError::NotFoundService {
                     service: name.to_owned(),
@@ -30,7 +32,12 @@ impl ServiceMapping for DefaultServiceMapping {
     }
 
     fn list_service_name(&self) -> Vec<String> {
-        vec!["asset".to_owned(), "metadata".to_owned(), "util".to_owned()]
+        vec![
+            "asset".to_owned(),
+            "metadata".to_owned(),
+            "util".to_owned(),
+            "account".to_owned(),
+        ]
     }
 }
 

--- a/protocol/src/traits/mod.rs
+++ b/protocol/src/traits/mod.rs
@@ -5,6 +5,7 @@ mod executor;
 mod mempool;
 mod network;
 mod storage;
+mod witness;
 
 pub use api::APIAdapter;
 pub use binding::{
@@ -24,3 +25,4 @@ pub use network::{Gossip, MessageCodec, MessageHandler, PeerTrust, Priority, Rpc
 pub use storage::{Storage, StorageAdapter, StorageBatchModify, StorageCategory, StorageSchema};
 
 pub use creep::{Cloneable, Context};
+pub use witness::Witness;

--- a/protocol/src/traits/witness.rs
+++ b/protocol/src/traits/witness.rs
@@ -1,0 +1,17 @@
+use crate::types::Address;
+use crate::ProtocolResult;
+use bytes::Bytes;
+
+pub trait Witness: Sized + Send {
+    fn as_bytes(&self) -> ProtocolResult<Bytes>;
+    fn from_bytes(bytes: Bytes) -> ProtocolResult<Self>;
+    fn as_string(&self) -> ProtocolResult<String>;
+    fn from_string(s: &str) -> ProtocolResult<Self>;
+
+    fn from_single_sig_hex(sig: String, pub_key: String) -> ProtocolResult<Self>;
+    fn from_multi_sig_hex(
+        sender: Address,
+        sigs: Vec<String>,
+        pub_keys: Vec<String>,
+    ) -> ProtocolResult<Self>;
+}

--- a/protocol/src/types/mod.rs
+++ b/protocol/src/types/mod.rs
@@ -36,6 +36,9 @@ pub enum TypesError {
 
     #[display(fmt = "Hex should start with 0x")]
     HexPrefix,
+
+    #[display(fmt = "Invalid Witness")]
+    InvalidWitness,
 }
 
 impl Error for TypesError {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
feature
**What this PR does / why we need it**:
- generate_account, generate an account of multisig which need sigs to be verfied
- get_account_from_address
- verify_signature,when tx----> mempool , mempool----->verify_signature of account service

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
```
// the data which is provided by user
#[derive(Deserialize, Serialize, Clone, Debug)]
pub struct GenerateAccountPayload {
    pub accounts:  Vec<PayloadAccount>,
    pub threshold: u8,
}


// the data which is stored in stateDB, Account.permission_id and account_type are used for expansion later,you can ignore this 
pub struct Permission {
    pub accounts:  Vec<Account>,
    pub threshold: u8,
}

pub struct Account {
    pub address:       Address,
    pub account_type:  u8,
    pub permission_id: u8,
    pub weight:        u8,
}
```