### PR TITLE
refactor(service): calculate multi-signature recursion depth

### DIFF
--- a/built-in-services/multi-signature/Cargo.toml
+++ b/built-in-services/multi-signature/Cargo.toml
@@ -15,6 +15,7 @@ common-crypto = { path = "../../common/crypto" }
 derive_more = "0.99"
 hasher = { version="0.1", features = ["hash-keccak"] }
 hex = "0.4"
+lazy_static = "1.4"
 muta-codec-derive = "0.2"
 protocol = { path = "../../protocol", package = "muta-protocol" }
 rand = "0.7"

--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -419,13 +419,6 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
             );
         }
 
-        if pubkeys.len() > MAX_PERMISSION_ACCOUNTS as usize {
-            return ServiceResponse::<()>::from_error(
-                115,
-                "len of signatures must be [1,16]".to_owned(),
-            );
-        }
-
         if pubkeys.len() == 1 {
             if let Ok(addr) = Address::from_pubkey_bytes(pubkeys[0].clone()) {
                 if addr == payload.sender {

--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -24,6 +24,10 @@ use crate::types::{
 const MAX_MULTI_SIGNATURE_RECURSION_DEPTH: u8 = 8;
 const MAX_PERMISSION_ACCOUNTS: u8 = 16;
 
+lazy_static::lazy_static! {
+    static ref ADEPTIVE_ADDRESS: Address = Address::from_hex("0xffffffffffffffffffff").unwrap();
+}
+
 pub struct MultiSignatureService<SDK> {
     sdk: SDK,
 }
@@ -63,9 +67,15 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
             })
             .collect::<Vec<_>>();
 
+        let owner = if payload.owner == ADEPTIVE_ADDRESS.clone() {
+            address.clone()
+        } else {
+            payload.owner.clone()
+        };
+
         let permission = MultiSigPermission {
             accounts,
-            owner: payload.owner,
+            owner,
             threshold: payload.threshold,
             memo: payload.memo,
         };
@@ -132,9 +142,15 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
                 })
                 .collect::<Vec<_>>();
 
+            let owner = if payload.owner == ADEPTIVE_ADDRESS.clone() {
+                address.clone()
+            } else {
+                payload.owner.clone()
+            };
+
             let permission = MultiSigPermission {
                 accounts,
-                owner: payload.owner,
+                owner,
                 threshold: payload.threshold,
                 memo: payload.memo,
             };

