### PR TITLE
refactor(executor): add proposer field in executor params

### DIFF
--- a/binding-macro/tests/mod.rs
+++ b/binding-macro/tests/mod.rs
@@ -418,6 +418,7 @@ fn mock_executor_params() -> ExecutorParams {
         height:       9,
         timestamp:    99,
         cycles_limit: 99999,
+        proposer:     Address::from_hash(Hash::from_empty()).unwrap(),
     }
 }
 

--- a/core/api/src/adapter/mod.rs
+++ b/core/api/src/adapter/mod.rs
@@ -153,6 +153,7 @@ impl<
             height,
             timestamp: block.header.timestamp,
             cycles_limit,
+            proposer: block.header.proposer,
         };
         executor.read(&params, &caller, cycles_price, &TransactionRequest {
             service_name,

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -127,7 +127,7 @@ where
         order_root: MerkleRoot,
         height: u64,
         cycles_price: u64,
-        coinbase: Address,
+        proposer: Address,
         block_hash: Hash,
         signed_txs: Vec<SignedTransaction>,
         cycles_limit: u64,
@@ -141,7 +141,7 @@ where
             block_hash,
             signed_txs,
             order_root,
-            coinbase,
+            proposer,
             cycles_limit,
             timestamp,
         };
@@ -461,6 +461,7 @@ where
         state_root: MerkleRoot,
         height: u64,
         timestamp: u64,
+        proposer: Address,
     ) -> ProtocolResult<Metadata> {
         let executor = EF::from_root(
             state_root.clone(),
@@ -476,6 +477,7 @@ where
             height,
             timestamp,
             cycles_limit: u64::max_value(),
+            proposer,
         };
         let exec_resp = executor.read(&params, &caller, 1, &TransactionRequest {
             service_name: "metadata".to_string(),
@@ -541,6 +543,7 @@ where
             previous_block.header.state_root.clone(),
             previous_block.header.height,
             previous_block.header.timestamp,
+            previous_block.header.proposer,
         )?;
 
         let authority_map = previous_metadata
@@ -654,6 +657,7 @@ where
             previous_block.header.state_root.clone(),
             previous_block.header.height,
             previous_block.header.timestamp,
+            previous_block.header.proposer,
         )?;
 
         let mut authority_list = metadata
@@ -920,6 +924,7 @@ where
             height,
             timestamp: info.timestamp,
             cycles_limit: info.cycles_limit,
+            proposer: info.proposer,
         };
         let resp = executor.exec(ctx.clone(), &exec_params, &txs)?;
         common_apm::metrics::consensus::CONSENSUS_TIME_HISTOGRAM_VEC_STATIC

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -371,6 +371,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             pill.block.header.state_root.clone(),
             pill.block.header.height,
             pill.block.header.timestamp,
+            pill.block.header.proposer.clone(),
         )?;
         info!(
             "[consensus]: validator of height {} is {:?}",
@@ -514,6 +515,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             old_block.header.state_root.clone(),
             old_block.header.timestamp,
             old_block.header.height,
+            old_block.header.proposer,
         )?;
         let mut old_validators = old_metadata
             .verifier_list
@@ -581,7 +583,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
         ctx: Context,
         order_root: MerkleRoot,
         height: u64,
-        address: Address,
+        proposer: Address,
         timestamp: u64,
         block_hash: Hash,
         txs: Vec<SignedTransaction>,
@@ -595,7 +597,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
                 order_root,
                 height,
                 status.cycles_price,
-                address,
+                proposer,
                 block_hash,
                 txs,
                 status.cycles_limit,

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -326,6 +326,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
             block.header.state_root.clone(),
             block.header.height,
             block.header.timestamp,
+            block.header.proposer.clone(),
         )?;
 
         self.crypto
@@ -440,6 +441,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
             height: rich_block.block.header.height,
             timestamp: rich_block.block.header.timestamp,
             cycles_limit,
+            proposer: rich_block.block.header.proposer,
         };
         let resp = self
             .adapter

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -280,6 +280,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
         _state_root: MerkleRoot,
         _height: u64,
         _timestamp: u64,
