### PR TITLE
fix(executor): tx events aren't cleared on execution error

### DIFF
--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -355,14 +355,19 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
                 )?;
 
                 let exec_resp = self.catch_call(context.clone(), ExecType::Write)?;
+                let events = if exec_resp.is_error() {
+                    Vec::new()
+                } else {
+                    context.get_events()
+                };
 
                 Ok(Receipt {
-                    state_root:  MerkleRoot::from_empty(),
-                    height:      context.get_current_height(),
-                    tx_hash:     stx.tx_hash.clone(),
+                    state_root: MerkleRoot::from_empty(),
+                    height: context.get_current_height(),
+                    tx_hash: stx.tx_hash.clone(),
                     cycles_used: context.get_cycles_used(),
-                    events:      context.get_events(),
-                    response:    ReceiptResponse {
+                    events,
+                    response: ReceiptResponse {
                         service_name: context.get_service_name().to_owned(),
                         method:       context.get_service_method().to_owned(),
                         response:     exec_resp,

--- a/framework/src/executor/tests/test_service.rs
+++ b/framework/src/executor/tests/test_service.rs
@@ -59,6 +59,27 @@ impl<SDK: ServiceSDK> TestService<SDK> {
 
     #[cycles(210_00)]
     #[write]
+    fn test_revert_event(
+        &mut self,
+        ctx: ServiceContext,
+        _: TestWritePayload,
+    ) -> ServiceResponse<TestWriteResponse> {
+        ServiceResponse::from_error(111, "error".to_owned())
+    }
+
+    #[cycles(210_00)]
+    #[write]
+    fn test_event(
+        &mut self,
+        ctx: ServiceContext,
+        _: TestWritePayload,
+    ) -> ServiceResponse<TestWriteResponse> {
+        ctx.emit_event("test".to_owned());
+        ServiceResponse::from_succeed(TestWriteResponse::default())
+    }
+
+    #[cycles(210_00)]
+    #[write]
     fn test_service_call_invoke_hook_only_once(
         &mut self,
         ctx: ServiceContext,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
fix

**What this PR does / why we need it**:
Transaction events aren't cleared on execution error. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # 18

**Special notes for your reviewer**:
