### PR TITLE
refactor(store): change index and len to u64

### DIFF
--- a/framework/src/binding/store/array.rs
+++ b/framework/src/binding/store/array.rs
@@ -41,7 +41,7 @@ impl<S: ServiceState, E: FixedCodec> DefaultStoreArray<S, E> {
         }
     }
 
-    fn inner_get(&self, index: u32) -> ProtocolResult<Option<E>> {
+    fn inner_get(&self, index: u64) -> ProtocolResult<Option<E>> {
         if let Some(k) = self.keys.inner.get(index as usize) {
             self.state.borrow().get(k)?.map_or_else(
                 || {
@@ -71,7 +71,7 @@ impl<S: ServiceState, E: FixedCodec> DefaultStoreArray<S, E> {
 
     // TODO(@zhounan): Atomicity of insert(k, v) and insert self.keys to
     // ServiceState is not guaranteed for now That must be settled soon after.
-    fn inner_remove(&mut self, index: u32) -> ProtocolResult<()> {
+    fn inner_remove(&mut self, index: u64) -> ProtocolResult<()> {
         let key = self.keys.inner.remove(index as usize);
         self.state
             .borrow_mut()
@@ -82,7 +82,7 @@ impl<S: ServiceState, E: FixedCodec> DefaultStoreArray<S, E> {
 }
 
 impl<S: ServiceState, E: FixedCodec> StoreArray<E> for DefaultStoreArray<S, E> {
-    fn get(&self, index: u32) -> Option<E> {
+    fn get(&self, index: u64) -> Option<E> {
         self.inner_get(index)
             .unwrap_or_else(|e| panic!("StoreArray get value failed: {}", e))
     }
@@ -92,13 +92,13 @@ impl<S: ServiceState, E: FixedCodec> StoreArray<E> for DefaultStoreArray<S, E> {
             .unwrap_or_else(|e| panic!("StoreArray push value failed: {}", e));
     }
 
-    fn remove(&mut self, index: u32) {
+    fn remove(&mut self, index: u64) {
         self.inner_remove(index)
             .unwrap_or_else(|e| panic!("StoreArray remove value failed: {}", e));
     }
 
-    fn len(&self) -> u32 {
-        self.keys.inner.len() as u32
+    fn len(&self) -> u64 {
+        self.keys.inner.len() as u64
     }
 
     fn is_empty(&self) -> bool {
@@ -109,19 +109,19 @@ impl<S: ServiceState, E: FixedCodec> StoreArray<E> for DefaultStoreArray<S, E> {
         }
     }
 
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (u32, E)> + 'a> {
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (u64, E)> + 'a> {
         Box::new(ArrayIter::<E, Self>::new(0, self))
     }
 }
 
 struct ArrayIter<'a, E: FixedCodec, A: StoreArray<E>> {
-    idx:     u32,
+    idx:     u64,
     array:   &'a A,
     phantom: PhantomData<E>,
 }
 
 impl<'a, E: FixedCodec, A: StoreArray<E>> ArrayIter<'a, E, A> {
-    pub fn new(idx: u32, array: &'a A) -> Self {
+    pub fn new(idx: u64, array: &'a A) -> Self {
         ArrayIter {
             idx,
             array,
@@ -131,7 +131,7 @@ impl<'a, E: FixedCodec, A: StoreArray<E>> ArrayIter<'a, E, A> {
 }
 
 impl<'a, E: FixedCodec, A: StoreArray<E>> Iterator for ArrayIter<'a, E, A> {
-    type Item = (u32, E);
+    type Item = (u64, E);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.idx < self.array.len() {

--- a/framework/src/binding/store/map.rs
+++ b/framework/src/binding/store/map.rs
@@ -18,7 +18,7 @@ pub struct DefaultStoreMap<S: ServiceState, K: FixedCodec + PartialEq, V: FixedC
     var_name: String,
     keys:     RefCell<FixedBuckets<K>>,
     len_key:  Bytes,
-    len:      u32,
+    len:      u64,
     phantom:  PhantomData<V>,
 }
 
@@ -34,7 +34,7 @@ where
             .borrow()
             .get(&len_key)
             .expect("Get len failed")
-            .unwrap_or(0u32);
+            .unwrap_or(0u64);
 
         DefaultStoreMap {
             state,
@@ -226,7 +226,7 @@ where
         }
     }
 
-    fn len(&self) -> u32 {
+    fn len(&self) -> u64 {
         self.len
     }
 
@@ -246,7 +246,7 @@ pub struct NewMapIter<
     K: 'static + FixedCodec + PartialEq,
     V: 'static + FixedCodec,
 > {
-    idx: u32,
+    idx: u64,
     map: &'a DefaultStoreMap<S, K, V>,
 }
 
@@ -256,7 +256,7 @@ where
     K: 'static + FixedCodec + PartialEq,
     V: 'static + FixedCodec,
 {
-    pub fn new(idx: u32, map: &'a DefaultStoreMap<S, K, V>) -> Self {
+    pub fn new(idx: u64, map: &'a DefaultStoreMap<S, K, V>) -> Self {
         Self { idx, map }
     }
 }
@@ -340,11 +340,11 @@ mod tests {
         let res = (0..17)
             .map(|i| {
                 if i > max {
-                    2u32
+                    2u64
                 } else if i > min {
-                    1u32
+                    1u64
                 } else {
-                    0u32
+                    0u64
                 }
             })
             .collect::<Vec<_>>();

--- a/framework/src/binding/store/mod.rs
+++ b/framework/src/binding/store/mod.rs
@@ -55,7 +55,7 @@ impl<K: FixedCodec> FixedCodec for FixedKeys<K> {
 
 pub struct FixedBuckets<K: FixedCodec + PartialEq> {
     pub keys_bucket:  Vec<Bucket<K>>,
-    pub bucket_lens:  Vec<u32>,
+    pub bucket_lens:  Vec<u64>,
     pub is_recovered: Vec<bool>,
 }
 
@@ -67,7 +67,7 @@ impl<K: FixedCodec + PartialEq> FixedBuckets<K> {
 
         for _i in 0..16 {
             keys_bucket.push(Bucket::new());
-            bucket_lens.push(0u32);
+            bucket_lens.push(0u64);
             is_recovered.push(false);
         }
 
@@ -112,7 +112,7 @@ impl<K: FixedCodec + PartialEq> FixedBuckets<K> {
     }
 
     /// The function will panic when index is greater than or equal 16.
-    fn get_abs_index_interval(&self, index: usize) -> (u32, u32) {
+    fn get_abs_index_interval(&self, index: usize) -> (u64, u64) {
         (self.bucket_lens[index], self.bucket_lens[index + 1])
     }
 
@@ -125,13 +125,13 @@ impl<K: FixedCodec + PartialEq> FixedBuckets<K> {
         let mut acc = self.bucket_lens[index];
 
         for i in start..17 {
-            acc += self.keys_bucket[i - 1].len() as u32;
+            acc += self.keys_bucket[i - 1].len() as u64;
             self.bucket_lens[i] = acc;
         }
     }
 
     #[cfg(test)]
-    fn len(&self) -> u32 {
+    fn len(&self) -> u64 {
         self.bucket_lens[16]
     }
 
@@ -259,7 +259,7 @@ mod tests {
 
         println!("{:?}", buckets.bucket_lens);
 
-        let intervals = (0u32..=16).map(|i| i * 16).collect::<Vec<_>>();
+        let intervals = (0u64..=16).map(|i| i * 16).collect::<Vec<_>>();
         assert!(intervals == buckets.bucket_lens);
         assert!(buckets.len() == 256);
 
@@ -293,7 +293,7 @@ mod tests {
         let _ = buckets
             .remove_item(get_bucket_index(&key.encode_fixed().unwrap()), &key)
             .unwrap();
-        let intervals = (0u32..=16)
+        let intervals = (0u64..=16)
             .map(|i| if i == 0 { 0 } else { i * 16 - 1 })
             .collect::<Vec<_>>();
         assert!(buckets.len() == 255);

--- a/framework/src/binding/store/primitive.rs
+++ b/framework/src/binding/store/primitive.rs
@@ -251,8 +251,8 @@ impl<S: ServiceState> DefaultStoreString<S> {
         }
     }
 
-    fn inner_len(&self) -> ProtocolResult<u32> {
-        self.inner_get().map(|s| s.len() as u32)
+    fn inner_len(&self) -> ProtocolResult<u64> {
+        self.inner_get().map(|s| s.len() as u64)
     }
 
     fn is_empty_(&self) -> ProtocolResult<bool> {
@@ -271,7 +271,7 @@ impl<S: ServiceState> StoreString for DefaultStoreString<S> {
             .unwrap_or_else(|e| panic!("StoreString set failed: {}", e));
     }
 
-    fn len(&self) -> u32 {
+    fn len(&self) -> u64 {
         self.inner_len()
             .unwrap_or_else(|e| panic!("StoreString get length failed: {}", e))
     }

--- a/framework/src/binding/tests/store.rs
+++ b/framework/src/binding/tests/store.rs
@@ -73,7 +73,7 @@ fn test_default_store_string() {
 
     ss.set("ok");
     assert_eq!(ss.get(), String::from("ok"));
-    assert_eq!(ss.len(), 2u32);
+    assert_eq!(ss.len(), 2u64);
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn test_default_store_map() {
     sm.remove(&Hash::digest(Bytes::from("key_1"))).unwrap();
 
     assert_eq!(sm.contains(&Hash::digest(Bytes::from("key_1"))), false);
-    assert_eq!(sm.len(), 1u32);
+    assert_eq!(sm.len(), 1u64);
 
     let sm = DefaultStoreMap::<_, Hash, Bytes>::new(Rc::clone(&rs), "test");
     assert_eq!(
@@ -130,26 +130,26 @@ fn test_default_store_array() {
 
     let mut sa = DefaultStoreArray::<_, Bytes>::new(Rc::clone(&rs), "test");
 
-    assert_eq!(sa.len(), 0u32);
-    assert_eq!(sa.get(0u32).is_none(), true);
+    assert_eq!(sa.len(), 0u64);
+    assert_eq!(sa.get(0u64).is_none(), true);
 
     sa.push(Bytes::from("111"));
     sa.push(Bytes::from("222"));
 
-    assert_eq!(sa.get(3u32).is_none(), true);
+    assert_eq!(sa.get(3u64).is_none(), true);
 
     {
         let mut it = sa.iter();
-        assert_eq!(it.next().unwrap(), (0u32, Bytes::from("111")));
-        assert_eq!(it.next().unwrap(), (1u32, Bytes::from("222")));
+        assert_eq!(it.next().unwrap(), (0u64, Bytes::from("111")));
+        assert_eq!(it.next().unwrap(), (1u64, Bytes::from("222")));
         assert_eq!(it.next().is_none(), true);
     }
 
-    assert_eq!(sa.get(0u32).unwrap(), Bytes::from("111"));
-    assert_eq!(sa.get(1u32).unwrap(), Bytes::from("222"));
+    assert_eq!(sa.get(0u64).unwrap(), Bytes::from("111"));
+    assert_eq!(sa.get(1u64).unwrap(), Bytes::from("222"));
 
-    sa.remove(0u32);
+    sa.remove(0u64);
 
-    assert_eq!(sa.len(), 1u32);
-    assert_eq!(sa.get(0u32).unwrap(), Bytes::from("222"));
+    assert_eq!(sa.len(), 1u64);
+    assert_eq!(sa.get(0u64).unwrap(), Bytes::from("222"));
 }

--- a/protocol/src/traits/binding.rs
+++ b/protocol/src/traits/binding.rs
@@ -209,7 +209,7 @@ pub trait StoreMap<K: FixedCodec + PartialEq, V: FixedCodec> {
 
     fn remove(&mut self, key: &K) -> Option<V>;
 
-    fn len(&self) -> u32;
+    fn len(&self) -> u64;
 
     fn is_empty(&self) -> bool;
 
@@ -217,17 +217,17 @@ pub trait StoreMap<K: FixedCodec + PartialEq, V: FixedCodec> {
 }
 
 pub trait StoreArray<E: FixedCodec> {
-    fn get(&self, index: u32) -> Option<E>;
+    fn get(&self, index: u64) -> Option<E>;
 
     fn push(&mut self, element: E);
 
-    fn remove(&mut self, index: u32);
+    fn remove(&mut self, index: u64);
 
-    fn len(&self) -> u32;
+    fn len(&self) -> u64;
 
     fn is_empty(&self) -> bool;
 
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (u32, E)> + 'a>;
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (u64, E)> + 'a>;
 }
 
 pub trait StoreUint64 {
@@ -265,7 +265,7 @@ pub trait StoreString {
 
     fn set(&mut self, val: &str);
 
-    fn len(&self) -> u32;
+    fn len(&self) -> u64;
 
     fn is_empty(&self) -> bool;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
refactor

**What this PR does / why we need it**:
* Change the index type of `DefaultStoreArray` and `DefaultStoreMap` to u64.
* Change the return type of `len()` method to u64.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
