### PR TITLE
feat(executor): allow cancel execution units through context

### DIFF
--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -107,19 +107,35 @@ impl<DB: TrieDB> CommitHooks<DB> {
     }
 
     // bagua kan 101 :)
-    fn kan<H: FnOnce() -> R, R>(states: Rc<ServiceStateMap<DB>>, hook: H) -> ProtocolResult<()> {
+    fn kan<H: FnOnce() -> R, R>(
+        context: ServiceContext,
+        states: Rc<ServiceStateMap<DB>>,
+        hook: H,
+    ) -> ProtocolResult<()> {
         match panic::catch_unwind(AssertUnwindSafe(hook)) {
-            Ok(_) => states.stash(),
+            Ok(_) if !context.canceled() => states.stash(),
+            Ok(_) => {
+                // An reason must be passed to cancel
+                let reason = context.cancel_reason();
+                debug_assert!(reason.is_some());
+
+                states.revert_cache()?;
+
+                Err(ExecutorError::Canceled {
+                    service: context.get_service_name().to_owned(),
+                    reason,
+                }
+                .into())
+            }
             Err(_) => states.revert_cache(),
         }
     }
 }
 
 impl<DB: TrieDB> TxHooks for CommitHooks<DB> {
-    // TODO: support abort execution
     fn before(&mut self, _context: Context, service_context: ServiceContext) -> ProtocolResult<()> {
         for hook in self.inner.iter_mut() {
-            Self::kan(Rc::clone(&self.states), || {
+            Self::kan(service_context.clone(), Rc::clone(&self.states), || {
                 hook.tx_hook_before_(service_context.clone())
             })?;
         }
@@ -129,7 +145,7 @@ impl<DB: TrieDB> TxHooks for CommitHooks<DB> {
 
     fn after(&mut self, _context: Context, service_context: ServiceContext) -> ProtocolResult<()> {
         for hook in self.inner.iter_mut() {
-            Self::kan(Rc::clone(&self.states), || {
+            Self::kan(service_context.clone(), Rc::clone(&self.states), || {
                 hook.tx_hook_after_(service_context.clone())
             })?;
         }
@@ -512,6 +528,12 @@ pub enum ExecutorError {
     QueryService(String),
     #[display(fmt = "Call service failed: {:?}", _0)]
     CallService(String),
+
+    #[display(fmt = "service {} canceled {:?}", service, reason)]
+    Canceled {
+        service: String,
+        reason:  Option<String>,
+    },
 }
 
 impl std::error::Error for ExecutorError {}

--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -115,11 +115,11 @@ impl<DB: TrieDB> CommitHooks<DB> {
         match panic::catch_unwind(AssertUnwindSafe(hook)) {
             Ok(_) if !context.canceled() => states.stash(),
             Ok(_) => {
+                states.stash()?;
+
                 // An reason must be passed to cancel
                 let reason = context.cancel_reason();
                 debug_assert!(reason.is_some());
-
-                states.revert_cache()?;
 
                 Err(ExecutorError::Canceled {
                     service: context.get_service_name().to_owned(),

--- a/framework/src/executor/tests/mod.rs
+++ b/framework/src/executor/tests/mod.rs
@@ -494,7 +494,7 @@ fn test_tx_hook_before_cancel() {
     let caller = Address::from_hex("0xf8389d774afdad8755ef8e629e5a154fddc6325a").unwrap();
 
     let before = read!(executor, &params, &caller, r#""before""#);
-    assert_eq!(before.succeed_data, r#""""#);
+    assert_eq!(before.succeed_data, r#""before""#);
 
     let tx_hook_before_cancel = read!(executor, &params, &caller, r#""tx_hook_before_cancel""#);
     assert_eq!(tx_hook_before_cancel.succeed_data, r#""""#);

--- a/framework/src/executor/tests/mod.rs
+++ b/framework/src/executor/tests/mod.rs
@@ -25,6 +25,20 @@ use protocol::ProtocolResult;
 use crate::executor::ServiceExecutor;
 use test_service::TestService;
 
+macro_rules! read {
+    ($executor:expr, $params:expr, $caller:expr, $payload:expr) => {{
+        let request = TransactionRequest {
+            service_name: "test".to_owned(),
+            method:       "test_read".to_owned(),
+            payload:      $payload.to_owned(),
+        };
+
+        $executor
+            .read($params, $caller, 1, &request)
+            .expect(&format!("read {}", $payload))
+    }};
+}
+
 pub const PUB_KEY_STR: &str = "031288a6788678c25952eba8693b2f278f66e2187004b64ac09416d07f83f96d5b";
 
 #[test]
@@ -475,6 +489,7 @@ fn test_tx_hook_before_cancel() {
         height:       1,
         timestamp:    0,
         cycles_limit: std::u64::MAX,
+        proposer:     Address::from_hash(Hash::from_empty()).unwrap(),
     };
 
     let mut stx = mock_signed_tx();
@@ -531,6 +546,7 @@ fn test_tx_hook_after_cancel() {
         height:       1,
         timestamp:    0,
         cycles_limit: std::u64::MAX,
+        proposer:     Address::from_hash(Hash::from_empty()).unwrap(),
     };
 
     let mut stx = mock_signed_tx();

--- a/framework/src/executor/tests/test_service.rs
+++ b/framework/src/executor/tests/test_service.rs
@@ -110,6 +110,35 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         ServiceResponse::from_succeed(())
     }
 
+    #[cycles(210_00)]
+    #[write]
+    fn tx_hook_before_cancel(
+        &mut self,
+        ctx: ServiceContext,
+        _payload: String,
+    ) -> ServiceResponse<()> {
+        self.sdk.set_value(
+            "tx_hook_before_cancel".to_owned(),
+            "tx_hook_before_cancel".to_owned(),
+        );
+        ServiceResponse::from_succeed(())
+    }
+
+    #[cycles(210_00)]
+    #[write]
+    fn tx_hook_after_cancel(
+        &mut self,
+        ctx: ServiceContext,
+        _payload: String,
+    ) -> ServiceResponse<()> {
+        self.sdk.set_value(
+            "tx_hook_after_cancel".to_owned(),
+            "tx_hook_after_cancel".to_owned(),
+        );
+        ctx.cancel("tx_hook_after_cancel".to_owned());
+        ServiceResponse::from_error(1, "tx_hook_after_cancel".to_owned())
+    }
+
     #[tx_hook_before]
     fn test_tx_hook_before(&mut self, ctx: ServiceContext) {
         if ctx.get_service_name() == "test"
@@ -120,6 +149,10 @@ impl<SDK: ServiceSDK> TestService<SDK> {
 
         if ctx.get_service_method() == "tx_hook_before_panic" {
             panic!("tx hook before");
+        }
+
+        if ctx.get_service_method() == "tx_hook_before_cancel" {
+            ctx.cancel("tx_hook_before_cancel".to_owned());
         }
 
         self.sdk.set_value("before".to_owned(), "before".to_owned());
@@ -135,6 +168,10 @@ impl<SDK: ServiceSDK> TestService<SDK> {
 
         if ctx.get_service_method() == "tx_hook_after_panic" {
             panic!("tx hook before");
+        }
+
+        if ctx.get_service_method() == "tx_hook_after_cancel" {
+            ctx.cancel("tx_hook_after_cancel".to_owned());
         }
 
         self.sdk.set_value("after".to_owned(), "after".to_owned());


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
feat

**What this PR does / why we need it**:

Right now, there is not way to cancel a tx execution. This pr provides a way to do
it through ```ServiceContext```.

Execution Flows: ( PR #316 

tx hook before units -----> tx unit -----> tx hook after units

Once canceled, following execution unit will not be executed.
Current execution changes will still be saved. We can still revert
those changes using panic.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
Require PR #316 