### PR TITLE
chore(db): export full configs from lib

### DIFF
--- a/core/storage/src/adapter/rocks.rs
+++ b/core/storage/src/adapter/rocks.rs
@@ -12,8 +12,8 @@ use protocol::Bytes;
 use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 pub struct Config {
-    options:             Options,
-    block_based_options: BlockBasedOptions,
+    pub options:             Options,
+    pub block_based_options: BlockBasedOptions,
 }
 
 impl Config {
@@ -21,11 +21,11 @@ impl Config {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
-        opts.set_max_open_files(64);
-        return Self {
-            options: opts,
+        opts.set_max_open_files(256);
+        Self {
+            options:             opts,
             block_based_options: BlockBasedOptions::default(),
-        };
+        }
     }
 
     pub fn suggest() -> Self {
@@ -33,16 +33,19 @@ impl Config {
         // https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#other-general-options
         cfgs.options.set_max_background_compactions(4);
         cfgs.options.set_max_background_flushes(2);
-        cfgs.options.set_bytes_per_sync(1048576);
+        cfgs.options.set_bytes_per_sync(1_048_576);
         cfgs.block_based_options.set_block_size(16 * 1024);
         cfgs.block_based_options
             .set_cache_index_and_filter_blocks(true);
+
         // https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#block-cache-size
         // We recommend that this should be about 1/3 of your total memory budget.
-        cfgs.block_based_options.set_lru_cache(512 << 20);
+        // cfgs.block_based_options.set_lru_cache(512 << 20);
+
         // [TODO] https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#bloom-filters
         // Since did not make a good decision.
-        return cfgs;
+
+        cfgs
     }
 }
 

--- a/core/storage/src/tests/adapter.rs
+++ b/core/storage/src/tests/adapter.rs
@@ -2,28 +2,36 @@ use protocol::traits::{StorageAdapter, StorageBatchModify};
 use protocol::types::Hash;
 
 use crate::adapter::memory::MemoryAdapter;
-use crate::adapter::rocks::{RocksAdapter, Config};
+use crate::adapter::rocks::{Config, RocksAdapter};
 use crate::tests::{get_random_bytes, mock_signed_tx};
 use crate::TransactionSchema;
 
 #[test]
 fn test_adapter_insert() {
     adapter_insert_test(MemoryAdapter::new());
-    adapter_insert_test(RocksAdapter::new("rocksdb/test_adapter_insert".to_string(), Config::default()).unwrap())
+    adapter_insert_test(
+        RocksAdapter::new("rocksdb/test_adapter_insert".to_string(), Config::default()).unwrap(),
+    )
 }
 
 #[test]
 fn test_adapter_batch_modify() {
     adapter_batch_modify_test(MemoryAdapter::new());
     adapter_batch_modify_test(
-        RocksAdapter::new("rocksdb/test_adapter_batch_modify".to_string(), Config::default()).unwrap(),
+        RocksAdapter::new(
+            "rocksdb/test_adapter_batch_modify".to_string(),
+            Config::default(),
+        )
+        .unwrap(),
     )
 }
 
 #[test]
 fn test_adapter_remove() {
     adapter_remove_test(MemoryAdapter::new());
-    adapter_remove_test(RocksAdapter::new("rocksdb/test_adapter_remove".to_string(), Config::default()).unwrap())
+    adapter_remove_test(
+        RocksAdapter::new("rocksdb/test_adapter_remove".to_string(), Config::default()).unwrap(),
+    )
 }
 
 fn adapter_insert_test(db: impl StorageAdapter) {

--- a/core/storage/src/tests/adapter.rs
+++ b/core/storage/src/tests/adapter.rs
@@ -2,28 +2,28 @@ use protocol::traits::{StorageAdapter, StorageBatchModify};
 use protocol::types::Hash;
 
 use crate::adapter::memory::MemoryAdapter;
-use crate::adapter::rocks::RocksAdapter;
+use crate::adapter::rocks::{RocksAdapter, Config};
 use crate::tests::{get_random_bytes, mock_signed_tx};
 use crate::TransactionSchema;
 
 #[test]
 fn test_adapter_insert() {
     adapter_insert_test(MemoryAdapter::new());
-    adapter_insert_test(RocksAdapter::new("rocksdb/test_adapter_insert".to_string(), 64).unwrap())
+    adapter_insert_test(RocksAdapter::new("rocksdb/test_adapter_insert".to_string(), Config::default()).unwrap())
 }
 
 #[test]
 fn test_adapter_batch_modify() {
     adapter_batch_modify_test(MemoryAdapter::new());
     adapter_batch_modify_test(
-        RocksAdapter::new("rocksdb/test_adapter_batch_modify".to_string(), 64).unwrap(),
+        RocksAdapter::new("rocksdb/test_adapter_batch_modify".to_string(), Config::default()).unwrap(),
     )
 }
 
 #[test]
 fn test_adapter_remove() {
     adapter_remove_test(MemoryAdapter::new());
-    adapter_remove_test(RocksAdapter::new("rocksdb/test_adapter_remove".to_string(), 64).unwrap())
+    adapter_remove_test(RocksAdapter::new("rocksdb/test_adapter_remove".to_string(), Config::default()).unwrap())
 }
 
 fn adapter_insert_test(db: impl StorageAdapter) {

--- a/core/storage/src/tests/storage.rs
+++ b/core/storage/src/tests/storage.rs
@@ -105,6 +105,7 @@ fn test_storage_wal_insert() {
 }
 
 #[test]
+#[ignore]
 fn test_storage_stat() {
     fs::remove_dir_all("rocksdb/test_adapter_stat").unwrap();
     let adapter = Arc::new(

--- a/core/storage/src/tests/storage.rs
+++ b/core/storage/src/tests/storage.rs
@@ -1,10 +1,13 @@
+use std::fs;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use protocol::fixed_codec::FixedCodec;
 use protocol::traits::Storage;
 use protocol::types::Hash;
 
 use crate::adapter::memory::MemoryAdapter;
+use crate::adapter::rocks::{Config, RocksAdapter};
 use crate::tests::{get_random_bytes, mock_block, mock_proof, mock_receipt, mock_signed_tx};
 use crate::ImplStorage;
 
@@ -99,4 +102,69 @@ fn test_storage_wal_insert() {
     exec!(storage.update_overlord_wal(info.clone()));
     let info_2 = exec!(storage.load_overlord_wal());
     assert_eq!(info, info_2);
+}
+
+#[test]
+fn test_storage_stat() {
+    fs::remove_dir_all("rocksdb/test_adapter_stat").unwrap();
+    let adapter = Arc::new(
+        RocksAdapter::new("rocksdb/test_adapter_stat".to_string(), Config::suggest()).unwrap(),
+    );
+    let storage = Arc::new(ImplStorage::new(Arc::clone(&adapter)));
+
+    let loop_num = 10;
+    let size = 1000000;
+    let rand_size = 500; // 500 * 10 = 5000
+
+    let mut head_5000_hashes = Vec::new();
+    let mut tail_5000_hashes = Vec::new();
+    let mut rand_5000_hashes = Vec::new();
+
+    for i in 0..loop_num {
+        let mut transactions = Vec::new();
+        let mut hashes = Vec::new();
+
+        for _ in 0..size {
+            let tx_hash = Hash::digest(get_random_bytes(10));
+            hashes.push(tx_hash.clone());
+            let transaction = mock_signed_tx(tx_hash.clone());
+            transactions.push(transaction);
+        }
+        if i == 0 {
+            head_5000_hashes = hashes[0..5000].to_vec();
+        }
+        if i == loop_num - 1 {
+            tail_5000_hashes = hashes[size - 5000..size].to_vec();
+        }
+        rand_5000_hashes.extend_from_slice(&hashes[0..rand_size]);
+
+        let now = SystemTime::now();
+        exec!(storage.insert_transactions(transactions.clone()));
+        println!(
+            "insert {:?} tx spent {:?}ms",
+            size,
+            now.elapsed().unwrap().as_millis()
+        );
+    }
+
+    let now_head = SystemTime::now();
+    exec!(storage.get_transactions(head_5000_hashes.to_vec()));
+    println!(
+        "get head 5000 tx spent {:?}ms",
+        now_head.elapsed().unwrap().as_millis()
+    );
+
+    let now_tail = SystemTime::now();
+    exec!(storage.get_transactions(tail_5000_hashes.to_vec()));
+    println!(
+        "get tail 5000 tx spent {:?}ms",
+        now_tail.elapsed().unwrap().as_millis()
+    );
+
+    let now_rand = SystemTime::now();
+    exec!(storage.get_transactions(rand_5000_hashes.to_vec()));
+    println!(
+        "get rand 5000 tx spent {:?}ms",
+        now_rand.elapsed().unwrap().as_millis()
+    );
 }

--- a/core/storage/src/tests/storage.rs
+++ b/core/storage/src/tests/storage.rs
@@ -114,7 +114,7 @@ fn test_storage_stat() {
     let storage = Arc::new(ImplStorage::new(Arc::clone(&adapter)));
 
     let loop_num = 10;
-    let size = 1000000;
+    let size = 1_000_000;
     let rand_size = 500; // 500 * 10 = 5000
 
     let mut head_5000_hashes = Vec::new();

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -42,4 +42,4 @@ metrics = true
 # modules_level = { "overlord::state::process" = "debug", core_consensus = "error" }
 
 [rocksdb]
-max_open_files = 64
+max_open_files = 256

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -68,7 +68,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
 
     // Init Block db
     let path_block = config.data_path_for_block();
-    let mut rocks_config = RocksConfig::suggest();
+    let mut rocks_config = RocksConfig::default();
     rocks_config
         .options
         .set_max_open_files(config.rocksdb.max_open_files);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**

chore

**What this PR does / why we need it**:

- The `core_storage` user can modify most rocksdb options now, by `pub Config` from library.
- Add two built-in configs: `Config::default()` and `Config::suggest()` from [https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#other-general-options](https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#other-general-options)
- Use 256 as the default max_open_file value. (Since we have two rocksdb instances, using 512 will exceed the limit of 1024)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

From the performance test, using suggest configuration has not changed much.