### PR TITLE
feat!: add 'name' field in event struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ SYS_ROCKSDB := $(if ${USE_SYS_ROCKSDB},ROCKSDB_LIB_DIR=${SYS_LIB_DIR},)
 CARGO := env ${SYS_ROCKSDB} cargo
 
 test:
-	${CARGO} test ${VERBOSE} --all  --release -- --skip trust_metric --nocapture
-	${CARGO} test --release -- --test-threads=1
+	${CARGO} test ${VERBOSE} --all -- --skip trust_metric --nocapture
+	${CARGO} test -- --test-threads=1
 
 doc:
 	cargo doc --all --no-deps

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ SYS_ROCKSDB := $(if ${USE_SYS_ROCKSDB},ROCKSDB_LIB_DIR=${SYS_LIB_DIR},)
 CARGO := env ${SYS_ROCKSDB} cargo
 
 test:
-	${CARGO} test ${VERBOSE} --all -- --skip trust_metric --nocapture
-	${CARGO} test -- --test-threads=1
+	${CARGO} test ${VERBOSE} --all  --release -- --skip trust_metric --nocapture
+	${CARGO} test --release -- --test-threads=1
 
 doc:
 	cargo doc --all --no-deps

--- a/built-in-services/asset/src/lib.rs
+++ b/built-in-services/asset/src/lib.rs
@@ -173,7 +173,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<Asset>::from_error(103, format!("{:?}", e));
         }
         let event_str = event_res.unwrap();
-        ctx.emit_event("Create".to_owned(), event_str);
+        ctx.emit_event("CreateAsset".to_owned(), event_str);
 
         ServiceResponse::<Asset>::from_succeed(asset)
     }
@@ -206,7 +206,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
-        ctx.emit_event("Transfer".to_owned(), event_str);
+        ctx.emit_event("TransferAsset".to_owned(), event_str);
 
         ServiceResponse::<()>::from_succeed(())
     }
@@ -255,7 +255,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
-        ctx.emit_event("Approve".to_owned(), event_str);
+        ctx.emit_event("ApproveAsset".to_owned(), event_str);
 
         ServiceResponse::<()>::from_succeed(())
     }

--- a/built-in-services/asset/src/lib.rs
+++ b/built-in-services/asset/src/lib.rs
@@ -173,7 +173,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<Asset>::from_error(103, format!("{:?}", e));
         }
         let event_str = event_res.unwrap();
-        ctx.emit_event(event_str);
+        ctx.emit_event("Create".to_owned(), event_str);
 
         ServiceResponse::<Asset>::from_succeed(asset)
     }
@@ -206,7 +206,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
-        ctx.emit_event(event_str);
+        ctx.emit_event("Transfer".to_owned(), event_str);
 
         ServiceResponse::<()>::from_succeed(())
     }
@@ -255,7 +255,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
-        ctx.emit_event(event_str);
+        ctx.emit_event("Approve".to_owned(), event_str);
 
         ServiceResponse::<()>::from_succeed(())
     }
@@ -317,7 +317,7 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
-        ctx.emit_event(event_str);
+        ctx.emit_event("TransferFrom".to_owned(), event_str);
 
         ServiceResponse::<()>::from_succeed(())
     }

--- a/core/api/src/schema/receipt.rs
+++ b/core/api/src/schema/receipt.rs
@@ -13,7 +13,6 @@ pub struct Receipt {
 #[derive(juniper::GraphQLObject, Clone)]
 pub struct Event {
     pub service: String,
-    pub method:  String,
     pub name:    String,
     pub data:    String,
 }
@@ -42,7 +41,6 @@ impl From<protocol::types::Event> for Event {
     fn from(event: protocol::types::Event) -> Self {
         Self {
             service: event.service,
-            method:  event.method,
             name:    event.name,
             data:    event.data,
         }

--- a/core/api/src/schema/receipt.rs
+++ b/core/api/src/schema/receipt.rs
@@ -13,6 +13,8 @@ pub struct Receipt {
 #[derive(juniper::GraphQLObject, Clone)]
 pub struct Event {
     pub service: String,
+    pub method:  String,
+    pub name:    String,
     pub data:    String,
 }
 
@@ -40,6 +42,8 @@ impl From<protocol::types::Event> for Event {
     fn from(event: protocol::types::Event) -> Self {
         Self {
             service: event.service,
+            method:  event.method,
+            name:    event.name,
             data:    event.data,
         }
     }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -268,6 +268,8 @@ pub fn mock_receipt_response() -> ReceiptResponse {
 pub fn mock_event() -> Event {
     Event {
         service: "mock-event".to_owned(),
+        method:  "mock-method".to_owned(),
+        name:    "mock-method".to_owned(),
         data:    "mock-data".to_owned(),
     }
 }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -268,7 +268,6 @@ pub fn mock_receipt_response() -> ReceiptResponse {
 pub fn mock_event() -> Event {
     Event {
         service: "mock-event".to_owned(),
-        method:  "mock-method".to_owned(),
         name:    "mock-method".to_owned(),
         data:    "mock-data".to_owned(),
     }

--- a/framework/src/executor/tests/service_call_service.rs
+++ b/framework/src/executor/tests/service_call_service.rs
@@ -116,7 +116,10 @@ impl<SDK: ServiceSDK> MockService<SDK> {
 
         let asset: Asset = serde_json::from_str(&ret.succeed_data).unwrap();
 
-        ctx.emit_event("call create asset succeed".to_owned());
+        ctx.emit_event(
+            "mock-asset".to_owned(),
+            "call create asset succeed".to_owned(),
+        );
         ServiceResponse::<Asset>::from_succeed(asset)
     }
 }

--- a/framework/src/executor/tests/test_service.rs
+++ b/framework/src/executor/tests/test_service.rs
@@ -59,7 +59,7 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         ctx: ServiceContext,
         _: TestWritePayload,
     ) -> ServiceResponse<TestWriteResponse> {
-        ctx.emit_event("test".to_owned());
+        ctx.emit_event("test-name".to_owned(), "test".to_owned());
         ServiceResponse::from_succeed(TestWriteResponse::default())
     }
 
@@ -144,7 +144,10 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         if ctx.get_service_name() == "test"
             && ctx.get_payload().to_owned().contains("test_hook_before")
         {
-            ctx.emit_event("test_tx_hook_before invoked".to_owned());
+            ctx.emit_event(
+                "test-name".to_owned(),
+                "test_tx_hook_before invoked".to_owned(),
+            );
         }
 
         if ctx.get_service_method() == "tx_hook_before_panic" {
@@ -163,7 +166,10 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         if ctx.get_service_name() == "test"
             && ctx.get_payload().to_owned().contains("test_hook_after")
         {
-            ctx.emit_event("test_tx_hook_after invoked".to_owned());
+            ctx.emit_event(
+                "test-name".to_owned(),
+                "test_tx_hook_after invoked".to_owned(),
+            );
         }
 
         if ctx.get_service_method() == "tx_hook_after_panic" {

--- a/jenkins-x-unit.yml
+++ b/jenkins-x-unit.yml
@@ -7,7 +7,7 @@ pipelineConfig:
           image: mutadev/muta-build-env:v0.1.0
         options:
           timeout:
-            time: 30
+            time: 45
             unit: minutes
         stages:
           - name: unit

--- a/protocol/src/codec/receipt.rs
+++ b/protocol/src/codec/receipt.rs
@@ -61,12 +61,9 @@ pub struct Event {
     pub service: Vec<u8>,
 
     #[prost(bytes, tag = "2")]
-    pub method: Vec<u8>,
-
-    #[prost(bytes, tag = "3")]
     pub name: Vec<u8>,
 
-    #[prost(bytes, tag = "4")]
+    #[prost(bytes, tag = "3")]
     pub data: Vec<u8>,
 }
 
@@ -158,7 +155,6 @@ impl From<receipt::Event> for Event {
     fn from(event: receipt::Event) -> Event {
         Event {
             service: event.service.as_bytes().to_vec(),
-            method:  event.method.as_bytes().to_vec(),
             name:    event.name.as_bytes().to_vec(),
             data:    event.data.as_bytes().to_vec(),
         }
@@ -171,7 +167,6 @@ impl TryFrom<Event> for receipt::Event {
     fn try_from(event: Event) -> Result<receipt::Event, Self::Error> {
         Ok(receipt::Event {
             service: String::from_utf8(event.service).map_err(CodecError::FromStringUtf8)?,
-            method:  String::from_utf8(event.method).map_err(CodecError::FromStringUtf8)?,
             name:    String::from_utf8(event.name).map_err(CodecError::FromStringUtf8)?,
             data:    String::from_utf8(event.data).map_err(CodecError::FromStringUtf8)?,
         })

--- a/protocol/src/codec/receipt.rs
+++ b/protocol/src/codec/receipt.rs
@@ -61,6 +61,12 @@ pub struct Event {
     pub service: Vec<u8>,
 
     #[prost(bytes, tag = "2")]
+    pub method: Vec<u8>,
+
+    #[prost(bytes, tag = "3")]
+    pub name: Vec<u8>,
+
+    #[prost(bytes, tag = "4")]
     pub data: Vec<u8>,
 }
 
@@ -152,6 +158,8 @@ impl From<receipt::Event> for Event {
     fn from(event: receipt::Event) -> Event {
         Event {
             service: event.service.as_bytes().to_vec(),
+            method:  event.method.as_bytes().to_vec(),
+            name:    event.name.as_bytes().to_vec(),
             data:    event.data.as_bytes().to_vec(),
         }
     }
@@ -163,6 +171,8 @@ impl TryFrom<Event> for receipt::Event {
     fn try_from(event: Event) -> Result<receipt::Event, Self::Error> {
         Ok(receipt::Event {
             service: String::from_utf8(event.service).map_err(CodecError::FromStringUtf8)?,
+            method:  String::from_utf8(event.method).map_err(CodecError::FromStringUtf8)?,
+            name:    String::from_utf8(event.name).map_err(CodecError::FromStringUtf8)?,
             data:    String::from_utf8(event.data).map_err(CodecError::FromStringUtf8)?,
         })
     }

--- a/protocol/src/fixed_codec/tests/mod.rs
+++ b/protocol/src/fixed_codec/tests/mod.rs
@@ -56,7 +56,6 @@ pub fn mock_receipt() -> Receipt {
 pub fn mock_event() -> Event {
     Event {
         service: "mock-event".to_owned(),
-        method:  "mock-method".to_owned(),
         name:    "mock-name".to_owned(),
         data:    "mock-data".to_owned(),
     }

--- a/protocol/src/fixed_codec/tests/mod.rs
+++ b/protocol/src/fixed_codec/tests/mod.rs
@@ -56,6 +56,8 @@ pub fn mock_receipt() -> Receipt {
 pub fn mock_event() -> Event {
     Event {
         service: "mock-event".to_owned(),
+        method:  "mock-method".to_owned(),
+        name:    "mock-name".to_owned(),
         data:    "mock-data".to_owned(),
     }
 }

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -24,7 +24,7 @@ pub const GENESIS_HEIGHT: u64 = 0;
 const HASH_LEN: usize = 32;
 
 // Should started with 0x
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Hex(String);
 
 impl Hex {
@@ -42,6 +42,12 @@ impl Hex {
 
     pub fn as_string_trim0x(&self) -> String {
         (&self.0[2..]).to_owned()
+    }
+}
+
+impl Default for Hex {
+    fn default() -> Self {
+        Hex::from_string("0x".to_owned()).expect("Hex must start with 0x")
     }
 }
 
@@ -345,6 +351,7 @@ mod tests {
     use bytes::Bytes;
 
     use super::{Address, Hash};
+    use crate::types::Hex;
 
     #[test]
     fn test_hash() {
@@ -372,5 +379,13 @@ mod tests {
 
         let address = Address::from_bytes(bytes).unwrap();
         assert_eq!(add_str, &address.as_hex().to_uppercase().as_str()[2..]);
+    }
+
+    #[test]
+    fn test_hex() {
+        let hex_str = "0x112233445566AABBcc";
+        let hex = Hex::from_string(hex_str.to_owned()).unwrap();
+
+        assert_eq!(hex_str, hex.0.as_str());
     }
 }

--- a/protocol/src/types/receipt.rs
+++ b/protocol/src/types/receipt.rs
@@ -8,6 +8,8 @@ use crate::{traits::ServiceResponse, ProtocolResult};
 #[derive(RlpFixedCodec, Debug, Clone, PartialEq, Eq)]
 pub struct Event {
     pub service: String,
+    pub method:  String,
+    pub name:    String,
     pub data:    String,
 }
 

--- a/protocol/src/types/receipt.rs
+++ b/protocol/src/types/receipt.rs
@@ -8,7 +8,6 @@ use crate::{traits::ServiceResponse, ProtocolResult};
 #[derive(RlpFixedCodec, Debug, Clone, PartialEq, Eq)]
 pub struct Event {
     pub service: String,
-    pub method:  String,
     pub name:    String,
     pub data:    String,
 }

--- a/protocol/src/types/service_context.rs
+++ b/protocol/src/types/service_context.rs
@@ -162,10 +162,12 @@ impl ServiceContext {
         *self.canceled.borrow_mut() = Some(reason);
     }
 
-    pub fn emit_event(&self, message: String) {
+    pub fn emit_event(&self, name: String, message: String) {
         self.events.borrow_mut().push(Event {
             service: self.service_name.clone(),
-            data:    message,
+            method: self.service_method.clone(),
+            name,
+            data: message,
         })
     }
 }

--- a/protocol/src/types/service_context.rs
+++ b/protocol/src/types/service_context.rs
@@ -165,7 +165,6 @@ impl ServiceContext {
     pub fn emit_event(&self, name: String, message: String) {
         self.events.borrow_mut().push(Event {
             service: self.service_name.clone(),
-            method: self.service_method.clone(),
             name,
             data: message,
         })


### PR DESCRIPTION
**What type of PR is this?**
BREAKING CHANGE

feature

**What this PR does / why we need it**:
to enhance event to include one new field:
name : String , this indicates the event name in the context

provided applied, this pr will help client to use 'name' field to filter events they interest, instead of try read JSON data to identify JSON data's type