--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -25,7 +25,7 @@ const MAX_MULTI_SIGNATURE_RECURSION_DEPTH: u8 = 8;
 const MAX_PERMISSION_ACCOUNTS: u8 = 16;
 
 lazy_static::lazy_static! {
-    static ref ADEPTIVE_ADDRESS: Address = Address::from_hex("0xffffffffffffffffffffffffffffffffffffffff").unwrap();
+    pub static ref ADEPTIVE_ADDRESS: Address = Address::from_hex("0xffffffffffffffffffffffffffffffffffffffff").unwrap();
 }
 
 pub struct MultiSignatureService<SDK> {

--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -25,7 +25,7 @@ const MAX_MULTI_SIGNATURE_RECURSION_DEPTH: u8 = 8;
 const MAX_PERMISSION_ACCOUNTS: u8 = 16;
 
 lazy_static::lazy_static! {
-    static ref ADEPTIVE_ADDRESS: Address = Address::from_hex("0xffffffffffffffffffff").unwrap();
+    static ref ADEPTIVE_ADDRESS: Address = Address::from_hex("0xffffffffffffffffffffffffffffffffffffffff").unwrap();
 }
 
 pub struct MultiSignatureService<SDK> {

--- a/built-in-services/multi-signature/src/tests/curd_test.rs
+++ b/built-in-services/multi-signature/src/tests/curd_test.rs
@@ -177,9 +177,9 @@ fn test_update_account() {
         .map(|pair| to_multi_sig_account(pair.1.clone()))
         .collect::<Vec<_>>();
     let multi_sig_address = service
-        .generate_account(context.clone(), GenerateMultiSigAccountPayload {
+        .generate_account(context, GenerateMultiSigAccountPayload {
             owner:            owner_address.clone(),
-            addr_with_weight: account_pubkeys.clone(),
+            addr_with_weight: account_pubkeys,
             threshold:        4,
             memo:             String::new(),
         })
@@ -187,8 +187,8 @@ fn test_update_account() {
         .address;
 
     let new_owner = gen_one_keypair();
-    let new_owner_address = Address::from_pubkey_bytes(new_owner.1.clone()).unwrap();
-    let context = mock_context(cycles_limit, owner_address.clone());
+    let new_owner_address = Address::from_pubkey_bytes(new_owner.1).unwrap();
+    let context = mock_context(cycles_limit, owner_address);
     let account_pubkeys = vec![AddressWithWeight {
         address: multi_sig_address.clone(),
         weight:  1u8,

--- a/built-in-services/multi-signature/src/tests/curd_test.rs
+++ b/built-in-services/multi-signature/src/tests/curd_test.rs
@@ -78,7 +78,7 @@ fn test_set_threshold() {
 
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
-    let owner_address = Address::from_pubkey_bytes(owner.1.clone()).unwrap();
+    let owner_address = Address::from_pubkey_bytes(owner.1).unwrap();
     let keypairs = gen_keypairs(4);
     let account_pubkeys = keypairs
         .iter()
@@ -120,7 +120,7 @@ fn test_add_account() {
 
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
-    let owner_address = Address::from_pubkey_bytes(owner.1.clone()).unwrap();
+    let owner_address = Address::from_pubkey_bytes(owner.1).unwrap();
     let keypairs = gen_keypairs(15);
     let mut account_pubkeys = keypairs
         .iter()
@@ -175,7 +175,7 @@ fn test_set_weight() {
 
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
-    let owner_address = Address::from_pubkey_bytes(owner.1.clone()).unwrap();
+    let owner_address = Address::from_pubkey_bytes(owner.1).unwrap();
     let keypairs = gen_keypairs(4);
     let mut account_pubkeys = keypairs
         .iter()
@@ -231,7 +231,7 @@ fn test_remove_account() {
 
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
-    let owner_address = Address::from_pubkey_bytes(owner.1.clone()).unwrap();
+    let owner_address = Address::from_pubkey_bytes(owner.1).unwrap();
     let keypairs = gen_keypairs(4);
     let mut account_pubkeys = keypairs
         .iter()

--- a/built-in-services/multi-signature/src/tests/curd_test.rs
+++ b/built-in-services/multi-signature/src/tests/curd_test.rs
@@ -73,12 +73,10 @@ fn test_generate_multi_signature() {
 #[test]
 fn test_set_threshold() {
     let cycles_limit = 1024 * 1024 * 1024; // 1073741824
-    let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
-    let context = mock_context(cycles_limit, caller);
-
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
     let owner_address = Address::from_pubkey_bytes(owner.1).unwrap();
+    let context = mock_context(cycles_limit, owner_address.clone());
     let keypairs = gen_keypairs(4);
     let account_pubkeys = keypairs
         .iter()
@@ -115,12 +113,10 @@ fn test_set_threshold() {
 #[test]
 fn test_add_account() {
     let cycles_limit = 1024 * 1024 * 1024; // 1073741824
-    let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
-    let context = mock_context(cycles_limit, caller);
-
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
     let owner_address = Address::from_pubkey_bytes(owner.1).unwrap();
+    let context = mock_context(cycles_limit, owner_address.clone());
     let keypairs = gen_keypairs(15);
     let mut account_pubkeys = keypairs
         .iter()
@@ -170,12 +166,10 @@ fn test_add_account() {
 #[test]
 fn test_set_weight() {
     let cycles_limit = 1024 * 1024 * 1024; // 1073741824
-    let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
-    let context = mock_context(cycles_limit, caller);
-
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
     let owner_address = Address::from_pubkey_bytes(owner.1).unwrap();
+    let context = mock_context(cycles_limit, owner_address.clone());
     let keypairs = gen_keypairs(4);
     let mut account_pubkeys = keypairs
         .iter()
@@ -226,12 +220,10 @@ fn test_set_weight() {
 #[test]
 fn test_remove_account() {
     let cycles_limit = 1024 * 1024 * 1024; // 1073741824
-    let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
-    let context = mock_context(cycles_limit, caller);
-
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
     let owner_address = Address::from_pubkey_bytes(owner.1).unwrap();
+    let context = mock_context(cycles_limit, owner_address.clone());
     let keypairs = gen_keypairs(4);
     let mut account_pubkeys = keypairs
         .iter()

--- a/built-in-services/multi-signature/src/tests/curd_test.rs
+++ b/built-in-services/multi-signature/src/tests/curd_test.rs
@@ -75,7 +75,6 @@ fn test_set_threshold() {
     let cycles_limit = 1024 * 1024 * 1024; // 1073741824
     let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
     let context = mock_context(cycles_limit, caller);
-    let tx_hash = context.get_tx_hash().unwrap();
 
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
@@ -97,7 +96,6 @@ fn test_set_threshold() {
 
     // test new threshold above sum of the weights
     let res = service.set_threshold(context.clone(), SetThresholdPayload {
-        witness:           gen_single_witness(&owner.0, &tx_hash),
         multi_sig_address: multi_sig_address.clone(),
         new_threshold:     5,
     });
@@ -108,7 +106,6 @@ fn test_set_threshold() {
 
     // test set new threshold success
     let res = service.set_threshold(context, SetThresholdPayload {
-        witness: gen_single_witness(&owner.0, &tx_hash),
         multi_sig_address,
         new_threshold: 2,
     });
@@ -120,7 +117,6 @@ fn test_add_account() {
     let cycles_limit = 1024 * 1024 * 1024; // 1073741824
     let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
     let context = mock_context(cycles_limit, caller);
-    let tx_hash = context.get_tx_hash().unwrap();
 
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
@@ -144,7 +140,6 @@ fn test_add_account() {
     let new_keypair = gen_one_keypair();
     account_pubkeys.push(to_multi_sig_account(new_keypair.1.clone()));
     let res = service.add_account(context.clone(), AddAccountPayload {
-        witness:           gen_single_witness(&owner.0, &tx_hash),
         multi_sig_address: multi_sig_address.clone(),
         new_account:       to_multi_sig_account(new_keypair.1).into_signle_account(),
     });
@@ -153,7 +148,6 @@ fn test_add_account() {
     // test add new account success above max count value
     let new_keypair = gen_one_keypair();
     let res = service.add_account(context.clone(), AddAccountPayload {
-        witness:           gen_single_witness(&owner.0, &tx_hash),
         multi_sig_address: multi_sig_address.clone(),
         new_account:       to_multi_sig_account(new_keypair.1).into_signle_account(),
     });
@@ -178,7 +172,6 @@ fn test_set_weight() {
     let cycles_limit = 1024 * 1024 * 1024; // 1073741824
     let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
     let context = mock_context(cycles_limit, caller);
-    let tx_hash = context.get_tx_hash().unwrap();
 
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
@@ -201,7 +194,6 @@ fn test_set_weight() {
 
     // test set weight success
     let res = service.set_account_weight(context.clone(), SetAccountWeightPayload {
-        witness:           gen_single_witness(&owner.0, &tx_hash),
         multi_sig_address: multi_sig_address.clone(),
         account_address:   to_be_changed_address.clone(),
         new_weight:        2,
@@ -210,7 +202,6 @@ fn test_set_weight() {
 
     // test set an invalid weight
     let res = service.set_account_weight(context.clone(), SetAccountWeightPayload {
-        witness:           gen_single_witness(&owner.0, &tx_hash),
         multi_sig_address: multi_sig_address.clone(),
         account_address:   to_be_changed_address,
         new_weight:        0,
@@ -237,7 +228,6 @@ fn test_remove_account() {
     let cycles_limit = 1024 * 1024 * 1024; // 1073741824
     let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
     let context = mock_context(cycles_limit, caller);
-    let tx_hash = context.get_tx_hash().unwrap();
 
     let mut service = new_multi_signature_service();
     let owner = gen_one_keypair();
@@ -259,7 +249,6 @@ fn test_remove_account() {
     let to_be_removed_address = Address::from_pubkey_bytes(keypairs[3].1.clone()).unwrap();
 
     let res = service.remove_account(context.clone(), RemoveAccountPayload {
-        witness:           gen_single_witness(&owner.0, &tx_hash),
         multi_sig_address: multi_sig_address.clone(),
         account_address:   to_be_removed_address,
     });
@@ -268,7 +257,6 @@ fn test_remove_account() {
 
     let to_be_removed_address = Address::from_pubkey_bytes(keypairs[2].1.clone()).unwrap();
     let res = service.remove_account(context.clone(), RemoveAccountPayload {
-        witness:           gen_single_witness(&owner.0, &tx_hash),
         multi_sig_address: multi_sig_address.clone(),
         account_address:   to_be_removed_address,
     });

--- a/built-in-services/multi-signature/src/tests/mod.rs
+++ b/built-in-services/multi-signature/src/tests/mod.rs
@@ -173,7 +173,7 @@ fn sign(privkey: &Bytes, hash: &Hash) -> Bytes {
         .to_bytes()
 }
 
-fn gen_single_witness(privkey: &Bytes, hash: &Hash) -> VerifySignaturePayload {
+fn _gen_single_witness(privkey: &Bytes, hash: &Hash) -> VerifySignaturePayload {
     let privkey = Secp256k1PrivateKey::try_from(privkey.as_ref()).unwrap();
     let pk = privkey.pub_key().to_bytes();
     let sig = privkey

--- a/built-in-services/multi-signature/src/types.rs
+++ b/built-in-services/multi-signature/src/types.rs
@@ -98,6 +98,12 @@ pub struct SetThresholdPayload {
     pub new_threshold:     u32,
 }
 
+#[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug)]
+pub struct UpdateAccountPayload {
+    pub account_address:  Address,
+    pub new_account_info: GenerateMultiSigAccountPayload,
+}
+
 #[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct MultiSigPermission {
     pub owner:     Address,

--- a/built-in-services/multi-signature/src/types.rs
+++ b/built-in-services/multi-signature/src/types.rs
@@ -63,35 +63,30 @@ pub struct GetMultiSigAccountResponse {
 
 #[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug)]
 pub struct ChangeOwnerPayload {
-    pub witness:           VerifySignaturePayload,
     pub multi_sig_address: Address,
     pub new_owner:         Address,
 }
 
 #[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug)]
 pub struct ChangeMemoPayload {
-    pub witness:           VerifySignaturePayload,
     pub multi_sig_address: Address,
     pub new_memo:          String,
 }
 
 #[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug)]
 pub struct AddAccountPayload {
-    pub witness:           VerifySignaturePayload,
     pub multi_sig_address: Address,
     pub new_account:       Account,
 }
 
 #[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug)]
 pub struct RemoveAccountPayload {
-    pub witness:           VerifySignaturePayload,
     pub multi_sig_address: Address,
     pub account_address:   Address,
 }
 
 #[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug)]
 pub struct SetAccountWeightPayload {
-    pub witness:           VerifySignaturePayload,
     pub multi_sig_address: Address,
     pub account_address:   Address,
     pub new_weight:        u8,
@@ -99,7 +94,6 @@ pub struct SetAccountWeightPayload {
 
 #[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug)]
 pub struct SetThresholdPayload {
-    pub witness:           VerifySignaturePayload,
     pub multi_sig_address: Address,
     pub new_threshold:     u32,
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
refactor

**What this PR does / why we need it**:
* Instead of using a global variable, use a local variable to calculate the multi-signature recursion depth.
* remove redundancy signature verify in `add_account`, `remove_account`, `set_threshold` .etc
* refactor check recursion depth function, when the depth is overflow, stop check immediately.
* Add adaptive address. If the owner address in the payload is `0xffffffffffffffffffffffffffffffffffffffff`, use the multi-signature address as the owner address.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