+        _proposer: Address,
     ) -> ProtocolResult<Metadata> {
         Ok(Metadata {
             chain_id:        Hash::from_empty(),
@@ -343,6 +344,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             previous_block.header.state_root.clone(),
             previous_block.header.height,
             previous_block.header.timestamp,
+            previous_block.header.proposer,
         )?;
 
         let authority_map = previous_metadata
@@ -447,6 +449,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             previous_block.header.state_root.clone(),
             previous_block.header.height,
             previous_block.header.timestamp,
+            previous_block.header.proposer,
         )?;
 
         let mut authority_list = metadata

--- a/core/consensus/src/util.rs
+++ b/core/consensus/src/util.rs
@@ -161,7 +161,7 @@ pub struct ExecuteInfo {
     pub signed_txs:   Vec<SignedTransaction>,
     pub order_root:   MerkleRoot,
     pub cycles_price: u64,
-    pub coinbase:     Address,
+    pub proposer:     Address,
     pub timestamp:    u64,
     pub cycles_limit: u64,
 }

--- a/framework/src/executor/tests/mod.rs
+++ b/framework/src/executor/tests/mod.rs
@@ -52,6 +52,7 @@ fn test_create_genesis() {
         height:       1,
         timestamp:    0,
         cycles_limit: std::u64::MAX,
+        proposer:     Address::from_hash(Hash::from_empty()).unwrap(),
     };
     let caller = Address::from_hex("0xf8389d774afdad8755ef8e629e5a154fddc6325a").unwrap();
     let request = TransactionRequest {
@@ -95,6 +96,7 @@ fn test_exec() {
         height:       1,
         timestamp:    0,
         cycles_limit: std::u64::MAX,
+        proposer:     Address::from_hash(Hash::from_empty()).unwrap(),
     };
 
     let stx = mock_signed_tx();
@@ -137,6 +139,7 @@ fn test_emit_event() {
         height:       1,
         timestamp:    0,
         cycles_limit: std::u64::MAX,
+        proposer:     Address::from_hash(Hash::from_empty()).unwrap(),
     };
 
     let mut stx = mock_signed_tx();
@@ -186,6 +189,7 @@ fn test_revert_event_on_exec_error() {
         height:       1,
         timestamp:    0,
         cycles_limit: std::u64::MAX,
+        proposer:     Address::from_hash(Hash::from_empty()).unwrap(),
     };
 
     let mut stx = mock_signed_tx();
@@ -234,6 +238,7 @@ fn test_tx_hook() {
         height:       1,
         timestamp:    0,
         cycles_limit: std::u64::MAX,
+        proposer:     Address::from_hash(Hash::from_empty()).unwrap(),
     };
 
     // no tx hook
@@ -315,6 +320,7 @@ fn bench_execute(b: &mut Bencher) {
             height:       1,
             timestamp:    0,
             cycles_limit: std::u64::MAX,
+            proposer:     Address::from_hash(Hash::from_empty()).unwrap(),
         };
         let txs = txs.clone();
         executor.exec(Context::new(), &params, &txs).unwrap();

--- a/framework/src/executor/tests/service_call_service.rs
+++ b/framework/src/executor/tests/service_call_service.rs
@@ -12,7 +12,7 @@ use protocol::traits::{
     Context, Executor, ExecutorParams, Service, ServiceMapping, ServiceResponse, ServiceSDK,
 };
 use protocol::types::{
-    Genesis, Hash, RawTransaction, ServiceContext, SignedTransaction, TransactionRequest,
+    Address, Genesis, Hash, RawTransaction, ServiceContext, SignedTransaction, TransactionRequest,
 };
 use protocol::ProtocolResult;
 
@@ -48,6 +48,7 @@ fn test_service_call_service() {
         height:       1,
         timestamp:    0,
         cycles_limit: std::u64::MAX,
+        proposer:     Address::from_hash(Hash::from_empty()).unwrap(),
     };
 
     let raw = RawTransaction {

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -124,6 +124,7 @@ pub trait CommonConsensusAdapter: Send + Sync {
         state_root: MerkleRoot,
         height: u64,
         timestamp: u64,
+        proposer: Address,
     ) -> ProtocolResult<Metadata>;
 
     fn report_bad(&self, ctx: Context, feedback: TrustFeedback);
@@ -193,7 +194,7 @@ pub trait ConsensusAdapter: CommonConsensusAdapter + Send + Sync {
         order_root: MerkleRoot,
         height: u64,
         cycles_price: u64,
-        coinbase: Address,
+        proposer: Address,
         block_hash: Hash,
         signed_txs: Vec<SignedTransaction>,
         cycles_limit: u64,

--- a/protocol/src/traits/executor.rs
+++ b/protocol/src/traits/executor.rs
@@ -21,6 +21,7 @@ pub struct ExecutorParams {
     pub height:       u64,
     pub timestamp:    u64,
     pub cycles_limit: u64,
+    pub proposer:     Address,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
refactor

**What this PR does / why we need it**:
Add `proposer` field in `ExecutorParams` struct. So that service can get the proposer address when developing after block hook.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
