### PR TITLE
refactor!(network): rename users_cast to multicast, pass peer_ids instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ hex = "0.4"
 rlp = "0.4"
 toml = "0.5"
 tokio = { version = "0.2", features = ["macros", "rt-core", "rt-util", "signal", "time"] }
+tentacle-secio = { version = "0.1", features = [ "flatc" ] }
 muta-apm = "0.1.0-alpha.7"
 futures-timer="3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ hex = "0.4"
 rlp = "0.4"
 toml = "0.5"
 tokio = { version = "0.2", features = ["macros", "rt-core", "rt-util", "signal", "time"] }
-tentacle-secio = { version = "0.1", features = [ "flatc" ] }
 muta-apm = "0.1.0-alpha.7"
 futures-timer="3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rand = "0.7"
 cita_trie = "2.0"
 core-network = { path = "./core/network", features = ["diagnostic"] }
 tokio = { version = "0.2", features = ["full"] }
-tentacle = { git = "https://github.com/zeroqn/p2p", branch = "v0.3.0.alpha5-muta", features = [ "molc" ]}
+bs58 = "0.3"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ rand = "0.7"
 cita_trie = "2.0"
 core-network = { path = "./core/network", features = ["diagnostic"] }
 tokio = { version = "0.2", features = ["full"] }
+tentacle = { git = "https://github.com/zeroqn/p2p", branch = "v0.3.0.alpha5-muta", features = [ "molc" ]}
 
 [workspace]
 members = [

--- a/built-in-services/metadata/Cargo.toml
+++ b/built-in-services/metadata/Cargo.toml
@@ -15,10 +15,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rlp = "0.4"
 bytes = "0.5"
-derive_more = "0.15"
+derive_more = "0.99"
 byteorder = "1.3"
 
 [dev-dependencies]
+hex = "0.4"
 cita_trie = "2.0"
 async-trait = "0.1"
 framework = { path = "../../framework" }

--- a/built-in-services/metadata/src/tests/mod.rs
+++ b/built-in-services/metadata/src/tests/mod.rs
@@ -64,7 +64,7 @@ fn mock_metadata() -> Metadata {
         interval:        3000,
         verifier_list:   [ValidatorExtend {
             bls_pub_key: Hex::from_string("0x04188ef9488c19458a963cc57b567adde7db8f8b6bec392d5cb7b67b0abc1ed6cd966edc451f6ac2ef38079460eb965e890d1f576e4039a20467820237cda753f07a8b8febae1ec052190973a1bcf00690ea8fc0168b3fbbccd1c4e402eda5ef22".to_owned()).unwrap(),
-            peer_id:        Bytes::from(hex::decode("0405e7689f808af9fea532548b1b90d1fac48112b4a6a83bc331629df70647a84cf8a0dbc73352ab78664a15f57caaef860f3a6c6ceb128f6ec01a86ac96c8b7f2ba3be79387faf69c7f3bd112f0ddf3c6225a7fe23ec0c680cf93580716dd6fe4".to_string()).unwrap()),
+            peer_id:     Hex::from_string("0x1220c7b1dc28da9eeecc7b825f39d0c1e79f87a5cf8a44d888c9f1f1b1ad6be0c79b".to_owned()).unwrap(),
             address: Address::from_hex("0xCAB8EEA4799C21379C20EF5BAA2CC8AF1BEC475B").unwrap(),
             propose_weight: 1,
             vote_weight:    1,

--- a/built-in-services/metadata/src/tests/mod.rs
+++ b/built-in-services/metadata/src/tests/mod.rs
@@ -64,7 +64,8 @@ fn mock_metadata() -> Metadata {
         interval:        3000,
         verifier_list:   [ValidatorExtend {
             bls_pub_key: Hex::from_string("0x04188ef9488c19458a963cc57b567adde7db8f8b6bec392d5cb7b67b0abc1ed6cd966edc451f6ac2ef38079460eb965e890d1f576e4039a20467820237cda753f07a8b8febae1ec052190973a1bcf00690ea8fc0168b3fbbccd1c4e402eda5ef22".to_owned()).unwrap(),
-            address:        Address::from_hex("0xCAB8EEA4799C21379C20EF5BAA2CC8AF1BEC475B").unwrap(),
+            peer_id:        Bytes::from(hex::decode("0405e7689f808af9fea532548b1b90d1fac48112b4a6a83bc331629df70647a84cf8a0dbc73352ab78664a15f57caaef860f3a6c6ceb128f6ec01a86ac96c8b7f2ba3be79387faf69c7f3bd112f0ddf3c6225a7fe23ec0c680cf93580716dd6fe4".to_string()).unwrap()),
+            address: Address::from_hex("0xCAB8EEA4799C21379C20EF5BAA2CC8AF1BEC475B").unwrap(),
             propose_weight: 1,
             vote_weight:    1,
         }]

--- a/built-in-services/metadata/src/tests/mod.rs
+++ b/built-in-services/metadata/src/tests/mod.rs
@@ -63,9 +63,9 @@ fn mock_metadata() -> Metadata {
         cycles_price:    1,
         interval:        3000,
         verifier_list:   [ValidatorExtend {
-            bls_pub_key: Hex::from_string("0x04188ef9488c19458a963cc57b567adde7db8f8b6bec392d5cb7b67b0abc1ed6cd966edc451f6ac2ef38079460eb965e890d1f576e4039a20467820237cda753f07a8b8febae1ec052190973a1bcf00690ea8fc0168b3fbbccd1c4e402eda5ef22".to_owned()).unwrap(),
-            peer_id:     Hex::from_string("0x1220c7b1dc28da9eeecc7b825f39d0c1e79f87a5cf8a44d888c9f1f1b1ad6be0c79b".to_owned()).unwrap(),
-            address: Address::from_hex("0xCAB8EEA4799C21379C20EF5BAA2CC8AF1BEC475B").unwrap(),
+            bls_pub_key: Hex::from_string("0x0401139331589f32220ec5f41f6faa0f5c3f4d36af011ab014cefd9d8f36b53b04a2031f681d1c9648a2a5d534d742931b0a5a4132da9ee752c1144d6396bed6cfc635c9687258cec9b60b387d35cf9e13f29091e11ae88024d74ca904c0ea3fb3".to_owned()).unwrap(),
+            pub_key:     Hex::from_string("0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004".to_owned()).unwrap(),
+            address:     Address::from_hex("0x76961e339fe2f1f931d84c425754806fb4174c34").unwrap(),
             propose_weight: 1,
             vote_weight:    1,
         }]

--- a/core/api/src/schema/block.rs
+++ b/core/api/src/schema/block.rs
@@ -67,7 +67,7 @@ pub struct Proof {
 #[derive(juniper::GraphQLObject, Clone)]
 #[graphql(description = "Validator address set")]
 pub struct Validator {
-    pub pub_key:        Bytes,
+    pub pubkey:         Bytes,
     pub propose_weight: i32,
     pub vote_weight:    i32,
 }
@@ -142,7 +142,7 @@ impl From<protocol::types::Proof> for Proof {
 impl From<protocol::types::Validator> for Validator {
     fn from(validator: protocol::types::Validator) -> Self {
         Validator {
-            pub_key:        Bytes::from(validator.pub_key),
+            pubkey:         Bytes::from(validator.pub_key),
             propose_weight: validator.vote_weight as i32,
             vote_weight:    validator.vote_weight as i32,
         }

--- a/core/api/src/schema/block.rs
+++ b/core/api/src/schema/block.rs
@@ -67,7 +67,7 @@ pub struct Proof {
 #[derive(juniper::GraphQLObject, Clone)]
 #[graphql(description = "Validator address set")]
 pub struct Validator {
-    pub address:        Address,
+    pub peer_id:        Bytes,
     pub propose_weight: i32,
     pub vote_weight:    i32,
 }
@@ -142,7 +142,7 @@ impl From<protocol::types::Proof> for Proof {
 impl From<protocol::types::Validator> for Validator {
     fn from(validator: protocol::types::Validator) -> Self {
         Validator {
-            address:        Address::from(validator.address),
+            peer_id:        Bytes::from(validator.peer_id),
             propose_weight: validator.vote_weight as i32,
             vote_weight:    validator.vote_weight as i32,
         }

--- a/core/api/src/schema/block.rs
+++ b/core/api/src/schema/block.rs
@@ -67,7 +67,7 @@ pub struct Proof {
 #[derive(juniper::GraphQLObject, Clone)]
 #[graphql(description = "Validator address set")]
 pub struct Validator {
-    pub peer_id:        Bytes,
+    pub pub_key:        Bytes,
     pub propose_weight: i32,
     pub vote_weight:    i32,
 }
@@ -142,7 +142,7 @@ impl From<protocol::types::Proof> for Proof {
 impl From<protocol::types::Validator> for Validator {
     fn from(validator: protocol::types::Validator) -> Self {
         Validator {
-            peer_id:        Bytes::from(validator.peer_id),
+            pub_key:        Bytes::from(validator.pub_key),
             propose_weight: validator.vote_weight as i32,
             vote_weight:    validator.vote_weight as i32,
         }

--- a/core/consensus/Cargo.toml
+++ b/core/consensus/Cargo.toml
@@ -40,7 +40,6 @@ bit-vec = "0.6"
 lazy_static = "1.4"
 num-traits = "0.2"
 rand = "0.7"
-tentacle-secio = { version = "0.1", features = [ "flatc" ] }
 
 [features]
 default = []

--- a/core/consensus/Cargo.toml
+++ b/core/consensus/Cargo.toml
@@ -40,7 +40,7 @@ bit-vec = "0.6"
 lazy_static = "1.4"
 num-traits = "0.2"
 rand = "0.7"
-
+tentacle-secio = { version = "0.1", features = [ "flatc" ] }
 
 [features]
 default = []

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -550,9 +550,9 @@ where
             .verifier_list
             .iter()
             .map(|v| {
-                let address = v.peer_id.decode();
+                let address = v.pub_key.decode();
                 let node = Node {
-                    address:        v.peer_id.decode(),
+                    address:        v.pub_key.decode(),
                     propose_weight: v.propose_weight,
                     vote_weight:    v.vote_weight,
                 };
@@ -578,10 +578,10 @@ where
 
         // check validators
         for validator in block.header.validators.iter() {
-            if !authority_map.contains_key(&validator.peer_id) {
+            if !authority_map.contains_key(&validator.pub_key) {
                 log::error!(
-                    "[consensus] verify_block_header, validator.address: {:?}, authority_map: {:?}",
-                    validator.peer_id,
+                    "[consensus] verify_block_header, validator.pub_key: {:?}, authority_map: {:?}",
+                    validator.pub_key,
                     authority_map
                 );
                 return Err(ConsensusError::VerifyBlockHeader(
@@ -590,14 +590,14 @@ where
                 )
                 .into());
             } else {
-                let node = authority_map.get(&validator.peer_id).unwrap();
+                let node = authority_map.get(&validator.pub_key).unwrap();
 
                 if node.vote_weight != validator.vote_weight
                     || node.propose_weight != validator.vote_weight
                 {
                     log::error!(
-                        "[consensus] verify_block_header, validator.address: {:?}, authority_map: {:?}",
-                        validator.peer_id,
+                        "[consensus] verify_block_header, validator.pub_key: {:?}, authority_map: {:?}",
+                        validator.pub_key,
                         authority_map
                     );
                     return Err(ConsensusError::VerifyBlockHeader(
@@ -667,7 +667,7 @@ where
             .verifier_list
             .iter()
             .map(|v| Node {
-                address:        v.peer_id.decode(),
+                address:        v.pub_key.decode(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })
@@ -701,7 +701,7 @@ where
             .verifier_list
             .iter()
             .filter_map(|v| {
-                if signed_voters.contains(&v.peer_id.decode()) {
+                if signed_voters.contains(&v.pub_key.decode()) {
                     Some(v.bls_pub_key.clone())
                 } else {
                     None

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -113,7 +113,7 @@ where
 
             MessageTarget::Specified(addr) => {
                 self.network
-                    .users_cast(ctx, end, vec![addr], msg, Priority::High)
+                    .multicast(ctx, end, vec![addr], msg, Priority::High)
                     .await
             }
         }

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -689,7 +689,7 @@ where
             .iter()
             .map(|node| (node.address.clone(), node.vote_weight))
             .collect::<HashMap<overlord::types::Address, u32>>();
-        self.verity_proof_weight(
+        self.verify_proof_weight(
             ctx.clone(),
             block.header.height,
             weight_map,
@@ -751,7 +751,7 @@ where
     }
 
     #[muta_apm::derive::tracing_span(kind = "consensus.adapter")]
-    fn verity_proof_weight(
+    fn verify_proof_weight(
         &self,
         ctx: Context,
         block_height: u64,
@@ -768,7 +768,7 @@ where
                     .ok_or(ConsensusError::VerifyProof(block_height, WeightNotFound))
                     .map_err(|e| {
                         log::error!(
-                            "[consensus] verity_proof_weight,signed_voter_address: {:?}",
+                            "[consensus] verify_proof_weight,signed_voter_address: {:?}",
                             signed_voter_address
                         );
                         e
@@ -776,7 +776,7 @@ where
                 accumulator += u64::from(*(weight));
             } else {
                 log::error!(
-                    "[consensus] verity_proof_weight, weight not found, signed_voter_address: {:?}",
+                    "[consensus] verify_proof_weight, weight not found, signed_voter_address: {:?}",
                     signed_voter_address
                 );
                 return Err(
@@ -787,7 +787,7 @@ where
 
         if 3 * accumulator <= 2 * total_validator_weight {
             log::error!(
-                "[consensus] verity_proof_weight, accumulator: {}, total: {}",
+                "[consensus] verify_proof_weight, accumulator: {}, total: {}",
                 accumulator,
                 total_validator_weight
             );

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -550,9 +550,9 @@ where
             .verifier_list
             .iter()
             .map(|v| {
-                let address = v.peer_id.clone();
+                let address = v.peer_id.decode();
                 let node = Node {
-                    address:        v.peer_id.clone(),
+                    address:        v.peer_id.decode(),
                     propose_weight: v.propose_weight,
                     vote_weight:    v.vote_weight,
                 };
@@ -667,7 +667,7 @@ where
             .verifier_list
             .iter()
             .map(|v| Node {
-                address:        v.peer_id.clone(),
+                address:        v.peer_id.decode(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })
@@ -701,7 +701,7 @@ where
             .verifier_list
             .iter()
             .filter_map(|v| {
-                if signed_voters.contains(&v.peer_id) {
+                if signed_voters.contains(&v.peer_id.decode()) {
                     Some(v.bls_pub_key.clone())
                 } else {
                     None

--- a/core/consensus/src/consensus.rs
+++ b/core/consensus/src/consensus.rs
@@ -119,7 +119,7 @@ impl<Adapter: ConsensusAdapter + 'static> OverlordConsensus<Adapter> {
             lock,
         ));
 
-        let overlord = Overlord::new(node_info.self_peer_id, Arc::clone(&engine), crypto, engine);
+        let overlord = Overlord::new(node_info.self_pub_key, Arc::clone(&engine), crypto, engine);
         let overlord_handler = overlord.get_handler();
         let status = status_agent.to_inner();
 
@@ -177,7 +177,7 @@ pub fn gen_overlord_status(
     let mut authority_list = validators
         .into_iter()
         .map(|v| Node {
-            address:        v.peer_id.clone(),
+            address:        v.pub_key.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/core/consensus/src/consensus.rs
+++ b/core/consensus/src/consensus.rs
@@ -182,7 +182,7 @@ pub fn gen_overlord_status(
     let mut authority_list = validators
         .into_iter()
         .map(|v| Node {
-            address:        v.address.as_bytes(),
+            address:        v.peer_id,
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -216,7 +216,7 @@ impl<T: overlord::Codec> OverlordMsgExt for OverlordMsg<T> {
             OverlordMsg::AggregatedVote(av) => av.get_height().to_string(),
             OverlordMsg::RichStatus(s) => s.height.to_string(),
             OverlordMsg::SignedChoke(sc) => sc.choke.height.to_string(),
-            OverlordMsg::Stop => "".to_owned(),
+            _ => "".to_owned(),
         }
     }
 
@@ -225,9 +225,8 @@ impl<T: overlord::Codec> OverlordMsgExt for OverlordMsg<T> {
             OverlordMsg::SignedProposal(sp) => sp.proposal.round.to_string(),
             OverlordMsg::SignedVote(sv) => sv.get_round().to_string(),
             OverlordMsg::AggregatedVote(av) => av.get_round().to_string(),
-            OverlordMsg::RichStatus(_) => "".to_owned(),
             OverlordMsg::SignedChoke(sc) => sc.choke.round.to_string(),
-            OverlordMsg::Stop => "".to_owned(),
+            _ => "".to_owned(),
         }
     }
 }

--- a/core/consensus/src/consensus.rs
+++ b/core/consensus/src/consensus.rs
@@ -120,7 +120,7 @@ impl<Adapter: ConsensusAdapter + 'static> OverlordConsensus<Adapter> {
         ));
 
         let overlord = Overlord::new(
-            node_info.self_address.as_bytes(),
+            node_info.self_peer_id.clone(),
             Arc::clone(&engine),
             crypto,
             engine,

--- a/core/consensus/src/consensus.rs
+++ b/core/consensus/src/consensus.rs
@@ -119,12 +119,7 @@ impl<Adapter: ConsensusAdapter + 'static> OverlordConsensus<Adapter> {
             lock,
         ));
 
-        let overlord = Overlord::new(
-            node_info.self_peer_id.clone(),
-            Arc::clone(&engine),
-            crypto,
-            engine,
-        );
+        let overlord = Overlord::new(node_info.self_peer_id, Arc::clone(&engine), crypto, engine);
         let overlord_handler = overlord.get_handler();
         let status = status_agent.to_inner();
 
@@ -182,7 +177,7 @@ pub fn gen_overlord_status(
     let mut authority_list = validators
         .into_iter()
         .map(|v| Node {
-            address:        v.peer_id,
+            address:        v.peer_id.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -520,7 +520,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             .verifier_list
             .into_iter()
             .map(|v| Node {
-                address:        v.peer_id,
+                address:        v.peer_id.decode(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })
@@ -759,7 +759,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
 pub fn generate_new_crypto_map(metadata: Metadata) -> ProtocolResult<HashMap<Bytes, BlsPublicKey>> {
     let mut new_addr_pubkey_map = HashMap::new();
     for validator in metadata.verifier_list.into_iter() {
-        let addr = validator.peer_id;
+        let addr = validator.peer_id.decode();
         let hex_pubkey = hex::decode(validator.bls_pub_key.as_string_trim0x()).map_err(|err| {
             ConsensusError::Other(format!("hex decode metadata bls pubkey error {:?}", err))
         })?;

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -454,12 +454,12 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
     /// Only signed vote will be transmit to the relayer.
     #[muta_apm::derive::tracing_span(
         kind = "consensus.engine",
-        logs = "{'address': 'Address::from_bytes(addr.clone()).unwrap().as_hex()'}"
+        logs = "{'peer_id': 'hex::encode(peer_id.clone())'}"
     )]
     async fn transmit_to_relayer(
         &self,
         ctx: Context,
-        addr: Bytes,
+        peer_id: Bytes,
         msg: OverlordMsg<FixedPill>,
     ) -> Result<(), Box<dyn Error + Send>> {
         match msg {
@@ -470,7 +470,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_SIGNED_VOTE,
-                        MessageTarget::Specified(addr),
+                        MessageTarget::Specified(peer_id),
                     )
                     .await?;
             }
@@ -481,7 +481,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_AGGREGATED_VOTE,
-                        MessageTarget::Specified(addr),
+                        MessageTarget::Specified(peer_id),
                     )
                     .await?;
             }

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -454,8 +454,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
     /// Only signed vote will be transmit to the relayer.
     #[muta_apm::derive::tracing_span(
         kind = "consensus.engine",
-        logs = "{'address':
-    'Address::from_bytes(addr.clone()).unwrap().as_hex()'}"
+        logs = "{'address': 'Address::from_bytes(addr.clone()).unwrap().as_hex()'}"
     )]
     async fn transmit_to_relayer(
         &self,
@@ -471,7 +470,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_SIGNED_VOTE,
-                        MessageTarget::Specified(Address::from_bytes(addr)?),
+                        MessageTarget::Specified(addr),
                     )
                     .await?;
             }
@@ -482,7 +481,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_AGGREGATED_VOTE,
-                        MessageTarget::Specified(Address::from_bytes(addr)?),
+                        MessageTarget::Specified(addr),
                     )
                     .await?;
             }
@@ -521,7 +520,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             .verifier_list
             .into_iter()
             .map(|v| Node {
-                address:        v.address.as_bytes(),
+                address:        v.peer_id,
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })
@@ -760,7 +759,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
 pub fn generate_new_crypto_map(metadata: Metadata) -> ProtocolResult<HashMap<Bytes, BlsPublicKey>> {
     let mut new_addr_pubkey_map = HashMap::new();
     for validator in metadata.verifier_list.into_iter() {
-        let addr = validator.address.as_bytes();
+        let addr = validator.peer_id;
         let hex_pubkey = hex::decode(validator.bls_pub_key.as_string_trim0x()).map_err(|err| {
             ConsensusError::Other(format!("hex decode metadata bls pubkey error {:?}", err))
         })?;
@@ -775,7 +774,7 @@ fn covert_to_overlord_authority(validators: &[Validator]) -> Vec<Node> {
     let mut authority = validators
         .iter()
         .map(|v| Node {
-            address:        v.address.as_bytes(),
+            address:        v.peer_id.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -462,7 +462,8 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
         pub_key: Bytes,
         msg: OverlordMsg<FixedPill>,
     ) -> Result<(), Box<dyn Error + Send>> {
-        let peer_id = Bytes::from(core_network::peer_id_from_pubkey_bytes(pub_key.clone())?.into_bytes());
+        let peer_id =
+            Bytes::from(core_network::peer_id_from_pubkey_bytes(pub_key.clone())?.into_bytes());
 
         match msg {
             OverlordMsg::SignedVote(sv) => {

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -462,6 +462,8 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
         pub_key: Bytes,
         msg: OverlordMsg<FixedPill>,
     ) -> Result<(), Box<dyn Error + Send>> {
+        let peer_id = Bytes::from(core_network::peer_id_from_pubkey_bytes(pub_key.clone())?.into_bytes());
+
         match msg {
             OverlordMsg::SignedVote(sv) => {
                 let msg = sv.rlp_bytes();
@@ -470,7 +472,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_SIGNED_VOTE,
-                        MessageTarget::Specified(pub_key),
+                        MessageTarget::Specified(peer_id),
                     )
                     .await?;
             }
@@ -481,7 +483,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_AGGREGATED_VOTE,
-                        MessageTarget::Specified(pub_key),
+                        MessageTarget::Specified(peer_id),
                     )
                     .await?;
             }

--- a/core/consensus/src/status.rs
+++ b/core/consensus/src/status.rs
@@ -146,7 +146,7 @@ impl CurrentConsensusStatus {
             .verifier_list
             .iter()
             .map(|v| Validator {
-                peer_id:        v.peer_id.decode(),
+                pub_key:        v.pub_key.decode(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })

--- a/core/consensus/src/status.rs
+++ b/core/consensus/src/status.rs
@@ -146,7 +146,7 @@ impl CurrentConsensusStatus {
             .verifier_list
             .iter()
             .map(|v| Validator {
-                address:        v.address.clone(),
+                peer_id:        v.peer_id.clone(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })

--- a/core/consensus/src/status.rs
+++ b/core/consensus/src/status.rs
@@ -147,7 +147,6 @@ impl CurrentConsensusStatus {
             .iter()
             .map(|v| Validator {
                 pub_key:        v.pub_key.decode(),
-                address:        v.address.as_bytes(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })

--- a/core/consensus/src/status.rs
+++ b/core/consensus/src/status.rs
@@ -146,7 +146,7 @@ impl CurrentConsensusStatus {
             .verifier_list
             .iter()
             .map(|v| Validator {
-                peer_id:        v.peer_id.clone(),
+                peer_id:        v.peer_id.decode(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })

--- a/core/consensus/src/status.rs
+++ b/core/consensus/src/status.rs
@@ -147,6 +147,7 @@ impl CurrentConsensusStatus {
             .iter()
             .map(|v| Validator {
                 pub_key:        v.pub_key.decode(),
+                address:        v.address.as_bytes(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -156,8 +156,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
 
     #[muta_apm::derive::tracing_span(
         kind = "consensus.sync",
-        logs = "{'current_height': 'current_height', 'remote_height':
-    'remote_height'}"
+        logs = "{'current_height': 'current_height', 'remote_height': 'remote_height'}"
     )]
     async fn start_sync(
         &self,
@@ -364,11 +363,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
         Ok(())
     }
 
-    #[muta_apm::derive::tracing_span(
-        kind = "consensus.sync",
-        logs = "{'height':
-    'height'}"
-    )]
+    #[muta_apm::derive::tracing_span(kind = "consensus.sync", logs = "{'height': 'height'}")]
     async fn get_rich_block_from_remote(
         &self,
         ctx: Context,
@@ -390,22 +385,14 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
         Ok(RichBlock { block, txs })
     }
 
-    #[muta_apm::derive::tracing_span(
-        kind = "consensus.sync",
-        logs = "{'height':
-    'height'}"
-    )]
+    #[muta_apm::derive::tracing_span(kind = "consensus.sync", logs = "{'height': 'height'}")]
     async fn get_block_from_remote(&self, ctx: Context, height: u64) -> ProtocolResult<Block> {
         self.adapter
             .get_block_from_remote(ctx.clone(), height)
             .await
     }
 
-    #[muta_apm::derive::tracing_span(
-        kind = "consensus.sync",
-        logs = "{'txs_len':
-    'txs.len()'}"
-    )]
+    #[muta_apm::derive::tracing_span(kind = "consensus.sync", logs = "{'txs_len': 'txs.len()'}")]
     async fn save_chain_data(
         &self,
         ctx: Context,

--- a/core/consensus/src/tests/status.rs
+++ b/core/consensus/src/tests/status.rs
@@ -151,7 +151,7 @@ fn mock_validators_extend(len: usize) -> Vec<ValidatorExtend> {
                 "0xd654c7a6747fc2e34808c1ebb1510bfb19b443d639f2fab6dc41fce9f634de37".to_string(),
             )
             .unwrap(),
-            peer_id:        mock_peer_id(),
+            pub_key:        mock_pub_key(),
             address:        mock_address(),
             propose_weight: random::<u32>(),
             vote_weight:    random::<u32>(),
@@ -202,7 +202,7 @@ fn mock_validators(len: usize) -> Vec<Validator> {
 
 fn mock_validator() -> Validator {
     Validator {
-        peer_id:        mock_peer_id().decode(),
+        pub_key:        mock_pub_key().decode(),
         propose_weight: random::<u32>(),
         vote_weight:    random::<u32>(),
     }
@@ -231,9 +231,9 @@ fn mock_address() -> Address {
     Address::from_hash(hash).unwrap()
 }
 
-fn mock_peer_id() -> Hex {
+fn mock_pub_key() -> Hex {
     Hex::from_string(
-        "0x1220c7b1dc28da9eeecc7b825f39d0c1e79f87a5cf8a44d888c9f1f1b1ad6be0c79b".to_owned(),
+        "0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004".to_owned(),
     )
     .unwrap()
 }

--- a/core/consensus/src/tests/status.rs
+++ b/core/consensus/src/tests/status.rs
@@ -203,6 +203,7 @@ fn mock_validators(len: usize) -> Vec<Validator> {
 fn mock_validator() -> Validator {
     Validator {
         pub_key:        mock_pub_key().decode(),
+        address:        mock_address().as_bytes(),
         propose_weight: random::<u32>(),
         vote_weight:    random::<u32>(),
     }

--- a/core/consensus/src/tests/status.rs
+++ b/core/consensus/src/tests/status.rs
@@ -203,7 +203,6 @@ fn mock_validators(len: usize) -> Vec<Validator> {
 fn mock_validator() -> Validator {
     Validator {
         pub_key:        mock_pub_key().decode(),
-        address:        mock_address().as_bytes(),
         propose_weight: random::<u32>(),
         vote_weight:    random::<u32>(),
     }

--- a/core/consensus/src/tests/status.rs
+++ b/core/consensus/src/tests/status.rs
@@ -151,6 +151,7 @@ fn mock_validators_extend(len: usize) -> Vec<ValidatorExtend> {
                 "0xd654c7a6747fc2e34808c1ebb1510bfb19b443d639f2fab6dc41fce9f634de37".to_string(),
             )
             .unwrap(),
+            peer_id:        mock_peer_id(),
             address:        mock_address(),
             propose_weight: random::<u32>(),
             vote_weight:    random::<u32>(),
@@ -201,7 +202,7 @@ fn mock_validators(len: usize) -> Vec<Validator> {
 
 fn mock_validator() -> Validator {
     Validator {
-        address:        mock_address(),
+        peer_id:        mock_peer_id().decode(),
         propose_weight: random::<u32>(),
         vote_weight:    random::<u32>(),
     }
@@ -228,6 +229,13 @@ fn mock_hash() -> Hash {
 fn mock_address() -> Address {
     let hash = mock_hash();
     Address::from_hash(hash).unwrap()
+}
+
+fn mock_peer_id() -> Hex {
+    Hex::from_string(
+        "0x1220c7b1dc28da9eeecc7b825f39d0c1e79f87a5cf8a44d888c9f1f1b1ad6be0c79b".to_owned(),
+    )
+    .unwrap()
 }
 
 fn get_random_bytes(len: usize) -> Bytes {

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -353,9 +353,9 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             .verifier_list
             .iter()
             .map(|v| {
-                let address = v.peer_id.clone();
+                let address = v.peer_id.decode();
                 let node = Node {
-                    address:        v.peer_id.clone(),
+                    address:        v.peer_id.decode(),
                     propose_weight: v.propose_weight,
                     vote_weight:    v.vote_weight,
                 };
@@ -461,7 +461,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             .verifier_list
             .iter()
             .map(|v| Node {
-                address:        v.peer_id.clone(),
+                address:        v.peer_id.decode(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })
@@ -484,7 +484,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             .verifier_list
             .iter()
             .filter_map(|v| {
-                if signed_voters.contains(&v.peer_id) {
+                if signed_voters.contains(&v.peer_id.decode()) {
                     Some(v.bls_pub_key.clone())
                 } else {
                     None
@@ -879,7 +879,7 @@ fn mock_proof(block_hash: Hash, height: u64, round: u64, key_tool: &KeyTool) -> 
         .clone()
         .iter()
         .map(|v| Node {
-            address:        v.peer_id.clone(),
+            address:        v.peer_id.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -1064,21 +1064,21 @@ fn mock_verifier_list() -> Vec<ValidatorExtend> {
     vec![
         ValidatorExtend {
             bls_pub_key: Hex::from_string("0x04061c1c36a4252e8267ca143d1947f185dd6a04b5cc20f3ec85290e4e631fb67766392fa726120b1235da64fb2e5ffa4813c7dfe67b8019765b231ac0fbb5e5d45b12cf39ba98c02a6f1587bc6f4d8d7b7324efb40d3b6798b3f1792fc414c5df".to_owned()).unwrap(),
-            peer_id: Bytes::from(hex::decode("1220c8007bb2f04b921ec052df4836a5c81e658c8975e4b514da3cefbc64cb824932").unwrap()),
+            peer_id: Hex::from_string("0x1220c8007bb2f04b921ec052df4836a5c81e658c8975e4b514da3cefbc64cb824932".to_owned()).unwrap(),
             address: Address::from_hex("0x40e680f764a84c3add6753685aecf59700e24a4b").unwrap(),
             propose_weight: 5,
             vote_weight:    5,
         },
         ValidatorExtend {
             bls_pub_key: Hex::from_string("0x0410d89f114ebd98a984fa2e964decc6b7b7542326a1abb6e4725b34c70f4408dbfff312ce163147039a6b07737b25902d082194cfe36b50f81d5106f6ee6ea146c4fbcfc87de87bdcd49ce087c01411b37c520402bd0a40fd13ce550c237362a0".to_owned()).unwrap(),
-            peer_id:        Bytes::from(hex::decode("122095c712e8fc94f2febfd4eb21a05dbc78ed2b45a7135e7a72422cfa69a22bf14c").unwrap()),
+            peer_id: Hex::from_string("0x122095c712e8fc94f2febfd4eb21a05dbc78ed2b45a7135e7a72422cfa69a22bf14c".to_owned()).unwrap(),
             address: Address::from_hex("0x8b1de21fb70dc97256f756fbdb04f91891e329bf").unwrap(),
             propose_weight: 1,
             vote_weight:    1,
         },
         ValidatorExtend {
             bls_pub_key: Hex::from_string("0x0402de7a497fb892c60aa98e3ec31a2de10d7f0f952aba3764caed202e3874cdb536b4c018c198a7c9354b898f9500ec6812a72f83b72ba3fa31b16be77bedbc056625db790174ee811b3d763bb1bca1fcceaf00333e1b3ba98bfa53e65d9e6488".to_owned()).unwrap(),
-            peer_id:        Bytes::from(hex::decode("122024ff8439058d2fa71492e7606547dadc0e0d8bda3c240cca50b6066fa813b1c2").unwrap()),
+            peer_id: Hex::from_string("0x122024ff8439058d2fa71492e7606547dadc0e0d8bda3c240cca50b6066fa813b1c2".to_owned()).unwrap(),
             address: Address::from_hex("0x8af94238483ea5660f3d30674db9b0ee683d9948").unwrap(),
             propose_weight: 1,
             vote_weight:    1,

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -679,6 +679,9 @@ fn mock_chained_rich_block(len: u64, gap: u64, key_tool: &KeyTool) -> (Vec<RichB
                 )
                 .unwrap()
                 .decode(),
+                address:        Address::from_hex("0x40e680f764a84c3add6753685aecf59700e24a4b")
+                    .unwrap()
+                    .as_bytes(),
                 propose_weight: 5,
                 vote_weight:    5,
             }],
@@ -763,6 +766,9 @@ fn mock_genesis_rich_block() -> RichBlock {
             )
             .unwrap()
             .decode(),
+            address:        Address::from_hex("0x40e680f764a84c3add6753685aecf59700e24a4b")
+                .unwrap()
+                .as_bytes(),
             propose_weight: 0,
             vote_weight:    0,
         }],

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -514,7 +514,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             .map(|node| (node.address.clone(), node.vote_weight))
             .collect::<HashMap<_, _>>();
 
-        self.verity_proof_weight(ctx.clone(), block.header.height, weight_map, signed_voters)?;
+        self.verify_proof_weight(ctx.clone(), block.header.height, weight_map, signed_voters)?;
 
         Ok(())
     }
@@ -540,7 +540,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             })
     }
 
-    fn verity_proof_weight(
+    fn verify_proof_weight(
         &self,
         _ctx: Context,
         block_height: u64,
@@ -554,7 +554,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             if weight_map.contains_key(signed_voter_address) {
                 let weight = weight_map.get(signed_voter_address).ok_or({
                     log::error!(
-                        "[consensus] verity_proof_weight, signed_voter_address: {:?}",
+                        "[consensus] verify_proof_weight, signed_voter_address: {:?}",
                         hex::encode(signed_voter_address)
                     );
                     ConsensusError::VerifyProof(block_height, WeightNotFound)
@@ -562,7 +562,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
                 accumulator += u64::from(*(weight));
             } else {
                 log::error!(
-                    "[consensus] verity_proof_weight,signed_voter_address: {:?}",
+                    "[consensus] verify_proof_weight,signed_voter_address: {:?}",
                     hex::encode(signed_voter_address)
                 );
                 return Err(
@@ -573,7 +573,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
 
         if 3 * accumulator <= 2 * total_validator_weight {
             log::error!(
-                "[consensus] verity_proof_weight, accumulator: {}, total: {}",
+                "[consensus] verify_proof_weight, accumulator: {}, total: {}",
                 accumulator,
                 total_validator_weight
             );

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -679,9 +679,6 @@ fn mock_chained_rich_block(len: u64, gap: u64, key_tool: &KeyTool) -> (Vec<RichB
                 )
                 .unwrap()
                 .decode(),
-                address:        Address::from_hex("0x40e680f764a84c3add6753685aecf59700e24a4b")
-                    .unwrap()
-                    .as_bytes(),
                 propose_weight: 5,
                 vote_weight:    5,
             }],
@@ -766,9 +763,6 @@ fn mock_genesis_rich_block() -> RichBlock {
             )
             .unwrap()
             .decode(),
-            address:        Address::from_hex("0x40e680f764a84c3add6753685aecf59700e24a4b")
-                .unwrap()
-                .as_bytes(),
             propose_weight: 0,
             vote_weight:    0,
         }],

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -9,7 +9,6 @@ use futures::lock::Mutex;
 use overlord::types::{AggregatedSignature, AggregatedVote, Node, SignedVote, Vote, VoteType};
 use overlord::{extract_voters, Crypto};
 use parking_lot::RwLock;
-use tentacle_secio::SecioKeyPair;
 
 use common_crypto::{
     BlsCommonReference, BlsPrivateKey, BlsPublicKey, HashValue, PrivateKey, PublicKey,
@@ -993,9 +992,9 @@ fn get_mock_key_tool() -> KeyTool {
         hex::decode("bd5da51982aa5ccc1bd6cec68ffee0caa708671ba5149390c39e4f660bfe4c49").unwrap();
     let secp_privkey = Secp256k1PrivateKey::try_from(hex_privkey.as_ref()).unwrap();
     let secp_pubkey: Secp256k1PublicKey = secp_privkey.pub_key();
-    let keypair = SecioKeyPair::secp256k1_raw_key(secp_privkey.to_bytes().as_ref())
-        .expect("secp256k1 keypair");
-    let peer_id = keypair.to_public_key().peer_id().into_bytes();
+    let peer_id =
+        hex::decode("1220c8007bb2f04b921ec052df4836a5c81e658c8975e4b514da3cefbc64cb824932")
+            .unwrap();
 
     let signer_node = SignerNode::new(secp_privkey, secp_pubkey, Bytes::from(peer_id));
 

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -9,7 +9,7 @@ use futures::lock::Mutex;
 use overlord::types::{AggregatedSignature, AggregatedVote, Node, SignedVote, Vote, VoteType};
 use overlord::{extract_voters, Crypto};
 use parking_lot::RwLock;
-use rlp::encode;
+use tentacle_secio::SecioKeyPair;
 
 use common_crypto::{
     BlsCommonReference, BlsPrivateKey, BlsPublicKey, HashValue, PrivateKey, PublicKey,
@@ -286,7 +286,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
     ) -> ProtocolResult<Metadata> {
         Ok(Metadata {
             chain_id:        Hash::from_empty(),
-            common_ref:      Hex::from_string("0x3453376d613471795964".to_string()).unwrap(),
+            common_ref:      Hex::from_string("0x5131414c656c5454355a".to_string()).unwrap(),
             timeout_gap:     20,
             cycles_limit:    9999,
             cycles_price:    1,
@@ -351,11 +351,11 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
 
         let authority_map = previous_metadata
             .verifier_list
-            .into_iter()
+            .iter()
             .map(|v| {
-                let address = v.address.as_bytes();
+                let address = v.peer_id.clone();
                 let node = Node {
-                    address:        v.address.as_bytes(),
+                    address:        v.peer_id.clone(),
                     propose_weight: v.propose_weight,
                     vote_weight:    v.vote_weight,
                 };
@@ -365,7 +365,10 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
 
         // check proposer
         if block.header.height != 0
-            && !authority_map.contains_key(&block.header.proposer.as_bytes())
+            && !previous_metadata
+                .verifier_list
+                .iter()
+                .any(|v| v.address == block.header.proposer)
         {
             log::error!(
                 "[consensus] verify_block_header, block.header.proposer: {:?}, authority_map: {:?}",
@@ -377,10 +380,10 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
 
         // check validators
         for validator in block.header.validators.iter() {
-            if !authority_map.contains_key(&validator.address.as_bytes()) {
+            if !authority_map.contains_key(&validator.peer_id) {
                 log::error!(
                     "[consensus] verify_block_header, validator.address: {:?}, authority_map: {:?}",
-                    validator.address,
+                    validator.peer_id,
                     authority_map
                 );
                 return Err(ConsensusError::VerifyBlockHeader(
@@ -389,14 +392,14 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
                 )
                 .into());
             } else {
-                let node = authority_map.get(&validator.address.as_bytes()).unwrap();
+                let node = authority_map.get(&validator.peer_id).unwrap();
 
                 if node.vote_weight != validator.vote_weight
                     || node.propose_weight != validator.vote_weight
                 {
                     log::error!(
                         "[consensus] verify_block_header, validator.address: {:?}, authority_map: {:?}",
-                        validator.address,
+                        validator.peer_id,
                         authority_map
                     );
                     return Err(ConsensusError::VerifyBlockHeader(
@@ -458,7 +461,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             .verifier_list
             .iter()
             .map(|v| Node {
-                address:        v.address.as_bytes(),
+                address:        v.peer_id.clone(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })
@@ -481,7 +484,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             .verifier_list
             .iter()
             .filter_map(|v| {
-                if signed_voters.contains(&v.address.as_bytes()) {
+                if signed_voters.contains(&v.peer_id) {
                     Some(v.bls_pub_key.clone())
                 } else {
                     None
@@ -509,7 +512,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
         let weight_map = authority_list
             .iter()
             .map(|node| (node.address.clone(), node.vote_weight))
-            .collect::<HashMap<overlord::types::Address, u32>>();
+            .collect::<HashMap<_, _>>();
 
         self.verity_proof_weight(ctx.clone(), block.header.height, weight_map, signed_voters)?;
 
@@ -547,12 +550,12 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
         let total_validator_weight: u64 = weight_map.iter().map(|pair| u64::from(*pair.1)).sum();
 
         let mut accumulator = 0u64;
-        for signed_voter_address in signed_voters {
-            if weight_map.contains_key(signed_voter_address.as_ref()) {
-                let weight = weight_map.get(signed_voter_address.as_ref()).ok_or({
+        for signed_voter_address in signed_voters.iter() {
+            if weight_map.contains_key(signed_voter_address) {
+                let weight = weight_map.get(signed_voter_address).ok_or({
                     log::error!(
-                        "[consensus] verity_proof_weight,signed_voter_address: {:?}",
-                        signed_voter_address
+                        "[consensus] verity_proof_weight, signed_voter_address: {:?}",
+                        hex::encode(signed_voter_address)
                     );
                     ConsensusError::VerifyProof(block_height, WeightNotFound)
                 })?;
@@ -560,7 +563,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             } else {
                 log::error!(
                     "[consensus] verity_proof_weight,signed_voter_address: {:?}",
-                    signed_voter_address
+                    hex::encode(signed_voter_address)
                 );
                 return Err(
                     ConsensusError::VerifyProof(block_height, BlockProofField::Validator).into(),
@@ -664,12 +667,16 @@ fn mock_chained_rich_block(len: u64, gap: u64, key_tool: &KeyTool) -> (Vec<RichB
             state_root: Hash::from_empty(),
             receipt_root: vec![],
             cycles_used: vec![],
-            proposer: Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773").unwrap(),
+            proposer: Address::from_hex("0x40e680f764a84c3add6753685aecf59700e24a4b").unwrap(),
             proof: last_proof,
             validator_version: 0,
             validators: vec![Validator {
-                address:        Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773")
+                peer_id:        Bytes::from(
+                    hex::decode(
+                        "1220c8007bb2f04b921ec052df4836a5c81e658c8975e4b514da3cefbc64cb824932",
+                    )
                     .unwrap(),
+                ),
                 propose_weight: 5,
                 vote_weight:    5,
             }],
@@ -737,7 +744,7 @@ fn mock_genesis_rich_block() -> RichBlock {
         receipt_root:                   vec![],
         cycles_used:                    vec![],
         proposer:                       Address::from_hex(
-            "0x82c67c421d208fb7015d2da79550212a50f2e773",
+            "0x40e680f764a84c3add6753685aecf59700e24a4b",
         )
         .unwrap(),
         proof:                          Proof {
@@ -749,8 +756,10 @@ fn mock_genesis_rich_block() -> RichBlock {
         },
         validator_version:              0,
         validators:                     vec![Validator {
-            address:        Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773")
-                .unwrap(),
+            peer_id:        Bytes::from(
+                hex::decode("1220c8007bb2f04b921ec052df4836a5c81e658c8975e4b514da3cefbc64cb824932")
+                    .unwrap(),
+            ),
             propose_weight: 0,
             vote_weight:    0,
         }],
@@ -846,19 +855,23 @@ fn mock_proof(block_hash: Hash, height: u64, round: u64, key_tool: &KeyTool) -> 
         block_hash: block_hash.as_bytes(),
     };
 
-    let vote_hash = key_tool.overlord_crypto.hash(Bytes::from(encode(&vote)));
+    let vote_hash = key_tool
+        .overlord_crypto
+        .hash(Bytes::from(rlp::encode(&vote)));
     let bls_signature = key_tool.overlord_crypto.sign(vote_hash).unwrap();
     let signed_vote = SignedVote {
-        voter:     key_tool.signer_node.secp_address.as_bytes(),
+        voter:     key_tool.signer_node.peer_id.clone(),
         signature: bls_signature,
         vote:      vote.clone(),
     };
 
-    let signed_voter =
-        vec![Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773").unwrap()]
-            .iter()
-            .cloned()
-            .collect::<HashSet<Address>>(); //
+    let signed_voter = vec![Bytes::from(
+        hex::decode("1220c8007bb2f04b921ec052df4836a5c81e658c8975e4b514da3cefbc64cb824932")
+            .unwrap(),
+    )]
+    .iter()
+    .cloned()
+    .collect::<HashSet<Bytes>>(); //
     let mut bit_map = BitVec::from_elem(3, false);
 
     let mut authority_list: Vec<Node> = key_tool
@@ -866,7 +879,7 @@ fn mock_proof(block_hash: Hash, height: u64, round: u64, key_tool: &KeyTool) -> 
         .clone()
         .iter()
         .map(|v| Node {
-            address:        v.address.as_bytes(),
+            address:        v.peer_id.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -874,7 +887,7 @@ fn mock_proof(block_hash: Hash, height: u64, round: u64, key_tool: &KeyTool) -> 
     authority_list.sort();
 
     for (index, node) in authority_list.iter().enumerate() {
-        if signed_voter.contains(&Address::from_bytes(node.address.clone()).unwrap()) {
+        if signed_voter.contains(&node.address) {
             bit_map.set(index, true);
         }
     }
@@ -894,7 +907,7 @@ fn mock_proof(block_hash: Hash, height: u64, round: u64, key_tool: &KeyTool) -> 
         height,
         round,
         block_hash: block_hash.as_bytes(),
-        leader: key_tool.signer_node.secp_address.as_bytes(),
+        leader: key_tool.signer_node.peer_id.clone(),
     };
 
     Proof {
@@ -938,19 +951,19 @@ fn exec_txs(height: u64, txs: &[SignedTransaction]) -> (ExecutorResp, MerkleRoot
 struct SignerNode {
     secp_private_key: Secp256k1PrivateKey,
     secp_public_key:  Secp256k1PublicKey,
-    secp_address:     Address,
+    peer_id:          Bytes,
 }
 
 impl SignerNode {
     pub fn new(
         secp_private_key: Secp256k1PrivateKey,
         secp_public_key: Secp256k1PublicKey,
-        secp_address: Address,
+        peer_id: Bytes,
     ) -> Self {
         SignerNode {
             secp_private_key,
             secp_public_key,
-            secp_address,
+            peer_id,
         }
     }
 }
@@ -977,18 +990,20 @@ impl KeyTool {
 
 fn get_mock_key_tool() -> KeyTool {
     let hex_privkey =
-        hex::decode("d654c7a6747fc2e34808c1ebb1510bfb19b443d639f2fab6dc41fce9f634de37").unwrap();
+        hex::decode("bd5da51982aa5ccc1bd6cec68ffee0caa708671ba5149390c39e4f660bfe4c49").unwrap();
     let secp_privkey = Secp256k1PrivateKey::try_from(hex_privkey.as_ref()).unwrap();
     let secp_pubkey: Secp256k1PublicKey = secp_privkey.pub_key();
-    let secp_address = Address::from_pubkey_bytes(secp_pubkey.to_bytes()).unwrap();
+    let keypair = SecioKeyPair::secp256k1_raw_key(secp_privkey.to_bytes().as_ref())
+        .expect("secp256k1 keypair");
+    let peer_id = keypair.to_public_key().peer_id().into_bytes();
 
-    let signer_node = SignerNode::new(secp_privkey, secp_pubkey, secp_address);
+    let signer_node = SignerNode::new(secp_privkey, secp_pubkey, Bytes::from(peer_id));
 
     // generate BLS/OverlordCrypto
     let mut bls_priv_key = Vec::new();
     bls_priv_key.extend_from_slice(&[0u8; 16]);
     let mut tmp =
-        hex::decode("d654c7a6747fc2e34808c1ebb1510bfb19b443d639f2fab6dc41fce9f634de37").unwrap();
+        hex::decode("bd5da51982aa5ccc1bd6cec68ffee0caa708671ba5149390c39e4f660bfe4c49").unwrap();
     bls_priv_key.append(&mut tmp);
     let bls_priv_key = BlsPrivateKey::try_from(bls_priv_key.as_ref()).unwrap();
 
@@ -1003,39 +1018,42 @@ fn get_mock_public_keys_and_common_ref() -> (HashMap<Bytes, BlsPublicKey>, BlsCo
     let mut bls_pub_keys: HashMap<Bytes, BlsPublicKey> = HashMap::new();
 
     // weight = 3
-    let bls_hex = Hex::from_string("0x0403142cf2dc63d122cc31e8245daa661b4b7c47793a9ab14e3c27430e3a835cb50b0bda0ea90480765d73d509e02c15f8031c20a77254fb0a8ec2919f2ed13b02034153776ad30d8fad90da15e0b85cd98cb81fa5f810c62563c8b507ef11604e".to_string()
+    let bls_hex = Hex::from_string("0x04061c1c36a4252e8267ca143d1947f185dd6a04b5cc20f3ec85290e4e631fb67766392fa726120b1235da64fb2e5ffa4813c7dfe67b8019765b231ac0fbb5e5d45b12cf39ba98c02a6f1587bc6f4d8d7b7324efb40d3b6798b3f1792fc414c5df".to_string()
     ).unwrap();
     let bls_hex = hex::decode(bls_hex.as_string_trim0x()).unwrap();
     bls_pub_keys.insert(
-        Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773")
-            .unwrap()
-            .as_bytes(),
+        Bytes::from(
+            hex::decode("1220c8007bb2f04b921ec052df4836a5c81e658c8975e4b514da3cefbc64cb824932")
+                .unwrap(),
+        ),
         BlsPublicKey::try_from(bls_hex.as_ref()).unwrap(),
     );
 
     // weight = 1
-    let bls_hex = Hex::from_string("0x0414a4665f0d3d0a2b034e933a40f8e84a2113b12cdc33c1f17d28a4a5313768cfdb5c1b6d8f9a3e0df54c87d6fb196b1a0e93d284bfe15814f5bce36c4092bdf26c88b77798570a3ac251c630cc7995a89047f51b2a9aebb1046d81d52486be32".to_string()
+    let bls_hex = Hex::from_string("0x0410d89f114ebd98a984fa2e964decc6b7b7542326a1abb6e4725b34c70f4408dbfff312ce163147039a6b07737b25902d082194cfe36b50f81d5106f6ee6ea146c4fbcfc87de87bdcd49ce087c01411b37c520402bd0a40fd13ce550c237362a0".to_string()
     ).unwrap();
     let bls_hex = hex::decode(bls_hex.as_string_trim0x()).unwrap();
     bls_pub_keys.insert(
-        Address::from_hex("0x6c9e6d3ccf42a3e67f6bf132a53a92db3bc065b5")
-            .unwrap()
-            .as_bytes(),
+        Bytes::from(
+            hex::decode("122095c712e8fc94f2febfd4eb21a05dbc78ed2b45a7135e7a72422cfa69a22bf14c")
+                .unwrap(),
+        ),
         BlsPublicKey::try_from(bls_hex.as_ref()).unwrap(),
     );
 
     // weight = 1
-    let bls_hex = Hex::from_string("0x04051326c12edd4eded8a215566390a03896389b80422a652327fc438d64d65f1f60065b69215bb5c0864a46e149ba30d21138ad5981ad6e0c79a357eeb686a4d0cd690caccca169e6393a9b1cc850c203f474276ae71c291a1523ce76f0a8851e".to_string()
+    let bls_hex = Hex::from_string("0x0402de7a497fb892c60aa98e3ec31a2de10d7f0f952aba3764caed202e3874cdb536b4c018c198a7c9354b898f9500ec6812a72f83b72ba3fa31b16be77bedbc056625db790174ee811b3d763bb1bca1fcceaf00333e1b3ba98bfa53e65d9e6488".to_string()
     ).unwrap();
     let bls_hex = hex::decode(bls_hex.as_string_trim0x()).unwrap();
     bls_pub_keys.insert(
-        Address::from_hex("0x9b80c81780b782d03b3cebe0033bb78cb8d855d7")
-            .unwrap()
-            .as_bytes(),
+        Bytes::from(
+            hex::decode("122024ff8439058d2fa71492e7606547dadc0e0d8bda3c240cca50b6066fa813b1c2")
+                .unwrap(),
+        ),
         BlsPublicKey::try_from(bls_hex.as_ref()).unwrap(),
     );
 
-    let hex_common_ref = hex::decode("3453376d613471795964").unwrap();
+    let hex_common_ref = hex::decode("5131414c656c5454355a").unwrap();
     let common_ref: BlsCommonReference =
         std::str::from_utf8(hex_common_ref.as_ref()).unwrap().into();
 
@@ -1045,71 +1063,66 @@ fn get_mock_public_keys_and_common_ref() -> (HashMap<Bytes, BlsPublicKey>, BlsCo
 fn mock_verifier_list() -> Vec<ValidatorExtend> {
     vec![
         ValidatorExtend {
-
-            bls_pub_key: Hex::from_string("0x0403142cf2dc63d122cc31e8245daa661b4b7c47793a9ab14e3c27430e3a835cb50b0bda0ea90480765d73d509e02c15f8031c20a77254fb0a8ec2919f2ed13b02034153776ad30d8fad90da15e0b85cd98cb81fa5f810c62563c8b507ef11604e".to_owned()).unwrap(),
-            address:        Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773").unwrap(),
+            bls_pub_key: Hex::from_string("0x04061c1c36a4252e8267ca143d1947f185dd6a04b5cc20f3ec85290e4e631fb67766392fa726120b1235da64fb2e5ffa4813c7dfe67b8019765b231ac0fbb5e5d45b12cf39ba98c02a6f1587bc6f4d8d7b7324efb40d3b6798b3f1792fc414c5df".to_owned()).unwrap(),
+            peer_id: Bytes::from(hex::decode("1220c8007bb2f04b921ec052df4836a5c81e658c8975e4b514da3cefbc64cb824932").unwrap()),
+            address: Address::from_hex("0x40e680f764a84c3add6753685aecf59700e24a4b").unwrap(),
             propose_weight: 5,
             vote_weight:    5,
         },
         ValidatorExtend {
-            bls_pub_key: Hex::from_string("0x0414a4665f0d3d0a2b034e933a40f8e84a2113b12cdc33c1f17d28a4a5313768cfdb5c1b6d8f9a3e0df54c87d6fb196b1a0e93d284bfe15814f5bce36c4092bdf26c88b77798570a3ac251c630cc7995a89047f51b2a9aebb1046d81d52486be32".to_owned()).unwrap(),
-            address:        Address::from_hex("0x6c9e6d3ccf42a3e67f6bf132a53a92db3bc065b5").unwrap(),
+            bls_pub_key: Hex::from_string("0x0410d89f114ebd98a984fa2e964decc6b7b7542326a1abb6e4725b34c70f4408dbfff312ce163147039a6b07737b25902d082194cfe36b50f81d5106f6ee6ea146c4fbcfc87de87bdcd49ce087c01411b37c520402bd0a40fd13ce550c237362a0".to_owned()).unwrap(),
+            peer_id:        Bytes::from(hex::decode("122095c712e8fc94f2febfd4eb21a05dbc78ed2b45a7135e7a72422cfa69a22bf14c").unwrap()),
+            address: Address::from_hex("0x8b1de21fb70dc97256f756fbdb04f91891e329bf").unwrap(),
             propose_weight: 1,
             vote_weight:    1,
         },
         ValidatorExtend {
-            bls_pub_key: Hex::from_string("0x04051326c12edd4eded8a215566390a03896389b80422a652327fc438d64d65f1f60065b69215bb5c0864a46e149ba30d21138ad5981ad6e0c79a357eeb686a4d0cd690caccca169e6393a9b1cc850c203f474276ae71c291a1523ce76f0a8851e".to_owned()).unwrap(),
-            address:        Address::from_hex("0x9b80c81780b782d03b3cebe0033bb78cb8d855d7").unwrap(),
+            bls_pub_key: Hex::from_string("0x0402de7a497fb892c60aa98e3ec31a2de10d7f0f952aba3764caed202e3874cdb536b4c018c198a7c9354b898f9500ec6812a72f83b72ba3fa31b16be77bedbc056625db790174ee811b3d763bb1bca1fcceaf00333e1b3ba98bfa53e65d9e6488".to_owned()).unwrap(),
+            peer_id:        Bytes::from(hex::decode("122024ff8439058d2fa71492e7606547dadc0e0d8bda3c240cca50b6066fa813b1c2").unwrap()),
+            address: Address::from_hex("0x8af94238483ea5660f3d30674db9b0ee683d9948").unwrap(),
             propose_weight: 1,
             vote_weight:    1,
         },
     ]
 }
 
+#[rustfmt::skip]
 // {
-// "common_ref": "3453376d613471795964",
-// "keypairs": [
-// {
-// "index": 1,
-// "private_key":
-// "d654c7a6747fc2e34808c1ebb1510bfb19b443d639f2fab6dc41fce9f634de37",
-// "public_key":
-// "03eacfbe0c216b9afd1370da335a49f49b88a4a34cc99c15885812e36bfab774fd",
-// "address": "82c67c421d208fb7015d2da79550212a50f2e773",
-// "bls_public_key":
-// "0403142cf2dc63d122cc31e8245daa661b4b7c47793a9ab14e3c27430e3a835cb50b0bda0ea90480765d73d509e02c15f8031c20a77254fb0a8ec2919f2ed13b02034153776ad30d8fad90da15e0b85cd98cb81fa5f810c62563c8b507ef11604e"
-// },
-// {
-// "index": 2,
-// "private_key":
-// "aa0374de198a4ba1187e4a41b316e159ab256ce129bcc76c10d746edfe6f82e5",
-// "public_key":
-// "03bf246a94a98a4c96a71a02187b8bc98539f853287800a7fa38d67b2ed9643bd2",
-// "address": "6c9e6d3ccf42a3e67f6bf132a53a92db3bc065b5",
-// "bls_public_key":
-// "0414a4665f0d3d0a2b034e933a40f8e84a2113b12cdc33c1f17d28a4a5313768cfdb5c1b6d8f9a3e0df54c87d6fb196b1a0e93d284bfe15814f5bce36c4092bdf26c88b77798570a3ac251c630cc7995a89047f51b2a9aebb1046d81d52486be32"
-// },
-// {
-// "index": 3,
-// "private_key":
-// "0c27b03412cae1df9cd7374c2eab1daff1023721f9930f44d7f5a0f8172a2b32",
-// "public_key":
-// "028b1e157e441a3cd6f2f6116ecac24235c02e1d66471407484fba5dca44242a8f",
-// "address": "9b80c81780b782d03b3cebe0033bb78cb8d855d7",
-// "bls_public_key":
-// "04051326c12edd4eded8a215566390a03896389b80422a652327fc438d64d65f1f60065b69215bb5c0864a46e149ba30d21138ad5981ad6e0c79a357eeb686a4d0cd690caccca169e6393a9b1cc850c203f474276ae71c291a1523ce76f0a8851e"
-// },
-// {
-// "index": 4,
-// "private_key":
-// "fc57fc08dc883891b88292a2d2915050b9a09c8a6096dfb04372bdd15162665e",
-// "public_key":
-// "03c00ce1cb83fbf8151c98d110d8cc4d83a6884fcee27916d416882ce42ae5925c",
-// "address": "0804d72af82a05733df54a72278a73629b4bea17",
-// "bls_public_key":
-// "040d606915df9b432acf66cdd9338d240fe781fb05249957201613113dda384960022649e9fd9e8b66c8962bb5e223d30405c5590e8d9cae893384ace1789d61a73b325e638ef5ee1c47d3b2a5a863e19b54fbfc881b5cc0b8bb05fce04d514807"
-// }
-// ]
+//   "common_ref": "0x5131414c656c5454355a",
+//   "keypairs": [
+//     {
+//       "index": 1,
+//       "private_key": "0xbd5da51982aa5ccc1bd6cec68ffee0caa708671ba5149390c39e4f660bfe4c49",
+//       "public_key": "0x025a1f87bd7980510d8d4224e9e521ba2e98865f420c555568b1b71a64977b5e41",
+//       "address": "0x40e680f764a84c3add6753685aecf59700e24a4b",
+//       "peer_id": "0x1220c8007bb2f04b921ec052df4836a5c81e658c8975e4b514da3cefbc64cb824932",
+//       "bls_public_key": "0x04061c1c36a4252e8267ca143d1947f185dd6a04b5cc20f3ec85290e4e631fb67766392fa726120b1235da64fb2e5ffa4813c7dfe67b8019765b231ac0fbb5e5d45b12cf39ba98c02a6f1587bc6f4d8d7b7324efb40d3b6798b3f1792fc414c5df"
+//     },
+//     {
+//       "index": 2,
+//       "private_key": "0xabec0e3a9cc9e5722a8582f5fd7cbaada11a12b0f2733873699aa1c17218f35a",
+//       "public_key": "0x028206a78f082023be8eed96f8d3c09c006bd827fb47c04950b62d8dfcb4134467",
+//       "address": "0x8b1de21fb70dc97256f756fbdb04f91891e329bf",
+//       "peer_id": "0x122095c712e8fc94f2febfd4eb21a05dbc78ed2b45a7135e7a72422cfa69a22bf14c",
+//       "bls_public_key": "0x0410d89f114ebd98a984fa2e964decc6b7b7542326a1abb6e4725b34c70f4408dbfff312ce163147039a6b07737b25902d082194cfe36b50f81d5106f6ee6ea146c4fbcfc87de87bdcd49ce087c01411b37c520402bd0a40fd13ce550c237362a0"
+//     },
+//     {
+//       "index": 3,
+//       "private_key": "0x1c43ffb8a5110b37bf2fba6678760fee4cf5a408526c1ef00f28b8f574df1d92",
+//       "public_key": "0x0230eb18bc3f638750affffff2fe7be468e50feb9cdd5e6af947b3e4505f2ed5e2",
+//       "address": "0x8af94238483ea5660f3d30674db9b0ee683d9948",
+//       "peer_id": "0x122024ff8439058d2fa71492e7606547dadc0e0d8bda3c240cca50b6066fa813b1c2",
+//       "bls_public_key": "0x0402de7a497fb892c60aa98e3ec31a2de10d7f0f952aba3764caed202e3874cdb536b4c018c198a7c9354b898f9500ec6812a72f83b72ba3fa31b16be77bedbc056625db790174ee811b3d763bb1bca1fcceaf00333e1b3ba98bfa53e65d9e6488"
+//     },
+//     {
+//       "index": 4,
+//       "private_key": "0x598e505735b9237fcb6736a3a69bb8e7c8293ca4a9b3458b9cbeb1207d2b421f",
+//       "public_key": "0x036fa093c97cbacf1094abd51d3799f9b0920a8decb27f3d126fff37854b58fbb6",
+//       "address": "0x8fff53935d33415ba794d9d81e710872727f9a2d",
+//       "peer_id": "0x122008bbfbff46a3ad94dabb521d0f57e37c3e09b716496be22282e1b560f93963f1",
+//       "bls_public_key": "0x0407d5cd1321e00c596c5c10bc1fd07fad1bf56b3b8e262ae49b1d220a21fcdcf1232862dc51db3673b1337a44d9d04a991415f3afc872e188e2208e7a71ba3d86352a0ad10f5938dfeeb9594c1091ff29051b5baaee825c62c9487835daad9fa8"
+//     }
+//   ]
 // }
 
 fn assert_sync(status: CurrentConsensusStatus, latest_block: Block) {

--- a/core/consensus/src/util.rs
+++ b/core/consensus/src/util.rs
@@ -114,11 +114,11 @@ impl Crypto for OverlordCrypto {
 impl OverlordCrypto {
     pub fn new(
         private_key: BlsPrivateKey,
-        peer_id_with_pubkey: HashMap<Bytes, BlsPublicKey>,
+        pubkey_to_bls_pubkey: HashMap<Bytes, BlsPublicKey>,
         common_ref: BlsCommonReference,
     ) -> Self {
         OverlordCrypto {
-            addr_pubkey: RwLock::new(peer_id_with_pubkey),
+            addr_pubkey: RwLock::new(pubkey_to_bls_pubkey),
             private_key,
             common_ref,
         }

--- a/core/consensus/src/util.rs
+++ b/core/consensus/src/util.rs
@@ -114,11 +114,11 @@ impl Crypto for OverlordCrypto {
 impl OverlordCrypto {
     pub fn new(
         private_key: BlsPrivateKey,
-        addr_pubkey: HashMap<Bytes, BlsPublicKey>,
+        peer_id_with_pubkey: HashMap<Bytes, BlsPublicKey>,
         common_ref: BlsCommonReference,
     ) -> Self {
         OverlordCrypto {
-            addr_pubkey: RwLock::new(addr_pubkey),
+            addr_pubkey: RwLock::new(peer_id_with_pubkey),
             private_key,
             common_ref,
         }

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -573,11 +573,11 @@ mod tests {
             Ok(())
         }
 
-        async fn users_cast<M>(
+        async fn multicast<M>(
             &self,
             _: Context,
             _: &str,
-            _: Vec<Address>,
+            _: Vec<Bytes>,
             _: M,
             _: Priority,
         ) -> ProtocolResult<()>

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -519,7 +519,6 @@ mod tests {
 
     use protocol::{
         traits::{Context, Gossip, MessageCodec, Priority},
-        types::Address,
         Bytes, ProtocolResult,
     };
 

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -32,6 +32,7 @@ tentacle-identify = { git = "https://github.com/zeroqn/p2p", branch = "v0.3.0.al
 tokio = { version = "0.2", features = ["macros", "rt-core"]}
 hostname = "0.3"
 lazy_static = "1.4"
+bs58 = "0.3"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/core/network/src/common.rs
+++ b/core/network/src/common.rs
@@ -7,7 +7,7 @@ use protocol::Bytes;
 use serde_derive::{Deserialize, Serialize};
 use tentacle::{
     multiaddr::{Multiaddr, Protocol},
-    secio::PeerId,
+    secio::{PeerId, PublicKey},
 };
 
 use std::{
@@ -47,6 +47,13 @@ macro_rules! service_ready {
 
 pub fn peer_id_from_bytes(bytes: Bytes) -> Result<PeerId, NetworkError> {
     PeerId::from_bytes(bytes.to_vec()).map_err(|_| NetworkError::InvalidPeerId)
+}
+
+pub fn peer_id_from_pubkey_bytes(bytes: Bytes) -> Result<PeerId, NetworkError> {
+    let pubkey =
+        PublicKey::secp256k1_raw_key(&bytes).map_err(|_| NetworkError::InvalidPublicKey)?;
+
+    Ok(PeerId::from_public_key(&pubkey))
 }
 
 pub fn socket_to_multi_addr(socket_addr: SocketAddr) -> Multiaddr {

--- a/core/network/src/common.rs
+++ b/core/network/src/common.rs
@@ -1,3 +1,15 @@
+use crate::{error::NetworkError, traits::MultiaddrExt};
+
+use derive_more::Display;
+use futures::{pin_mut, task::AtomicWaker};
+use futures_timer::Delay;
+use protocol::Bytes;
+use serde_derive::{Deserialize, Serialize};
+use tentacle::{
+    multiaddr::{Multiaddr, Protocol},
+    secio::PeerId,
+};
+
 use std::{
     borrow::Cow,
     future::Future,
@@ -9,17 +21,6 @@ use std::{
     time::{Duration, Instant},
     vec::IntoIter,
 };
-
-use derive_more::Display;
-use futures::{pin_mut, task::AtomicWaker};
-use futures_timer::Delay;
-use serde_derive::{Deserialize, Serialize};
-use tentacle::{
-    multiaddr::{Multiaddr, Protocol},
-    secio::PeerId,
-};
-
-use crate::traits::MultiaddrExt;
 
 #[macro_export]
 macro_rules! loop_ready {
@@ -42,6 +43,10 @@ macro_rules! service_ready {
             }
         }
     };
+}
+
+pub fn peer_id_from_bytes(bytes: Bytes) -> Result<PeerId, NetworkError> {
+    PeerId::from_bytes(bytes.to_vec()).map_err(|_| NetworkError::InvalidPeerId)
 }
 
 pub fn socket_to_multi_addr(socket_addr: SocketAddr) -> Multiaddr {

--- a/core/network/src/error.rs
+++ b/core/network/src/error.rs
@@ -95,14 +95,12 @@ pub enum NetworkError {
     },
 
     #[display(
-        fmt = "send incompletely, unconnected {:?} unknown {:?}, other {:?}",
+        fmt = "send incompletely, unconnected {:?}, other {:?}",
         unconnected,
-        unknown,
         other
     )]
-    UserSend {
-        unconnected: Option<Vec<Address>>,
-        unknown:     Option<Vec<Address>>,
+    MultiCast {
+        unconnected: Option<Vec<PeerId>>,
         other:       Option<Box<dyn Error + Send>>,
     },
 
@@ -117,6 +115,9 @@ pub enum NetworkError {
 
     #[display(fmt = "cannot decode private key bytes")]
     InvalidPrivateKey,
+
+    #[display(fmt = "cannot decode peer id")]
+    InvalidPeerId,
 
     #[display(fmt = "unsupported peer address {}", _0)]
     UnexpectedPeerAddr(String),

--- a/core/network/src/error.rs
+++ b/core/network/src/error.rs
@@ -185,6 +185,12 @@ impl From<tentacle::error::TransportErrorKind> for NetworkError {
     }
 }
 
+impl From<NetworkError> for Box<dyn Error + Send> {
+    fn from(err: NetworkError) -> Box<dyn Error + Send> {
+        err.boxed()
+    }
+}
+
 impl NetworkError {
     pub fn boxed(self) -> Box<dyn Error + Send> {
         Box::new(self) as Box<dyn Error + Send>

--- a/core/network/src/event.rs
+++ b/core/network/src/event.rs
@@ -170,6 +170,8 @@ pub enum PeerManagerEvent {
         feedback: TrustFeedback,
     },
 
+    // FIXME: Reomve Whitelist
+    #[allow(dead_code)]
     #[display(fmt = "whitelist peers by chain addresses {:?}", chain_addrs)]
     WhitelistPeersByChainAddr { chain_addrs: Vec<Address> },
 

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -25,3 +25,5 @@ pub use service::{NetworkService, NetworkServiceHandle};
 
 #[cfg(feature = "diagnostic")]
 pub use peer_manager::diagnostic::{DiagnosticEvent, TrustReport};
+
+pub use tentacle::secio::PeerId;

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -26,4 +26,5 @@ pub use service::{NetworkService, NetworkServiceHandle};
 #[cfg(feature = "diagnostic")]
 pub use peer_manager::diagnostic::{DiagnosticEvent, TrustReport};
 
+pub use common::peer_id_from_pubkey_bytes;
 pub use tentacle::secio::PeerId;

--- a/core/network/src/outbound/gossip.rs
+++ b/core/network/src/outbound/gossip.rs
@@ -6,7 +6,7 @@ use protocol::{
 use tentacle::service::TargetSession;
 
 use crate::{
-    common::peer_id_from_bytes,
+    common::peer_id_from_pubkey_bytes,
     endpoint::Endpoint,
     error::NetworkError,
     message::{Headers, NetworkMessage},
@@ -64,13 +64,13 @@ where
     async fn multisend(
         &self,
         _ctx: Context,
-        peer_ids: Vec<Bytes>,
+        pub_keys: Vec<Bytes>,
         msg: Bytes,
         pri: Priority,
     ) -> Result<(), NetworkError> {
-        let peers = peer_ids
+        let peers = pub_keys
             .into_iter()
-            .map(peer_id_from_bytes)
+            .map(peer_id_from_pubkey_bytes)
             .collect::<Result<Vec<_>, _>>()?;
 
         self.sender.multisend(peers, msg, pri).await

--- a/core/network/src/outbound/gossip.rs
+++ b/core/network/src/outbound/gossip.rs
@@ -6,7 +6,7 @@ use protocol::{
 use tentacle::service::TargetSession;
 
 use crate::{
-    common::peer_id_from_pubkey_bytes,
+    common::peer_id_from_bytes,
     endpoint::Endpoint,
     error::NetworkError,
     message::{Headers, NetworkMessage},
@@ -64,13 +64,13 @@ where
     async fn multisend(
         &self,
         _ctx: Context,
-        pub_keys: Vec<Bytes>,
+        peer_ids: Vec<Bytes>,
         msg: Bytes,
         pri: Priority,
     ) -> Result<(), NetworkError> {
-        let peers = pub_keys
+        let peers = peer_ids
             .into_iter()
-            .map(peer_id_from_pubkey_bytes)
+            .map(peer_id_from_bytes)
             .collect::<Result<Vec<_>, _>>()?;
 
         self.sender.multisend(peers, msg, pri).await

--- a/core/network/src/outbound/gossip.rs
+++ b/core/network/src/outbound/gossip.rs
@@ -61,6 +61,8 @@ where
         self.sender.send(tar, msg, pri)
     }
 
+    // FIXME
+    #[allow(dead_code)]
     async fn users_send(
         &self,
         _ctx: Context,
@@ -88,22 +90,23 @@ where
         Ok(())
     }
 
-    async fn users_cast<M>(
+    async fn multicast<M>(
         &self,
-        cx: Context,
-        end: &str,
-        users: Vec<Address>,
-        msg: M,
-        p: Priority,
+        _cx: Context,
+        _end: &str,
+        _peer_ids: Vec<Bytes>,
+        _msg: M,
+        _p: Priority,
     ) -> ProtocolResult<()>
     where
         M: MessageCodec,
     {
-        let msg = self.package_message(cx.clone(), end, msg).await?;
-        let user_count = users.len();
-        self.users_send(cx, users, msg, p).await?;
-        common_apm::metrics::network::on_network_message_sent_multi_target(end, user_count as i64);
-
-        Ok(())
+        todo!()
+        // let msg = self.package_message(cx.clone(), end, msg).await?;
+        // let user_count = users.len();
+        // self.users_send(cx, users, msg, p).await?;
+        // common_apm::metrics::network::on_network_message_sent_multi_target(end, user_count as i64);
+        //
+        // Ok(())
     }
 }

--- a/core/network/src/peer_manager/diagnostic.rs
+++ b/core/network/src/peer_manager/diagnostic.rs
@@ -3,7 +3,7 @@ use crate::event::PeerManagerEvent;
 
 use derive_more::Display;
 use protocol::{traits::TrustFeedback, types::Address};
-use tentacle::SessionId;
+use tentacle::{secio::PeerId, SessionId};
 
 use std::sync::Arc;
 
@@ -70,10 +70,8 @@ impl Diagnostic {
         Diagnostic(inner)
     }
 
-    pub fn session_by_chain(&self, addr: &Address) -> Option<SessionId> {
-        let chain = self.0.chain.read();
-
-        match chain.get(addr).map(|peer| peer.session_id()) {
+    pub fn session(&self, peer_id: &PeerId) -> Option<SessionId> {
+        match self.0.peer(peer_id).map(|p| p.session_id()) {
             Some(sid) if sid != SessionId::new(0) => Some(sid),
             _ => None,
         }

--- a/core/network/src/peer_manager/diagnostic.rs
+++ b/core/network/src/peer_manager/diagnostic.rs
@@ -2,7 +2,7 @@ use super::{Inner, WORSE_TRUST_SCALAR_RATIO};
 use crate::event::PeerManagerEvent;
 
 use derive_more::Display;
-use protocol::{traits::TrustFeedback, types::Address};
+use protocol::traits::TrustFeedback;
 use tentacle::{secio::PeerId, SessionId};
 
 use std::sync::Arc;

--- a/core/network/src/peer_manager/shared.rs
+++ b/core/network/src/peer_manager/shared.rs
@@ -73,37 +73,20 @@ impl SessionBook for SharedSessions {
         }
     }
 
-    fn by_chain(&self, addrs: Vec<Address>) -> (Vec<SessionId>, Vec<Address>) {
-        let chain = self.inner.chain.read();
-
+    fn peers(&self, pids: Vec<PeerId>) -> (Vec<SessionId>, Vec<PeerId>) {
         let mut connected = Vec::new();
         let mut unconnected = Vec::new();
-        for addr in addrs {
-            match chain.get(&addr) {
+
+        for peer_id in pids {
+            match self.inner.peer(&peer_id) {
                 Some(peer) if peer.connectedness() == Connectedness::Connected => {
-                    connected.push(peer.session_id());
+                    connected.push(peer.session_id())
                 }
-                _ => unconnected.push(addr),
+                _ => unconnected.push(peer_id),
             }
         }
 
         (connected, unconnected)
-    }
-
-    fn peers_by_chain(&self, addrs: Vec<Address>) -> (Vec<PeerId>, Vec<Address>) {
-        let chain = self.inner.chain.read();
-
-        let mut peers = Vec::new();
-        let mut unknown = Vec::new();
-        for addr in addrs {
-            if let Some(peer) = chain.get(&addr) {
-                peers.push(peer.owned_id());
-            } else {
-                unknown.push(addr);
-            }
-        }
-
-        (peers, unknown)
     }
 
     fn all(&self) -> Vec<SessionId> {
@@ -138,14 +121,14 @@ impl SessionBook for SharedSessions {
 #[cfg(test)]
 mod tests {
     use super::{SessionBook, SharedSessions, SharedSessionsConfig};
-    use crate::peer_manager::{Inner, Peer};
+    use crate::peer_manager::Inner;
 
     use tentacle::secio::SecioKeyPair;
 
     use std::sync::Arc;
 
     #[test]
-    fn should_push_not_found_chain_addr_to_unconneded_on_by_chain() {
+    fn should_return_unconnected_peer_ids() {
         let sess_conf = SharedSessionsConfig {
             max_stream_window_size: 10,
             write_timeout:          10,
@@ -156,17 +139,10 @@ mod tests {
 
         let keypair = SecioKeyPair::secp256k1_generated();
         let pubkey = keypair.public_key();
-        let chain_addr = Peer::pubkey_to_chain_addr(&pubkey).expect("chain addr");
+        let peer_id = pubkey.peer_id();
+        assert!(inner.peer(&peer_id).is_none(), "should not be registered");
 
-        assert!(
-            inner.peer_by_chain(&chain_addr).is_none(),
-            "should not be registered"
-        );
-
-        let (_, unconnected) = sessions.by_chain(vec![chain_addr.clone()]);
-        assert!(
-            unconnected.contains(&chain_addr),
-            "should be inserted to unconnected"
-        );
+        let (_, unconnected) = sessions.peers(vec![peer_id.clone()]);
+        assert!(unconnected.contains(&peer_id));
     }
 }

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -18,8 +18,7 @@ use protocol::{
     traits::{
         Context, Gossip, MessageCodec, MessageHandler, PeerTrust, Priority, Rpc, TrustFeedback,
     },
-    types::Address,
-    ProtocolResult,
+    ProtocolResult, Bytes,
 };
 
 #[cfg(feature = "diagnostic")]
@@ -66,18 +65,18 @@ impl Gossip for NetworkServiceHandle {
         self.gossip.broadcast(cx, end, msg, p).await
     }
 
-    async fn users_cast<M>(
+    async fn multicast<M>(
         &self,
         cx: Context,
         end: &str,
-        users: Vec<Address>,
+        peer_ids: Vec<Bytes>,
         msg: M,
         p: Priority,
     ) -> ProtocolResult<()>
     where
         M: MessageCodec,
     {
-        self.gossip.users_cast(cx, end, users, msg, p).await
+        self.gossip.multicast(cx, end, peer_ids, msg, p).await
     }
 }
 

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -18,7 +18,7 @@ use protocol::{
     traits::{
         Context, Gossip, MessageCodec, MessageHandler, PeerTrust, Priority, Rpc, TrustFeedback,
     },
-    ProtocolResult, Bytes,
+    Bytes, ProtocolResult,
 };
 
 #[cfg(feature = "diagnostic")]

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -20,6 +20,7 @@ use protocol::{
     },
     Bytes, ProtocolResult,
 };
+use tentacle::secio::PeerId;
 
 #[cfg(feature = "diagnostic")]
 use crate::peer_manager::diagnostic::{Diagnostic, DiagnosticHookFn};
@@ -328,6 +329,10 @@ impl NetworkService {
             #[cfg(feature = "diagnostic")]
             diagnostic:                                self.diagnostic.clone(),
         }
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.config.secio_keypair.peer_id()
     }
 
     pub async fn listen(&mut self, socket_addr: SocketAddr) -> ProtocolResult<()> {

--- a/core/network/src/traits.rs
+++ b/core/network/src/traits.rs
@@ -31,7 +31,7 @@ pub trait NetworkProtocol {
 #[async_trait]
 pub trait MessageSender {
     fn send(&self, tar: TargetSession, msg: Bytes, pri: Priority) -> Result<(), NetworkError>;
-    async fn users_send(&self, users: Vec<Address>, msg: Bytes, pri: Priority) -> Result<(), NetworkError>;
+    async fn multisend(&self, peers: Vec<PeerId>, msg: Bytes, pri: Priority) -> Result<(), NetworkError>;
 }
 
 pub trait Compression {
@@ -61,8 +61,7 @@ pub trait SessionBook {
     fn all_sendable(&self) -> Vec<SessionId>;
     fn all_blocked(&self) -> Vec<SessionId>;
     fn refresh_blocked(&self);
-    fn by_chain(&self, addrs: Vec<Address>) -> (Vec<SessionId>, Vec<Address>);
-    fn peers_by_chain(&self, addrs: Vec<Address>) -> (Vec<PeerId>, Vec<Address>);
+    fn peers(&self, pids: Vec<PeerId>) -> (Vec<SessionId>, Vec<PeerId>);
     fn all(&self) -> Vec<SessionId>;
     fn connected_addr(&self, sid: SessionId) -> Option<ConnectedAddr>;
     fn pending_data_size(&self, sid: SessionId) -> usize;

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -1,5 +1,5 @@
 # crypto
-privkey = "0x45c56be699dca666191ad3446897e0f480da234da896270202514a0e1a587c3f"
+privkey = "0x6ada9d857e8d34b52962e3719a31683cede8c2f8751101c05f79c3b51f2ea05e"
 
 # db config
 data_path = "./devtools/chain/data"
@@ -20,7 +20,7 @@ rpc_timeout = 10
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
-pubkey = "0x031288a6788678c25952eba8693b2f278f66e2187004b64ac09416d07f83f96d5b"
+pubkey = "0x03f7f168051bedfaa8a23bbb1a8f04a933269bfd04f249f48322f16f607a8790d6"
 address = "0.0.0.0:1888"
 
 [mempool]

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -1,5 +1,5 @@
 # crypto
-privkey = "0xb4116bd2d920058dceb7a9aa3cbfd842e58492dd85de6defa2627bda5ad4a6c4"
+privkey = "0x4a33067c449635c434cc758ed5f595e1f5653debc45233997c93814c31f710d5"
 
 # db config
 data_path = "./devtools/chain/data"
@@ -20,7 +20,7 @@ rpc_timeout = 10
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
-peer_id = "QmPRHVQjboKfot9bnNw2oxuoSLaGGiq3dtqZxxQSNSDdsb"
+peer_id = "QmeG2AjWkLbK5ThySV7TrX5KuFryPsaM8GBgDs6Ch1Z5xJ"
 address = "0.0.0.0:1888"
 
 [mempool]

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -1,5 +1,5 @@
 # crypto
-privkey = "0x6ada9d857e8d34b52962e3719a31683cede8c2f8751101c05f79c3b51f2ea05e"
+privkey = "0xb4116bd2d920058dceb7a9aa3cbfd842e58492dd85de6defa2627bda5ad4a6c4"
 
 # db config
 data_path = "./devtools/chain/data"
@@ -20,7 +20,7 @@ rpc_timeout = 10
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
-pubkey = "0x03f7f168051bedfaa8a23bbb1a8f04a933269bfd04f249f48322f16f607a8790d6"
+peer_id = "QmPRHVQjboKfot9bnNw2oxuoSLaGGiq3dtqZxxQSNSDdsb"
 address = "0.0.0.0:1888"
 
 [mempool]

--- a/devtools/chain/genesis.toml
+++ b/devtools/chain/genesis.toml
@@ -25,9 +25,9 @@ payload = '''
     "interval": 3000,
     "verifier_list": [
         {
-            "bls_pub_key": "0x040c3393c426ddbc2ed817ad2069c3d0dbf7257a295d55983246eec21f927095e003a8214ca33f5555a2b2f3a5a6c85eac19b657e6742720ef7de10945f84bbefdb48a6f3ca9ef891c13f7eaede2a96462e79e2949d9e86bf9a831da67e1a568e0",
-            "address": "0x2963cb2595fce9ea9f2ae22bcf9bb06cb500f821",
-            "peer_id": "0x1220a8fa41c212812f49b01b96b9cc9f00c21593ab843eae1417548d6725c134f080",
+            "bls_pub_key": "0x0415e096d77867ebd9a36581ed91afbb3377a653beb76dfd1acc6f078838d2e40a8819444698923f9fccf367ab8d276fec099b857e35bef77df53327e5d2165ceef813b9289cc75c0140465777b76e37a8d5762d2eef9aff94a8ec52aed6be30a2",
+            "address": "0x5235aaa2a4d20b513728afb0f13dc695443f1a80",
+            "peer_id": "0x1220100b9942e60a55abcbf25b8700ece7552ed8d680be62e9fe50aba9951b9ff5d6",
             "propose_weight": 1,
             "vote_weight": 1
         }

--- a/devtools/chain/genesis.toml
+++ b/devtools/chain/genesis.toml
@@ -27,6 +27,7 @@ payload = '''
         {
             "bls_pub_key": "0x0401139331589f32220ec5f41f6faa0f5c3f4d36af011ab014cefd9d8f36b53b04a2031f681d1c9648a2a5d534d742931b0a5a4132da9ee752c1144d6396bed6cfc635c9687258cec9b60b387d35cf9e13f29091e11ae88024d74ca904c0ea3fb3",
             "pub_key": "0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004",
+            "address": "0x76961e339fe2f1f931d84c425754806fb4174c34",
             "propose_weight": 1,
             "vote_weight": 1
         }

--- a/devtools/chain/genesis.toml
+++ b/devtools/chain/genesis.toml
@@ -25,9 +25,8 @@ payload = '''
     "interval": 3000,
     "verifier_list": [
         {
-            "bls_pub_key": "0x0415e096d77867ebd9a36581ed91afbb3377a653beb76dfd1acc6f078838d2e40a8819444698923f9fccf367ab8d276fec099b857e35bef77df53327e5d2165ceef813b9289cc75c0140465777b76e37a8d5762d2eef9aff94a8ec52aed6be30a2",
-            "address": "0x5235aaa2a4d20b513728afb0f13dc695443f1a80",
-            "peer_id": "0x1220100b9942e60a55abcbf25b8700ece7552ed8d680be62e9fe50aba9951b9ff5d6",
+            "bls_pub_key": "0x0401139331589f32220ec5f41f6faa0f5c3f4d36af011ab014cefd9d8f36b53b04a2031f681d1c9648a2a5d534d742931b0a5a4132da9ee752c1144d6396bed6cfc635c9687258cec9b60b387d35cf9e13f29091e11ae88024d74ca904c0ea3fb3",
+            "pub_key": "0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004",
             "propose_weight": 1,
             "vote_weight": 1
         }

--- a/devtools/chain/genesis.toml
+++ b/devtools/chain/genesis.toml
@@ -18,15 +18,16 @@ name = "metadata"
 payload = '''
 {
     "chain_id": "0xb6a4d7da21443f5e816e8700eea87610e6d769657d6b8ec73028457bf2ca4036",
-    "common_ref": "0x703873635a6b51513451",
+    "common_ref": "0x6853675068394a6a7450",
     "timeout_gap": 20,
     "cycles_limit": 1000000,
     "cycles_price": 1,
     "interval": 3000,
     "verifier_list": [
         {
-            "bls_pub_key": "0x04188ef9488c19458a963cc57b567adde7db8f8b6bec392d5cb7b67b0abc1ed6cd966edc451f6ac2ef38079460eb965e890d1f576e4039a20467820237cda753f07a8b8febae1ec052190973a1bcf00690ea8fc0168b3fbbccd1c4e402eda5ef22",
-            "address": "0xf8389d774afdad8755ef8e629e5a154fddc6325a",
+            "bls_pub_key": "0x040c3393c426ddbc2ed817ad2069c3d0dbf7257a295d55983246eec21f927095e003a8214ca33f5555a2b2f3a5a6c85eac19b657e6742720ef7de10945f84bbefdb48a6f3ca9ef891c13f7eaede2a96462e79e2949d9e86bf9a831da67e1a568e0",
+            "address": "0x2963cb2595fce9ea9f2ae22bcf9bb06cb500f821",
+            "peer_id": "0x1220a8fa41c212812f49b01b96b9cc9f00c21593ab843eae1417548d6725c134f080",
             "propose_weight": 1,
             "vote_weight": 1
         }

--- a/devtools/keypair/Cargo.toml
+++ b/devtools/keypair/Cargo.toml
@@ -20,4 +20,4 @@ protocol = { version = "0.1.0-alpha.1", package = "muta-protocol" }
 rand = "0.7"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-tentacle-secio = { version = "0.1", features = [ "flatc" ] }
+tentacle-secio = { version = "0.1", features = [ "molc" ] }

--- a/devtools/keypair/src/main.rs
+++ b/devtools/keypair/src/main.rs
@@ -7,7 +7,7 @@ use std::default::Default;
 use clap::App;
 use ophelia::{PublicKey, ToBlsPublicKey};
 use ophelia_bls_amcl::BlsPrivateKey;
-use protocol::types::Hash;
+use protocol::types::{Address, Hash};
 use protocol::{Bytes, BytesMut};
 use rand::distributions::Alphanumeric;
 use rand::Rng;
@@ -20,6 +20,7 @@ struct Keypair {
     pub index:          usize,
     pub private_key:    String,
     pub public_key:     String,
+    pub address:        String,
     pub peer_id:        String,
     pub bls_public_key: String,
 }
@@ -69,10 +70,13 @@ pub fn main() {
             Hash::digest(BytesMut::from(seed.as_ref()).freeze()).as_bytes()
         };
         let keypair = SecioKeyPair::secp256k1_raw_key(seckey.as_ref()).expect("secp256k1 keypair");
+        let pubkey = keypair.to_public_key().inner();
+        let user_addr = Address::from_pubkey_bytes(pubkey.clone().into()).expect("user addr");
 
         k.private_key = add_0x(hex::encode(seckey.as_ref()));
-        k.public_key = add_0x(hex::encode(keypair.to_public_key().inner()));
+        k.public_key = add_0x(hex::encode(pubkey));
         k.peer_id = add_0x(hex::encode(keypair.to_public_key().peer_id().as_bytes()));
+        k.address = add_0x(user_addr.as_hex());
 
         let priv_key =
             BlsPrivateKey::try_from([&[0u8; 16], seckey.as_ref()].concat().as_ref()).unwrap();

--- a/devtools/keypair/src/main.rs
+++ b/devtools/keypair/src/main.rs
@@ -21,7 +21,6 @@ struct Keypair {
     pub private_key:    String,
     pub public_key:     String,
     pub address:        String,
-    pub peer_id_hex:    String,
     pub peer_id:        String,
     pub bls_public_key: String,
 }
@@ -76,7 +75,6 @@ pub fn main() {
 
         k.private_key = add_0x(hex::encode(seckey.as_ref()));
         k.public_key = add_0x(hex::encode(pubkey));
-        k.peer_id_hex = add_0x(hex::encode(keypair.to_public_key().peer_id().as_bytes()));
         k.peer_id = keypair.to_public_key().peer_id().to_base58();
         k.address = add_0x(user_addr.as_hex());
 

--- a/devtools/keypair/src/main.rs
+++ b/devtools/keypair/src/main.rs
@@ -21,6 +21,7 @@ struct Keypair {
     pub private_key:    String,
     pub public_key:     String,
     pub address:        String,
+    pub peer_id_hex:    String,
     pub peer_id:        String,
     pub bls_public_key: String,
 }
@@ -75,7 +76,8 @@ pub fn main() {
 
         k.private_key = add_0x(hex::encode(seckey.as_ref()));
         k.public_key = add_0x(hex::encode(pubkey));
-        k.peer_id = add_0x(hex::encode(keypair.to_public_key().peer_id().as_bytes()));
+        k.peer_id_hex = add_0x(hex::encode(keypair.to_public_key().peer_id().as_bytes()));
+        k.peer_id = keypair.to_public_key().peer_id().to_base58();
         k.address = add_0x(user_addr.as_hex());
 
         let priv_key =

--- a/devtools/keypair/src/main.rs
+++ b/devtools/keypair/src/main.rs
@@ -7,7 +7,7 @@ use std::default::Default;
 use clap::App;
 use ophelia::{PublicKey, ToBlsPublicKey};
 use ophelia_bls_amcl::BlsPrivateKey;
-use protocol::types::{Address, Hash};
+use protocol::types::Hash;
 use protocol::{Bytes, BytesMut};
 use rand::distributions::Alphanumeric;
 use rand::Rng;
@@ -20,7 +20,7 @@ struct Keypair {
     pub index:          usize,
     pub private_key:    String,
     pub public_key:     String,
-    pub address:        String,
+    pub peer_id:        String,
     pub bls_public_key: String,
 }
 
@@ -69,12 +69,10 @@ pub fn main() {
             Hash::digest(BytesMut::from(seed.as_ref()).freeze()).as_bytes()
         };
         let keypair = SecioKeyPair::secp256k1_raw_key(seckey.as_ref()).expect("secp256k1 keypair");
-        let pubkey = keypair.to_public_key().inner();
-        let user_addr = Address::from_pubkey_bytes(pubkey.into()).expect("user addr");
 
         k.private_key = add_0x(hex::encode(seckey.as_ref()));
         k.public_key = add_0x(hex::encode(keypair.to_public_key().inner()));
-        k.address = add_0x(user_addr.as_hex());
+        k.peer_id = add_0x(hex::encode(keypair.to_public_key().peer_id().as_bytes()));
 
         let priv_key =
             BlsPrivateKey::try_from([&[0u8; 16], seckey.as_ref()].concat().as_ref()).unwrap();

--- a/examples/config-1.toml
+++ b/examples/config-1.toml
@@ -1,5 +1,5 @@
 data_path = "./devtools/chain/data/1"
-privkey = "0xb4116bd2d920058dceb7a9aa3cbfd842e58492dd85de6defa2627bda5ad4a6c4"
+privkey = "0x4a33067c449635c434cc758ed5f595e1f5653debc45233997c93814c31f710d5"
 
 [network]
 listening_address = "0.0.0.0:1337"

--- a/examples/config-1.toml
+++ b/examples/config-1.toml
@@ -1,5 +1,5 @@
 data_path = "./devtools/chain/data/1"
-privkey = "0x592d6f62cd5c3464d4956ea585ec7007bcf5217eb89cc50bf14eea95f3b09706"
+privkey = "0xb4116bd2d920058dceb7a9aa3cbfd842e58492dd85de6defa2627bda5ad4a6c4"
 
 [network]
 listening_address = "0.0.0.0:1337"

--- a/examples/config-2.toml
+++ b/examples/config-2.toml
@@ -1,12 +1,12 @@
 data_path = "./devtools/chain/data/2"
-privkey = "0x8c02ea7f0ad4adf302275ca4a7c54cd90893a887d02c647c5c0376848d40cd81"
+privkey = "0x86756d9074b984526f6780a46958b7b358565a7ef14aa4185854ee95b77b126c"
 
 [network]
 listening_address = "0.0.0.0:1338"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-peer_id = "QmPRHVQjboKfot9bnNw2oxuoSLaGGiq3dtqZxxQSNSDdsb"
+peer_id = "QmeG2AjWkLbK5ThySV7TrX5KuFryPsaM8GBgDs6Ch1Z5xJ"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/config-2.toml
+++ b/examples/config-2.toml
@@ -1,12 +1,12 @@
 data_path = "./devtools/chain/data/2"
-privkey = "0x8b41630934fc7df92a016af88aae477bd173118fb72113f31db8a950230b029f"
+privkey = "0x8c02ea7f0ad4adf302275ca4a7c54cd90893a887d02c647c5c0376848d40cd81"
 
 [network]
 listening_address = "0.0.0.0:1338"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-pubkey = "0x02fa3a27712962a70e3e474363f38661f6a9e56f9cc91efd0d343713d51f3fa355"
+peer_id = "QmPRHVQjboKfot9bnNw2oxuoSLaGGiq3dtqZxxQSNSDdsb"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/config-3.toml
+++ b/examples/config-3.toml
@@ -1,12 +1,12 @@
 data_path = "./devtools/chain/data/3"
-privkey = "0xc37ebfcc4c98d9e2a4c53110273e18e221cd94f8ae11e98b4e4d12e7b55f71f8"
+privkey = "0x4dc6d3fe1181c2df13e41ff6e99233bfe1a58767d463759ab9ba1ce7d9f85b8d"
 
 [network]
 listening_address = "0.0.0.0:1339"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-peer_id = "QmPRHVQjboKfot9bnNw2oxuoSLaGGiq3dtqZxxQSNSDdsb"
+peer_id = "QmeG2AjWkLbK5ThySV7TrX5KuFryPsaM8GBgDs6Ch1Z5xJ"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/config-3.toml
+++ b/examples/config-3.toml
@@ -1,12 +1,12 @@
 data_path = "./devtools/chain/data/3"
-privkey = "0x28f53779b60e261ba68cdccefcc6a152136df8cb794e067ec76dc5a02c8f2ccf"
+privkey = "0xc37ebfcc4c98d9e2a4c53110273e18e221cd94f8ae11e98b4e4d12e7b55f71f8"
 
 [network]
 listening_address = "0.0.0.0:1339"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-pubkey = "0x02fa3a27712962a70e3e474363f38661f6a9e56f9cc91efd0d343713d51f3fa355"
+peer_id = "QmPRHVQjboKfot9bnNw2oxuoSLaGGiq3dtqZxxQSNSDdsb"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/config-4.toml
+++ b/examples/config-4.toml
@@ -1,12 +1,12 @@
 data_path = "./devtools/chain/data/4"
-privkey = "0x8e065679aa8b1185406c7514343073cd8c1695218925c9b2d5e98c3483d71d81"
+privkey = "0x019dc1d390790abcb8f2e8ab9556644cb2806eede3c3f745261baec20baac686"
 
 [network]
 listening_address = "0.0.0.0:1340"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-pubkey = "0x02fa3a27712962a70e3e474363f38661f6a9e56f9cc91efd0d343713d51f3fa355"
+peer_id = "QmPRHVQjboKfot9bnNw2oxuoSLaGGiq3dtqZxxQSNSDdsb"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/config-4.toml
+++ b/examples/config-4.toml
@@ -1,12 +1,12 @@
 data_path = "./devtools/chain/data/4"
-privkey = "0x019dc1d390790abcb8f2e8ab9556644cb2806eede3c3f745261baec20baac686"
+privkey = "0xd96f7e0fc7f73295dfb7d4d8edb621d7581456fb0eedde75b8a92ecb8cb84b98"
 
 [network]
 listening_address = "0.0.0.0:1340"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-peer_id = "QmPRHVQjboKfot9bnNw2oxuoSLaGGiq3dtqZxxQSNSDdsb"
+peer_id = "QmeG2AjWkLbK5ThySV7TrX5KuFryPsaM8GBgDs6Ch1Z5xJ"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/genesis.toml
+++ b/examples/genesis.toml
@@ -26,14 +26,14 @@ payload = '''
     "verifier_list": [
         {
             "bls_pub_key": "0x0415e096d77867ebd9a36581ed91afbb3377a653beb76dfd1acc6f078838d2e40a8819444698923f9fccf367ab8d276fec099b857e35bef77df53327e5d2165ceef813b9289cc75c0140465777b76e37a8d5762d2eef9aff94a8ec52aed6be30a2",
-            "address": "0x5235aaa2a4d20b513728afb0f13dc695443f1a80"
+            "address": "0x5235aaa2a4d20b513728afb0f13dc695443f1a80",
             "peer_id": "0x1220100b9942e60a55abcbf25b8700ece7552ed8d680be62e9fe50aba9951b9ff5d6",
             "propose_weight": 1,
             "vote_weight": 1
         },
         {
             "bls_pub_key": "0x040bcc7162b391562c2ca5628fa16905d99078987af2d798c5e29a9c04ea4fe34a1ae31155b0162dcaaaabd4c4e64b98670b45b9f8ebddc16b072b431aab0f18d3240109ce6e3f85bca6d3e4d7aa001dac0d213326abf39da397fed8497e9af26d",
-            "address": "0x68d383e586683b943e6a0c4a042e8aaa3729dcdf"
+            "address": "0x68d383e586683b943e6a0c4a042e8aaa3729dcdf",
             "peer_id": "0x1220718c67c7543581a1d1133f43ba4a12da8edc92dd161d534b00c0475d31c7f859",
             "propose_weight": 1,
             "vote_weight": 1

--- a/examples/genesis.toml
+++ b/examples/genesis.toml
@@ -25,30 +25,30 @@ payload = '''
     "interval": 3000,
     "verifier_list": [
         {
-            "bls_pub_key": "0x0415e096d77867ebd9a36581ed91afbb3377a653beb76dfd1acc6f078838d2e40a8819444698923f9fccf367ab8d276fec099b857e35bef77df53327e5d2165ceef813b9289cc75c0140465777b76e37a8d5762d2eef9aff94a8ec52aed6be30a2",
-            "address": "0x5235aaa2a4d20b513728afb0f13dc695443f1a80",
-            "peer_id": "0x1220100b9942e60a55abcbf25b8700ece7552ed8d680be62e9fe50aba9951b9ff5d6",
+            "bls_pub_key": "0x0401139331589f32220ec5f41f6faa0f5c3f4d36af011ab014cefd9d8f36b53b04a2031f681d1c9648a2a5d534d742931b0a5a4132da9ee752c1144d6396bed6cfc635c9687258cec9b60b387d35cf9e13f29091e11ae88024d74ca904c0ea3fb3",
+            "pub_key": "0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004",
+            "address": "0x76961e339fe2f1f931d84c425754806fb4174c34",
             "propose_weight": 1,
             "vote_weight": 1
         },
         {
-            "bls_pub_key": "0x040bcc7162b391562c2ca5628fa16905d99078987af2d798c5e29a9c04ea4fe34a1ae31155b0162dcaaaabd4c4e64b98670b45b9f8ebddc16b072b431aab0f18d3240109ce6e3f85bca6d3e4d7aa001dac0d213326abf39da397fed8497e9af26d",
-            "address": "0x68d383e586683b943e6a0c4a042e8aaa3729dcdf",
-            "peer_id": "0x1220718c67c7543581a1d1133f43ba4a12da8edc92dd161d534b00c0475d31c7f859",
+            "bls_pub_key": "0x04070c98bb4b0974fe57be878d4dc1776c6f28250ecc8014101c4ff47baeabb6cb375ad5bca4b58e512d12f9d549ab472718c7ea57e8fd53de5141f79e4dd575fed85281e1e9cd3fc8a13ab787868fe804d833e5ee4c26eb5b1d01eedb2dc33e71",
+            "pub_key": "0x03080670d0160566c2afda5e0ae1a19300161a26e08b2ae954258504aa5b20e6ff",
+            "address": "0xaba7c0b7d5017f68232e515a2a60d609bb42439f",
             "propose_weight": 1,
             "vote_weight": 1
         },
         {
-            "bls_pub_key": "0x040f7ef6a0b503c59ce98de7fec48f41922bffee94b6ef67f4709c4e4a00e1bf4ff556c3817ff0af22f17ed502c1465e4017e835bedfde3105061dfe70eb8cb7ea336af9c60db5042f2df926042cb5448cc3404b0579c173d639fc81cdc6156e36",
-            "address": "0x753b075f360901a8bf8f334125990296fdeb37be",
-            "peer_id": "0x12200ba1ef88b27195c24e1d48022902829cc7345235a37549410a14fcffa20b7602",
+            "bls_pub_key": "0x04093d17f53695ef66952e99c885a3375d586fee84f1270a75b961ca2109700c73328e77f0db68fdebd2f6cf06605226cb0836da2040c6a154935fcc8b73d71be816965645686333a80a9900055bfb7f66133473658e259c63687ef39c32a94844",
+            "pub_key": "0x039395a060de0f8d4b23fc4c37509703d096d549361f756f07df29f9545f9f234f",
+            "address": "0x24facaaa473b104112b99c193149acea72d986f4",
             "propose_weight": 1,
             "vote_weight": 1
         },
         {
-            "bls_pub_key": "0x0405cba97ecff50cb1ebd02e6c3c85c363da727f642af12fbcf423a0569854b2666db5c0894b0435a69abc5d987609ab8b01065c983fd1e7b4c6fc443738438622bfcefcb71c50d5279c50149be16ccc60bf8ca32113ec6915af996c39af15b93b",
-            "address": "0xcfbb29f187b61029ff9e4c7aea3a04ca365468b2",
-            "peer_id": "0x1220e563e19e32bbb81f093171d3d2da3c5aebb4c19baf8b04523c1a51265565f3ff",
+            "bls_pub_key": "0x040514607ef22ce9ea0e47496ac19104148e7b5f47acf74654c8e4798848cf426c7c65ea9c0dacd3a08155f249a6edf41a141a4bf5c4fcf3e2b0c8d7a6f6c5fc5c34c8e2601d466bb1c80aa9c7827ffab3d20039aa4bd39f107b691ebd6617bdcf",
+            "pub_key": "0x038aa869ca5e2f092a8b9de0c60c57adb0836d9ca277c0eccdae2833460f027106",
+            "address": "0xd3a26fd39c6d6abe2d0f9dbf2831cc389308c53b",
             "propose_weight": 1,
             "vote_weight": 1
         }

--- a/examples/genesis.toml
+++ b/examples/genesis.toml
@@ -18,33 +18,37 @@ name = "metadata"
 payload = '''
 {
     "chain_id": "0xb6a4d7da21443f5e816e8700eea87610e6d769657d6b8ec73028457bf2ca4036",
-    "common_ref": "0x7446645045376b553041",
+    "common_ref": "0x6853675068394a6a7450",
     "timeout_gap": 20,
     "cycles_limit": 999999999999,
     "cycles_price": 1,
     "interval": 3000,
     "verifier_list": [
         {
-            "bls_pub_key": "0x040386a8ac1cce6fd90c31effa628bc8513cbd625c752ca76ade6ff37b97edbdfb97d94caeddd261d9e2fd6b5456aecc100ea730ddee3c94f040a54152ded330a4e409f39bfbc34b286536790fef8bbaf734431679ba6a8d5d6994e557e82306df",
-            "address": "0x12d8baf8c4efb32a7983efac2d8535fe57deb756",
+            "bls_pub_key": "0x0415e096d77867ebd9a36581ed91afbb3377a653beb76dfd1acc6f078838d2e40a8819444698923f9fccf367ab8d276fec099b857e35bef77df53327e5d2165ceef813b9289cc75c0140465777b76e37a8d5762d2eef9aff94a8ec52aed6be30a2",
+            "address": "0x5235aaa2a4d20b513728afb0f13dc695443f1a80"
+            "peer_id": "0x1220100b9942e60a55abcbf25b8700ece7552ed8d680be62e9fe50aba9951b9ff5d6",
             "propose_weight": 1,
             "vote_weight": 1
         },
         {
-            "bls_pub_key": "0x040e7b00b59d37d4d735041ea1b69a55cd7fd80e920b5d70d85d051af6b847c3aec5b412b128f85ad8b4c6bac0561105a80fa8dd5f60cd42c3a2da0fd0b946fa3d761b1d21c569e0958b847da22dec14a132121027006df8c5d4ccf7caf8535f70",
-            "address": "0xa55e1261a73116c755291140e427caa0cbb5309e",
+            "bls_pub_key": "0x040bcc7162b391562c2ca5628fa16905d99078987af2d798c5e29a9c04ea4fe34a1ae31155b0162dcaaaabd4c4e64b98670b45b9f8ebddc16b072b431aab0f18d3240109ce6e3f85bca6d3e4d7aa001dac0d213326abf39da397fed8497e9af26d",
+            "address": "0x68d383e586683b943e6a0c4a042e8aaa3729dcdf"
+            "peer_id": "0x1220718c67c7543581a1d1133f43ba4a12da8edc92dd161d534b00c0475d31c7f859",
             "propose_weight": 1,
             "vote_weight": 1
         },
         {
-            "bls_pub_key": "0x0413584a15f1dec552bb12233bf73a886ed49a3f56c68eda080743577005417635c9ac72a528a961a0e14a2df3a50a5c660641f446f629788486d7935d4ad4918035ce884a98bbaaa4c96307a2428729cba694329a693ce60c02e13b039c6a8978",
-            "address": "0x78ef0eff2fb9f569d86d75d22b69ea8407f6f092",
+            "bls_pub_key": "0x040f7ef6a0b503c59ce98de7fec48f41922bffee94b6ef67f4709c4e4a00e1bf4ff556c3817ff0af22f17ed502c1465e4017e835bedfde3105061dfe70eb8cb7ea336af9c60db5042f2df926042cb5448cc3404b0579c173d639fc81cdc6156e36",
+            "address": "0x753b075f360901a8bf8f334125990296fdeb37be",
+            "peer_id": "0x12200ba1ef88b27195c24e1d48022902829cc7345235a37549410a14fcffa20b7602",
             "propose_weight": 1,
             "vote_weight": 1
         },
         {
-            "bls_pub_key": "0x041611b7da94a7fb7a8ff1c802bbf61da689f8d6f974d99466adeb1f47bcaff70470b6f279763abeb0cec5565abcfcb4ce13e79b8c310f0d1b26605b61ac2c04e0efcedbae18e763a86adb7a0e8ed0fcb1dc11fded12583972403815a7aa3dc300",
-            "address": "0x103252cad4e0380fe57a0c73f549f1ee2c9ea8e8",
+            "bls_pub_key": "0x0405cba97ecff50cb1ebd02e6c3c85c363da727f642af12fbcf423a0569854b2666db5c0894b0435a69abc5d987609ab8b01065c983fd1e7b4c6fc443738438622bfcefcb71c50d5279c50149be16ccc60bf8ca32113ec6915af996c39af15b93b",
+            "address": "0xcfbb29f187b61029ff9e4c7aea3a04ca365468b2",
+            "peer_id": "0x1220e563e19e32bbb81f093171d3d2da3c5aebb4c19baf8b04523c1a51265565f3ff",
             "propose_weight": 1,
             "vote_weight": 1
         }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -197,6 +197,10 @@ pub fn mock_address() -> Address {
     Address::from_hash(hash).unwrap()
 }
 
+pub fn mock_peer_id(s: &'static str) -> Bytes {
+    Hash::digest(Bytes::from(s)).as_bytes()
+}
+
 pub fn mock_hash() -> Hash {
     Hash::digest(Bytes::from("mock"))
 }
@@ -277,9 +281,9 @@ pub fn mock_event() -> Event {
 // Mock Block
 // #####################
 
-pub fn mock_validator() -> Validator {
+pub fn mock_validator(s: &'static str) -> Validator {
     Validator {
-        peer_id:        get_random_bytes(16),
+        peer_id:        mock_peer_id(s),
         propose_weight: 1,
         vote_weight:    1,
     }
@@ -312,10 +316,10 @@ pub fn mock_block_header() -> BlockHeader {
         proof:                          mock_proof(),
         validator_version:              1,
         validators:                     vec![
-            mock_validator(),
-            mock_validator(),
-            mock_validator(),
-            mock_validator(),
+            mock_validator("a"),
+            mock_validator("b"),
+            mock_validator("c"),
+            mock_validator("d"),
         ],
     }
 }
@@ -325,9 +329,4 @@ pub fn mock_block(order_size: usize) -> Block {
         header:            mock_block_header(),
         ordered_tx_hashes: (0..order_size).map(|_| mock_hash()).collect(),
     }
-}
-
-fn get_random_bytes(len: usize) -> Bytes {
-    let vec: Vec<u8> = (0..len).map(|_| rand::random::<u8>()).collect();
-    Bytes::from(vec)
 }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -197,7 +197,7 @@ pub fn mock_address() -> Address {
     Address::from_hash(hash).unwrap()
 }
 
-pub fn mock_peer_id(s: &'static str) -> Bytes {
+pub fn mock_pub_key(s: &'static str) -> Bytes {
     Hash::digest(Bytes::from(s)).as_bytes()
 }
 
@@ -283,7 +283,7 @@ pub fn mock_event() -> Event {
 
 pub fn mock_validator(s: &'static str) -> Validator {
     Validator {
-        peer_id:        mock_peer_id(s),
+        pub_key:        mock_pub_key(s),
         propose_weight: 1,
         vote_weight:    1,
     }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -284,6 +284,7 @@ pub fn mock_event() -> Event {
 pub fn mock_validator(s: &'static str) -> Validator {
     Validator {
         pub_key:        mock_pub_key(s),
+        address:        mock_address().as_bytes(),
         propose_weight: 1,
         vote_weight:    1,
     }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -279,7 +279,7 @@ pub fn mock_event() -> Event {
 
 pub fn mock_validator() -> Validator {
     Validator {
-        address:        mock_address(),
+        peer_id:        get_random_bytes(16),
         propose_weight: 1,
         vote_weight:    1,
     }
@@ -325,4 +325,9 @@ pub fn mock_block(order_size: usize) -> Block {
         header:            mock_block_header(),
         ordered_tx_hashes: (0..order_size).map(|_| mock_hash()).collect(),
     }
+}
+
+fn get_random_bytes(len: usize) -> Bytes {
+    let vec: Vec<u8> = (0..len).map(|_| rand::random::<u8>()).collect();
+    Bytes::from(vec)
 }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -284,7 +284,6 @@ pub fn mock_event() -> Event {
 pub fn mock_validator(s: &'static str) -> Validator {
     Validator {
         pub_key:        mock_pub_key(s),
-        address:        mock_address().as_bytes(),
         propose_weight: 1,
         vote_weight:    1,
     }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -27,6 +27,7 @@ cita_trie = "2.0"
 json = "0.12"
 byteorder = "1.3"
 muta-codec-derive = "0.2"
+bs58 = "0.3"
 
 [dev-dependencies]
 rayon = "1.3"

--- a/protocol/src/codec/block.rs
+++ b/protocol/src/codec/block.rs
@@ -95,7 +95,7 @@ pub struct Proof {
 #[derive(Clone, Message)]
 pub struct Validator {
     #[prost(bytes, tag = "1")]
-    pub peer_id: Vec<u8>,
+    pub pub_key: Vec<u8>,
 
     #[prost(uint32, tag = "2")]
     pub propose_weight: u32,
@@ -298,7 +298,7 @@ impl TryFrom<Proof> for block::Proof {
 impl From<block::Validator> for Validator {
     fn from(validator: block::Validator) -> Validator {
         Validator {
-            peer_id:        validator.peer_id.to_vec(),
+            pub_key:        validator.pub_key.to_vec(),
             propose_weight: validator.propose_weight,
             vote_weight:    validator.vote_weight,
         }
@@ -310,7 +310,7 @@ impl TryFrom<Validator> for block::Validator {
 
     fn try_from(validator: Validator) -> Result<block::Validator, Self::Error> {
         let validator = block::Validator {
-            peer_id:        Bytes::from(validator.peer_id),
+            pub_key:        Bytes::from(validator.pub_key),
             propose_weight: validator.propose_weight,
             vote_weight:    validator.vote_weight,
         };

--- a/protocol/src/codec/block.rs
+++ b/protocol/src/codec/block.rs
@@ -94,8 +94,8 @@ pub struct Proof {
 
 #[derive(Clone, Message)]
 pub struct Validator {
-    #[prost(message, tag = "1")]
-    pub address: Option<Address>,
+    #[prost(bytes, tag = "1")]
+    pub peer_id: Vec<u8>,
 
     #[prost(uint32, tag = "2")]
     pub propose_weight: u32,
@@ -297,12 +297,10 @@ impl TryFrom<Proof> for block::Proof {
 
 impl From<block::Validator> for Validator {
     fn from(validator: block::Validator) -> Validator {
-        let address = Some(Address::from(validator.address));
-
         Validator {
-            address,
+            peer_id:        validator.peer_id.to_vec(),
             propose_weight: validator.propose_weight,
-            vote_weight: validator.vote_weight,
+            vote_weight:    validator.vote_weight,
         }
     }
 }
@@ -311,10 +309,8 @@ impl TryFrom<Validator> for block::Validator {
     type Error = ProtocolError;
 
     fn try_from(validator: Validator) -> Result<block::Validator, Self::Error> {
-        let address = field!(validator.address, "Validator", "address")?;
-
         let validator = block::Validator {
-            address:        protocol_primitive::Address::try_from(address)?,
+            peer_id:        Bytes::from(validator.peer_id),
             propose_weight: validator.propose_weight,
             vote_weight:    validator.vote_weight,
         };

--- a/protocol/src/codec/block.rs
+++ b/protocol/src/codec/block.rs
@@ -97,13 +97,10 @@ pub struct Validator {
     #[prost(bytes, tag = "1")]
     pub pub_key: Vec<u8>,
 
-    #[prost(bytes, tag = "2")]
-    pub address: Vec<u8>,
-
-    #[prost(uint32, tag = "3")]
+    #[prost(uint32, tag = "2")]
     pub propose_weight: u32,
 
-    #[prost(uint32, tag = "4")]
+    #[prost(uint32, tag = "3")]
     pub vote_weight: u32,
 }
 
@@ -302,7 +299,6 @@ impl From<block::Validator> for Validator {
     fn from(validator: block::Validator) -> Validator {
         Validator {
             pub_key:        validator.pub_key.to_vec(),
-            address:        validator.address.to_vec(),
             propose_weight: validator.propose_weight,
             vote_weight:    validator.vote_weight,
         }
@@ -315,7 +311,6 @@ impl TryFrom<Validator> for block::Validator {
     fn try_from(validator: Validator) -> Result<block::Validator, Self::Error> {
         let validator = block::Validator {
             pub_key:        Bytes::from(validator.pub_key),
-            address:        Bytes::from(validator.address),
             propose_weight: validator.propose_weight,
             vote_weight:    validator.vote_weight,
         };

--- a/protocol/src/codec/block.rs
+++ b/protocol/src/codec/block.rs
@@ -97,10 +97,13 @@ pub struct Validator {
     #[prost(bytes, tag = "1")]
     pub pub_key: Vec<u8>,
 
-    #[prost(uint32, tag = "2")]
-    pub propose_weight: u32,
+    #[prost(bytes, tag = "2")]
+    pub address: Vec<u8>,
 
     #[prost(uint32, tag = "3")]
+    pub propose_weight: u32,
+
+    #[prost(uint32, tag = "4")]
     pub vote_weight: u32,
 }
 
@@ -299,6 +302,7 @@ impl From<block::Validator> for Validator {
     fn from(validator: block::Validator) -> Validator {
         Validator {
             pub_key:        validator.pub_key.to_vec(),
+            address:        validator.address.to_vec(),
             propose_weight: validator.propose_weight,
             vote_weight:    validator.vote_weight,
         }
@@ -311,6 +315,7 @@ impl TryFrom<Validator> for block::Validator {
     fn try_from(validator: Validator) -> Result<block::Validator, Self::Error> {
         let validator = block::Validator {
             pub_key:        Bytes::from(validator.pub_key),
+            address:        Bytes::from(validator.address),
             propose_weight: validator.propose_weight,
             vote_weight:    validator.vote_weight,
         };

--- a/protocol/src/fixed_codec/tests/mod.rs
+++ b/protocol/src/fixed_codec/tests/mod.rs
@@ -101,6 +101,7 @@ pub fn mock_sign_tx() -> SignedTransaction {
 pub fn mock_validator() -> Validator {
     Validator {
         pub_key:        get_random_bytes(32),
+        address:        mock_address().as_bytes(),
         propose_weight: 1,
         vote_weight:    1,
     }

--- a/protocol/src/fixed_codec/tests/mod.rs
+++ b/protocol/src/fixed_codec/tests/mod.rs
@@ -101,7 +101,6 @@ pub fn mock_sign_tx() -> SignedTransaction {
 pub fn mock_validator() -> Validator {
     Validator {
         pub_key:        get_random_bytes(32),
-        address:        mock_address().as_bytes(),
         propose_weight: 1,
         vote_weight:    1,
     }

--- a/protocol/src/fixed_codec/tests/mod.rs
+++ b/protocol/src/fixed_codec/tests/mod.rs
@@ -100,7 +100,7 @@ pub fn mock_sign_tx() -> SignedTransaction {
 
 pub fn mock_validator() -> Validator {
     Validator {
-        peer_id:        get_random_bytes(16),
+        pub_key:        get_random_bytes(32),
         propose_weight: 1,
         vote_weight:    1,
     }

--- a/protocol/src/fixed_codec/tests/mod.rs
+++ b/protocol/src/fixed_codec/tests/mod.rs
@@ -100,7 +100,7 @@ pub fn mock_sign_tx() -> SignedTransaction {
 
 pub fn mock_validator() -> Validator {
     Validator {
-        address:        mock_address(),
+        peer_id:        get_random_bytes(16),
         propose_weight: 1,
         vote_weight:    1,
     }

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -20,6 +20,7 @@ pub enum MessageTarget {
 pub struct NodeInfo {
     pub chain_id:     Hash,
     pub self_address: Address,
+    pub self_peer_id: Bytes,
 }
 
 #[async_trait]
@@ -144,7 +145,7 @@ pub trait CommonConsensusAdapter: Send + Sync {
         vote_pubkeys: Vec<Hex>,
     ) -> ProtocolResult<()>;
 
-    fn verity_proof_weight(
+    fn verify_proof_weight(
         &self,
         ctx: Context,
         block_height: u64,

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -13,7 +13,7 @@ use crate::{traits::mempool::MixedTxHashes, ProtocolResult};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MessageTarget {
     Broadcast,
-    Specified(Address),
+    Specified(Bytes),
 }
 
 #[derive(Debug, Clone)]

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -19,8 +19,8 @@ pub enum MessageTarget {
 #[derive(Debug, Clone)]
 pub struct NodeInfo {
     pub chain_id:     Hash,
+    pub self_pub_key: Bytes,
     pub self_address: Address,
-    pub self_peer_id: Bytes,
 }
 
 #[async_trait]

--- a/protocol/src/traits/network.rs
+++ b/protocol/src/traits/network.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
-use crate::{traits::Context, types::Address, ProtocolError, ProtocolErrorKind, ProtocolResult};
+use crate::{traits::Context, ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 #[derive(Debug)]
 pub enum Priority {
@@ -68,11 +68,11 @@ pub trait Gossip: Send + Sync {
     where
         M: MessageCodec;
 
-    async fn users_cast<M>(
+    async fn multicast<M>(
         &self,
         cx: Context,
         end: &str,
-        users: Vec<Address>,
+        peer_ids: Vec<Bytes>,
         msg: M,
         p: Priority,
     ) -> ProtocolResult<()>

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -61,7 +61,7 @@ pub struct Proof {
 
 #[derive(RlpFixedCodec, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Validator {
-    pub peer_id:        Bytes,
+    pub pub_key:        Bytes,
     pub propose_weight: u32,
     pub vote_weight:    u32,
 }

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -61,7 +61,7 @@ pub struct Proof {
 
 #[derive(RlpFixedCodec, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Validator {
-    pub address:        Address,
+    pub peer_id:        Bytes,
     pub propose_weight: u32,
     pub vote_weight:    u32,
 }

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -62,6 +62,7 @@ pub struct Proof {
 #[derive(RlpFixedCodec, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Validator {
     pub pub_key:        Bytes,
+    pub address:        Bytes,
     pub propose_weight: u32,
     pub vote_weight:    u32,
 }

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -62,7 +62,6 @@ pub struct Proof {
 #[derive(RlpFixedCodec, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Validator {
     pub pub_key:        Bytes,
-    pub address:        Bytes,
     pub propose_weight: u32,
     pub vote_weight:    u32,
 }

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -305,6 +305,7 @@ pub struct Metadata {
 #[derive(RlpFixedCodec, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
 pub struct ValidatorExtend {
     pub bls_pub_key:    Hex,
+    pub peer_id:        Bytes,
     pub address:        Address,
     pub propose_weight: u32,
     pub vote_weight:    u32,
@@ -321,9 +322,10 @@ impl fmt::Debug for ValidatorExtend {
 
         write!(
             f,
-            "bls public key {:?}, address {:?}, propose weight {}, vote weight {}",
+            "bls public key {:?}, address {:?}, preer ID {:?}, propose weight {}, vote weight {}",
             pk,
-            self.address.as_hex(),
+            self.address,
+            hex::encode(&self.peer_id),
             self.propose_weight,
             self.vote_weight
         )

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -352,8 +352,8 @@ fn ensure_len(real: usize, expect: usize) -> ProtocolResult<()> {
 mod tests {
     use bytes::Bytes;
 
-    use super::{Address, Hash};
-    use crate::types::Hex;
+    use super::{Address, Hash, ValidatorExtend};
+    use crate::{fixed_codec::FixedCodec, types::Hex};
 
     #[test]
     fn test_hash() {
@@ -389,5 +389,19 @@ mod tests {
         let hex = Hex::from_string(hex_str.to_owned()).unwrap();
 
         assert_eq!(hex_str, hex.0.as_str());
+    }
+
+    #[test]
+    fn test_validator_extend() {
+        let extend = ValidatorExtend {
+            bls_pub_key: Hex::from_string("0x04195bf31d7de5e98d4a4b4d6f248bdc4fe203a2f771e2fc0264b912214ef5d9e4316f6aedd89de0e0052c744ff29c94280ab51f1baa9c7784f9e29284b47b4d51144344dcae4bc819353352d21d138bc59e97916a3991343379695681e8fcb1c1".to_owned()).unwrap(),
+            peer_id:        Bytes::from(hex::decode("1220b4f89f60d42d7242cac567d1df57eabf7e47d5d00498e8de3964040ff162a1cf").unwrap()),
+            address: Address::from_hex("0x85f6162ac2c2223ce784155f304fe685372fa795").unwrap(),
+            propose_weight: 1,
+            vote_weight:    1,
+        };
+
+        let decoded = ValidatorExtend::decode_fixed(extend.encode_fixed().unwrap()).unwrap();
+        assert_eq!(decoded, extend);
     }
 }

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -305,7 +305,7 @@ pub struct Metadata {
 #[derive(RlpFixedCodec, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
 pub struct ValidatorExtend {
     pub bls_pub_key:    Hex,
-    pub peer_id:        Bytes,
+    pub peer_id:        Hex,
     pub address:        Address,
     pub propose_weight: u32,
     pub vote_weight:    u32,
@@ -320,14 +320,15 @@ impl fmt::Debug for ValidatorExtend {
             bls_pub_key.as_str()
         };
 
+        let peer_id = match hex::decode(&self.peer_id.as_string_trim0x()) {
+            Ok(bytes) => bs58::encode(&bytes).into_string(),
+            Err(_) => self.peer_id.0.to_owned(),
+        };
+
         write!(
             f,
-            "bls public key {:?}, address {:?}, preer ID {:?}, propose weight {}, vote weight {}",
-            pk,
-            self.address,
-            bs58::encode(&self.peer_id).into_string(),
-            self.propose_weight,
-            self.vote_weight
+            "bls public key {:?}, address {:?}, preer ID {}, propose weight {}, vote weight {}",
+            pk, self.address, peer_id, self.propose_weight, self.vote_weight
         )
     }
 }
@@ -395,7 +396,7 @@ mod tests {
     fn test_validator_extend() {
         let extend = ValidatorExtend {
             bls_pub_key: Hex::from_string("0x04195bf31d7de5e98d4a4b4d6f248bdc4fe203a2f771e2fc0264b912214ef5d9e4316f6aedd89de0e0052c744ff29c94280ab51f1baa9c7784f9e29284b47b4d51144344dcae4bc819353352d21d138bc59e97916a3991343379695681e8fcb1c1".to_owned()).unwrap(),
-            peer_id:        Bytes::from(hex::decode("1220b4f89f60d42d7242cac567d1df57eabf7e47d5d00498e8de3964040ff162a1cf").unwrap()),
+            peer_id:     Hex::from_string("0x1220c7b1dc28da9eeecc7b825f39d0c1e79f87a5cf8a44d888c9f1f1b1ad6be0c79b".to_owned()).unwrap(),
             address: Address::from_hex("0x85f6162ac2c2223ce784155f304fe685372fa795").unwrap(),
             propose_weight: 1,
             vote_weight:    1,

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -325,7 +325,7 @@ impl fmt::Debug for ValidatorExtend {
             "bls public key {:?}, address {:?}, preer ID {:?}, propose weight {}, vote weight {}",
             pk,
             self.address,
-            hex::encode(&self.peer_id),
+            bs58::encode(&self.peer_id).into_string(),
             self.propose_weight,
             self.vote_weight
         )

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -310,7 +310,7 @@ pub struct Metadata {
 #[derive(RlpFixedCodec, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
 pub struct ValidatorExtend {
     pub bls_pub_key:    Hex,
-    pub peer_id:        Hex,
+    pub pub_key:        Hex,
     pub address:        Address,
     pub propose_weight: u32,
     pub vote_weight:    u32,
@@ -324,12 +324,11 @@ impl fmt::Debug for ValidatorExtend {
         } else {
             bls_pub_key.as_str()
         };
-        let peer_id = bs58::encode(&self.peer_id.decode()).into_string();
 
         write!(
             f,
-            "bls public key {:?}, address {:?}, preer ID {}, propose weight {}, vote weight {}",
-            pk, self.address, peer_id, self.propose_weight, self.vote_weight
+            "bls public key {:?}, public key {:?}, address {:?} propose weight {}, vote weight {}",
+            pk, self.pub_key, self.address, self.propose_weight, self.vote_weight
         )
     }
 }
@@ -396,9 +395,9 @@ mod tests {
     #[test]
     fn test_validator_extend() {
         let extend = ValidatorExtend {
-            bls_pub_key: Hex::from_string("0x04195bf31d7de5e98d4a4b4d6f248bdc4fe203a2f771e2fc0264b912214ef5d9e4316f6aedd89de0e0052c744ff29c94280ab51f1baa9c7784f9e29284b47b4d51144344dcae4bc819353352d21d138bc59e97916a3991343379695681e8fcb1c1".to_owned()).unwrap(),
-            peer_id:     Hex::from_string("0x1220c7b1dc28da9eeecc7b825f39d0c1e79f87a5cf8a44d888c9f1f1b1ad6be0c79b".to_owned()).unwrap(),
-            address: Address::from_hex("0x85f6162ac2c2223ce784155f304fe685372fa795").unwrap(),
+            bls_pub_key: Hex::from_string("0x0401139331589f32220ec5f41f6faa0f5c3f4d36af011ab014cefd9d8f36b53b04a2031f681d1c9648a2a5d534d742931b0a5a4132da9ee752c1144d6396bed6cfc635c9687258cec9b60b387d35cf9e13f29091e11ae88024d74ca904c0ea3fb3".to_owned()).unwrap(),
+            pub_key:     Hex::from_string("0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004".to_owned()).unwrap(),
+            address:     Address::from_hex("0x76961e339fe2f1f931d84c425754806fb4174c34").unwrap(),
             propose_weight: 1,
             vote_weight:    1,
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,7 @@ pub struct ConfigNetwork {
 
 #[derive(Debug, Deserialize)]
 pub struct ConfigNetworkBootstrap {
-    pub pubkey:  Hex,
+    pub peer_id: String,
     pub address: String,
 }
 

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -181,10 +181,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let mut bootstrap_pairs = vec![];
     if let Some(bootstrap) = &config.network.bootstraps {
         for bootstrap in bootstrap.iter() {
-            bootstrap_pairs.push((
-                bootstrap.pubkey.as_string_trim0x(),
-                bootstrap.address.to_owned(),
-            ));
+            bootstrap_pairs.push((bootstrap.peer_id.to_owned(), bootstrap.address.to_owned()));
         }
     }
 

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -57,7 +57,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            peer_id:        v.peer_id.clone(),
+            peer_id:        v.peer_id.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -298,7 +298,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            peer_id:        v.peer_id.clone(),
+            peer_id:        v.peer_id.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -347,7 +347,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
 
     let mut bls_pub_keys = HashMap::new();
     for validator_extend in metadata.verifier_list.iter() {
-        let address = validator_extend.peer_id.clone();
+        let address = validator_extend.peer_id.decode(); // Use peer id bytes instead
         let hex_pubkey = hex::decode(validator_extend.bls_pub_key.as_string_trim0x())
             .map_err(MainError::FromHex)?;
         let pub_key = BlsPublicKey::try_from(hex_pubkey.as_ref()).map_err(MainError::Crypto)?;

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -58,6 +58,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .iter()
         .map(|v| Validator {
             pub_key:        v.pub_key.decode(),
+            address:        v.address.as_bytes(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -296,6 +297,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .iter()
         .map(|v| Validator {
             pub_key:        v.pub_key.decode(),
+            address:        v.address.as_bytes(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -57,7 +57,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            peer_id:        v.peer_id.decode(),
+            pub_key:        v.pub_key.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -295,17 +295,16 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            peer_id:        v.peer_id.decode(),
+            pub_key:        v.pub_key.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
         .collect();
 
-    let my_peer_id = Bytes::from(network_service.peer_id().into_bytes());
     let node_info = NodeInfo {
         chain_id:     metadata.chain_id.clone(),
         self_address: my_address.clone(),
-        self_peer_id: my_peer_id,
+        self_pub_key: my_pubkey.to_bytes(),
     };
     let current_header = &current_block.header;
     let block_hash = Hash::digest(current_block.header.encode_fixed()?);
@@ -344,7 +343,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
 
     let mut bls_pub_keys = HashMap::new();
     for validator_extend in metadata.verifier_list.iter() {
-        let address = validator_extend.peer_id.decode(); // Use peer id bytes instead
+        let address = validator_extend.pub_key.decode();
         let hex_pubkey = hex::decode(validator_extend.bls_pub_key.as_string_trim0x())
             .map_err(MainError::FromHex)?;
         let pub_key = BlsPublicKey::try_from(hex_pubkey.as_ref()).map_err(MainError::Crypto)?;
@@ -491,7 +490,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let authority_list = validators
         .iter()
         .map(|v| Node {
-            address:        v.peer_id.clone(),
+            address:        v.pub_key.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -58,7 +58,6 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .iter()
         .map(|v| Validator {
             pub_key:        v.pub_key.decode(),
-            address:        v.address.as_bytes(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -297,7 +296,6 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .iter()
         .map(|v| Validator {
             pub_key:        v.pub_key.decode(),
-            address:        v.address.as_bytes(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -57,7 +57,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            address:        v.address.clone(),
+            peer_id:        v.peer_id.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -298,7 +298,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            address:        v.address.clone(),
+            peer_id:        v.peer_id.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -345,7 +345,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
 
     let mut bls_pub_keys = HashMap::new();
     for validator_extend in metadata.verifier_list.iter() {
-        let address = validator_extend.address.as_bytes();
+        let address = validator_extend.peer_id.clone();
         let hex_pubkey = hex::decode(validator_extend.bls_pub_key.as_string_trim0x())
             .map_err(MainError::FromHex)?;
         let pub_key = BlsPublicKey::try_from(hex_pubkey.as_ref()).map_err(MainError::Crypto)?;
@@ -492,7 +492,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let authority_list = validators
         .iter()
         .map(|v| Node {
-            address:        v.address.as_bytes(),
+            address:        v.peer_id.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -301,11 +301,11 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         })
         .collect();
 
-    let my_peer_id = hex::encode(network_service.peer_id().as_bytes());
+    let my_peer_id = Bytes::from(network_service.peer_id().into_bytes());
     let node_info = NodeInfo {
         chain_id:     metadata.chain_id.clone(),
         self_address: my_address.clone(),
-        self_peer_id: Bytes::from("0x".to_owned() + &my_peer_id),
+        self_peer_id: my_peer_id,
     };
     let current_header = &current_block.header;
     let block_hash = Hash::digest(current_block.header.encode_fixed()?);

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -10,11 +10,11 @@
     "prettier": "prettier --write **/*.{js,ts,graphql}"
   },
   "dependencies": {
-    "@mutadev/account": "0.2.0-dev+pr315.0",
-    "@mutadev/client": "0.2.0-dev+pr315.0",
-    "@mutadev/muta-sdk": "0.2.0-dev+pr315.0",
-    "@mutadev/service": "0.2.0-dev+pr315.0",
-    "@mutadev/utils": "0.2.0-dev+pr315.0",
+    "@mutadev/account": "0.2.0-pr348.0",
+    "@mutadev/client": "0.2.0-pr348.0",
+    "@mutadev/muta-sdk": "0.2.0-pr348.0",
+    "@mutadev/service": "0.2.0-pr348.0",
+    "@mutadev/utils": "0.2.0-pr348.0",
     "@types/node": "^14.0.14",
     "@types/node-fetch": "^2.5.7",
     "apollo-boost": "^0.4.4",

--- a/tests/e2e/sdk.test.ts
+++ b/tests/e2e/sdk.test.ts
@@ -1,10 +1,10 @@
-import { Account } from '@mutadev/account';
 import { AssetService } from '@mutadev/service'
-import { toHex } from '@mutadev/utils';
-import { retry } from '@mutadev/client';
 import * as sdk from '@mutadev/muta-sdk';
 import { mutaClient } from './utils';
 import { MultiSigService } from './multisig';
+
+const { Account, retry } = sdk;
+const { toHex } = sdk.utils;
 
 describe("API test via @mutadev/muta-sdk-js", () => {
   test("getLatestBlock", async () => {

--- a/tests/e2e/yarn.lock
+++ b/tests/e2e/yarn.lock
@@ -345,104 +345,104 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@mutadev/account@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/account/-/account-0.2.0-dev.tgz#3b8b26499305debf4b291ba06ea65296a815a3e7"
-  integrity sha512-iwSeQ4dK7NjIN07S5gkN2fgeu6w2UxJNRItezQ55mm66Lxu21bR33k4Kqr/YKo/34D+JX1UPdhtyzolbPFVCDA==
+"@mutadev/account@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/account/-/account-0.2.0-pr348.0.tgz#2baea03a8829765c9d31e5f073052e61ed7c30fd"
+  integrity sha512-4eMMDb9LulFguzJ9TQowfh7gEEztxJCv5HpcsJhZV+ncdhWG3QxfnEjyCJvAOBNYIC9BK6pvLfd/VfzRZLfhiA==
   dependencies:
-    "@mutadev/defaults" "0.2.0-dev+pr315.0"
-    "@mutadev/utils" "0.2.0-dev+pr315.0"
+    "@mutadev/defaults" "0.2.0-pr348.0"
+    "@mutadev/utils" "0.2.0-pr348.0"
 
-"@mutadev/client-raw@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/client-raw/-/client-raw-0.2.0-dev.tgz#d7b66689f43f6f875c54bda75b073ee4876ac4f1"
-  integrity sha512-cWQbqwzAAJIONIRLwW5oVs5Zdy+QjpIDV1EYLqRDyeulbHItMb+Cc9S0aOD0iD/fGpfz9h8BmyX+8RWYV4AVUg==
+"@mutadev/client-raw@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/client-raw/-/client-raw-0.2.0-pr348.0.tgz#f3fb184f48aeb75c64d95d7349648c8ae6d34458"
+  integrity sha512-6Y+XQfN8SVaV+AF7yYz/m5Z3M6EYNOf+YcGJjNWC/FByRcsW8IltFvgj1UiW4z0xWgiavNAh+v+rHgmqjDC+LA==
   dependencies:
     graphql-request "^1.8.2"
     graphql-tag "^2.10.1"
 
-"@mutadev/client@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/client/-/client-0.2.0-dev.tgz#ba1562b6298fffb4fdbf52e1ba85606073a736cb"
-  integrity sha512-NL0XKxcmuCaTr8XUl2oam37fV08go6SNpEOvJP+yvOfxp00kZ4Sqv1P/r/ZNJo+tRwfbk81QHl3tJ9ZZURPF5A==
+"@mutadev/client@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/client/-/client-0.2.0-pr348.0.tgz#4aab4a87f2262cb0e8540c98b7ab5d31feccb98a"
+  integrity sha512-yXs3f6/QXsaj1BB8DU0iVQbdAW2nzQOPfwzgfIwie3dXd+a3PVnV6rPwR1fu+JatN5vXELbQGAVNj6XU8Rob2A==
   dependencies:
-    "@mutadev/client-raw" "0.2.0-dev+pr315.0"
-    "@mutadev/defaults" "0.2.0-dev+pr315.0"
-    "@mutadev/shared" "0.2.0-dev+pr315.0"
-    "@mutadev/types" "0.2.0-dev+pr315.0"
-    "@mutadev/utils" "0.2.0-dev+pr315.0"
+    "@mutadev/client-raw" "0.2.0-pr348.0"
+    "@mutadev/defaults" "0.2.0-pr348.0"
+    "@mutadev/shared" "0.2.0-pr348.0"
+    "@mutadev/types" "0.2.0-pr348.0"
+    "@mutadev/utils" "0.2.0-pr348.0"
     "@types/lodash" "^4.14.149"
     invariant "^2.2.4"
     lodash "^4.17.15"
     p-limit "^2.3.0"
     utility-types "^3.10.0"
 
-"@mutadev/defaults@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/defaults/-/defaults-0.2.0-dev.tgz#549e1504a12c4a9c7a4a6a76dcd6db79059a6805"
-  integrity sha512-wZgPUmknBOq0po7TZZKtHREYLXJvjokUoPFcdcqO0loLE2mNoFUm5VSBtUBNLh3nt1hm/m14uliTFUhp3+M/Mw==
+"@mutadev/defaults@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/defaults/-/defaults-0.2.0-pr348.0.tgz#d9c566b15c21d3fcce0bb5956be0e460a5c9dce7"
+  integrity sha512-pUMVWtfw3PH3Ymmw6X1Q1mi47Y1n0fAx1CxwirVwhMhWmey9dbaFvGEdbd81zEQkj4pya8AUPPG2QYlq2gOIIg==
 
-"@mutadev/muta-sdk@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/muta-sdk/-/muta-sdk-0.2.0-dev.tgz#b2f57a3f8a61b96c01edc32de14001ee98a753e7"
-  integrity sha512-+iQ0WO80VYlGg+sIvzwX4KDtvvsbhgedEMjVTq96iaY+AmfV/SEZiFT691cHP3MA7lRvjkKK0ZxnxGbcjsZr5w==
+"@mutadev/muta-sdk@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/muta-sdk/-/muta-sdk-0.2.0-pr348.0.tgz#38cb52f2d35ef0cff690c3eba1b677671bab2e9b"
+  integrity sha512-xBVS4Cl4K93cwMk3B6xfO1UhP4KERtt3CMBDxwOE9OQuMLT5yzzmEaM+h0OvWtQG53oaiC5MHYaNr2fRYd57Og==
   dependencies:
-    "@mutadev/account" "0.2.0-dev+pr315.0"
-    "@mutadev/client" "0.2.0-dev+pr315.0"
-    "@mutadev/defaults" "0.2.0-dev+pr315.0"
-    "@mutadev/shared" "0.2.0-dev+pr315.0"
-    "@mutadev/types" "0.2.0-dev+pr315.0"
-    "@mutadev/wallet" "0.2.0-dev+pr315.0"
+    "@mutadev/account" "0.2.0-pr348.0"
+    "@mutadev/client" "0.2.0-pr348.0"
+    "@mutadev/defaults" "0.2.0-pr348.0"
+    "@mutadev/shared" "0.2.0-pr348.0"
+    "@mutadev/types" "0.2.0-pr348.0"
+    "@mutadev/wallet" "0.2.0-pr348.0"
     utility-types "^3.10.0"
 
-"@mutadev/service@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/service/-/service-0.2.0-dev.tgz#84e88ec1aa35be5a7defb4b391608b52f125c7f1"
-  integrity sha512-5C/dbM1OWFDpgQJrO1xUW+Eb3AHu1Q10o3IC05pZpPaZCP3iu3kdwrZ5ZQORLT72epEcUoFsoc8RWE+b2rGcbA==
+"@mutadev/service@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/service/-/service-0.2.0-pr348.0.tgz#952fc80122ce9edfcdf1a22b91c3da881e0a23a0"
+  integrity sha512-teqP9aWtKCR9vEsuJABV5hxQyM8KPHMNTGjENQAbI7XIx/kNl3xR/csds+3VsFVDu1A74zK09RE81ei/eKjDkA==
   dependencies:
-    "@mutadev/account" "0.2.0-dev+pr315.0"
-    "@mutadev/client" "0.2.0-dev+pr315.0"
-    "@mutadev/shared" "0.2.0-dev+pr315.0"
-    "@mutadev/types" "0.2.0-dev+pr315.0"
-    "@mutadev/utils" "0.2.0-dev+pr315.0"
+    "@mutadev/account" "0.2.0-pr348.0"
+    "@mutadev/client" "0.2.0-pr348.0"
+    "@mutadev/shared" "0.2.0-pr348.0"
+    "@mutadev/types" "0.2.0-pr348.0"
+    "@mutadev/utils" "0.2.0-pr348.0"
     lodash "^4.17.15"
     utility-types "^3.10.0"
 
-"@mutadev/shared@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/shared/-/shared-0.2.0-dev.tgz#ef7177c0755d6b9bdd9ff2e897784dcf2dce7fcc"
-  integrity sha512-IuZoX6mPrddiPWETAe5utrDMJ4QAOY6/v6G+m7WX3oPzYZ/Loey+1D+ZCb2XLKjcmkYJ7l4RUwIq+DnxmPsHlA==
+"@mutadev/shared@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/shared/-/shared-0.2.0-pr348.0.tgz#9edf60a6308a845bb9d4938bc665b178ba9f3320"
+  integrity sha512-UP8jjqjfb+yU6qIVCThn3zVIksZPeb12yNmkWeD3+pqZGVUbzgro7X1j10m2D4mccPyr+A8Vl0xqzNf1O7V+MA==
   dependencies:
     "@types/invariant" "^2.2.4"
     bignumber.js "^9.0.0"
     invariant "^2.2.4"
 
-"@mutadev/types@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/types/-/types-0.2.0-dev.tgz#9342877bdf78ae9a86a30f0798242ca47039c1cf"
-  integrity sha512-FVEW4Hy5OBa7r+06grARAjJvvkR/wXiS+YeJrjWA/NDsUqwmZ1nOcHMrD9ulUZq1sEJQsDElvjo9ZeTFFwz0Xw==
+"@mutadev/types@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/types/-/types-0.2.0-pr348.0.tgz#6a442135ab55a877fac50f3e37e7c4d96dbd1f48"
+  integrity sha512-R210g63pjRbJFqexnA48aIuTVCOlIZm41Mtncm4PYbT28mw4LbHpzmQF7HPkBboRT5FpLGelg2P71tTLBZjp5w==
   dependencies:
     bignumber.js "^9.0.0"
 
-"@mutadev/utils@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/utils/-/utils-0.2.0-dev.tgz#9a89ca196a654cd194f251fa0b67ab0dfdf4484b"
-  integrity sha512-xY7K3Vz7mCporHA5hvsyoJOF0nOHRGUQ3UF70TlIkzQ4C4tPBSuIapDLZu8+tZfEPLxRIa/dYNd/tJMnIV4zhQ==
+"@mutadev/utils@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/utils/-/utils-0.2.0-pr348.0.tgz#405899f3d9f66205b8b8c8540a18453a63381961"
+  integrity sha512-zEspWMVy5FJMaXGlcrxfOX+IzHZvqZw7DrTUttSlJpXOmxNwpExT0QPPruLoZbnZTF17gOZkW+tlMEtRUkZ8gQ==
   dependencies:
-    "@mutadev/types" "0.2.0-dev+pr315.0"
+    "@mutadev/types" "0.2.0-pr348.0"
     json-bigint "^0.3.0"
     keccak "^3.0.0"
     randombytes "^2.1.0"
     rlp "^2.2.5"
     secp256k1 "^4.0.0"
 
-"@mutadev/wallet@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/wallet/-/wallet-0.2.0-dev.tgz#3fddedbef9db7d144d39d635c41b8f39de6bb957"
-  integrity sha512-/6m2nPfz/GhVPg9EeKz/LrHVvoGQREjrFCYXZ5N2fCa9J08W8oNy4CcTynZpaDnekt22veBCHDeG0GTs61R3lg==
+"@mutadev/wallet@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/wallet/-/wallet-0.2.0-pr348.0.tgz#a0f6d00bd8460670ccbe0ebfa696e3e68b71da2d"
+  integrity sha512-5W1nfqDyEu/ETNyoEZbEA/X4FJ9HnBJFAK2QMxfsjZYiAmLZcgHJ8xwNTtUwxjsi5L7XF4UAYm56nZtYTNbyoQ==
   dependencies:
-    "@mutadev/account" "0.2.0-dev+pr315.0"
-    "@mutadev/utils" "0.2.0-dev+pr315.0"
+    "@mutadev/account" "0.2.0-pr348.0"
+    "@mutadev/utils" "0.2.0-pr348.0"
     bip39 "^3.0.2"
     hdkey "^1.1.1"
 

--- a/tests/trust_metric_all/node/client_node.rs
+++ b/tests/trust_metric_all/node/client_node.rs
@@ -177,7 +177,7 @@ impl ClientNode {
     pub async fn broadcast<M: MessageCodec>(&self, endpoint: &str, msg: M) -> ClientResult<()> {
         use Priority::High;
 
-        let sid = match self.connected_session(&self.remote_chain_addr) {
+        let sid = match self.connected_session(&self.remote_peer_id) {
             Some(sid) => sid,
             None => return Err(ClientNodeError::NotConnected),
         };
@@ -200,7 +200,7 @@ impl ClientNode {
         M: MessageCodec,
         R: MessageCodec,
     {
-        let sid = match self.connected_session(&self.remote_chain_addr) {
+        let sid = match self.connected_session(&self.remote_peer_id) {
             Some(sid) => sid,
             None => return Err(ClientNodeError::NotConnected),
         };
@@ -306,7 +306,7 @@ fn full_node_peer_id(hex_pubkey: &str) -> PeerId {
         tentacle::secio::PublicKey::from_bytes(pubkey_bytes).expect("decode pubkey")
     };
 
-    pubkye.peer_id()
+    pubkey.peer_id()
 }
 
 fn mock_block(height: u64) -> Block {

--- a/tests/trust_metric_all/node/client_node.rs
+++ b/tests/trust_metric_all/node/client_node.rs
@@ -185,7 +185,7 @@ impl ClientNode {
         let ctx = Context::new().with_value::<usize>("session_id", sid);
         let users = vec![self.remote_chain_addr.clone()];
 
-        match self.users_cast::<M>(ctx, endpoint, users, msg, High).await {
+        match self.multicast::<M>(ctx, endpoint, users, msg, High).await {
             Err(_) if !self.connected() => Err(ClientNodeError::NotConnected),
             Err(e) => {
                 let err_msg = format!("broadcast to {} {}", endpoint, e);

--- a/tests/trust_metric_all/node/client_node.rs
+++ b/tests/trust_metric_all/node/client_node.rs
@@ -183,7 +183,7 @@ impl ClientNode {
         };
 
         let ctx = Context::new().with_value::<usize>("session_id", sid);
-        let peers = vec![self.remote_peer_id.clone()];
+        let peers = vec![Bytes::from(self.remote_peer_id.clone().into_bytes())];
 
         match self.multicast::<M>(ctx, endpoint, peers, msg, High).await {
             Err(_) if !self.connected() => Err(ClientNodeError::NotConnected),
@@ -303,7 +303,7 @@ fn full_node_hex_pubkey() -> String {
 fn full_node_peer_id(hex_pubkey: &str) -> PeerId {
     let pubkey = {
         let pubkey_bytes = hex::decode(hex_pubkey).expect("decode hex full node pubkey");
-        tentacle::secio::PublicKey::from_bytes(pubkey_bytes).expect("decode pubkey")
+        tentacle::secio::PublicKey::secp256k1_raw_key(pubkey_bytes).expect("decode pubkey")
     };
 
     pubkey.peer_id()

--- a/tests/trust_metric_all/node/config.rs
+++ b/tests/trust_metric_all/node/config.rs
@@ -30,7 +30,7 @@ pub struct ConfigNetwork {
 
 #[derive(Debug, Deserialize)]
 pub struct ConfigNetworkBootstrap {
-    pub pubkey:  Hex,
+    pub peer_id: String,
     pub address: String,
 }
 

--- a/tests/trust_metric_all/node/full_node/default_start.rs
+++ b/tests/trust_metric_all/node/full_node/default_start.rs
@@ -56,7 +56,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            peer_id:        v.peer_id.decode(),
+            pub_key:        v.pub_key.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -272,17 +272,16 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            peer_id:        v.peer_id.decode(),
+            pub_key:        v.pub_key.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
         .collect();
 
-    let my_peer_id = Bytes::from(network_service.peer_id().into_bytes());
     let node_info = NodeInfo {
         chain_id:     metadata.chain_id.clone(),
         self_address: my_address.clone(),
-        self_peer_id: my_peer_id,
+        self_pub_key: my_pubkey.to_bytes(),
     };
     let current_header = &current_block.header;
     let block_hash = Hash::digest(current_block.header.encode_fixed()?);
@@ -316,7 +315,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
 
     let mut bls_pub_keys = HashMap::new();
     for validator_extend in metadata.verifier_list.iter() {
-        let address = validator_extend.peer_id.decode();
+        let address = validator_extend.pub_key.decode();
         let hex_pubkey = hex::decode(validator_extend.bls_pub_key.as_string_trim0x())
             .map_err(MainError::FromHex)?;
         let pub_key = BlsPublicKey::try_from(hex_pubkey.as_ref()).map_err(MainError::Crypto)?;
@@ -464,7 +463,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let authority_list = validators
         .iter()
         .map(|v| Node {
-            address:        v.peer_id.clone(),
+            address:        v.pub_key.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/tests/trust_metric_all/node/full_node/default_start.rs
+++ b/tests/trust_metric_all/node/full_node/default_start.rs
@@ -57,7 +57,6 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .iter()
         .map(|v| Validator {
             pub_key:        v.pub_key.decode(),
-            address:        v.address.as_bytes(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -274,7 +273,6 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .iter()
         .map(|v| Validator {
             pub_key:        v.pub_key.decode(),
-            address:        v.address.as_bytes(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/tests/trust_metric_all/node/full_node/default_start.rs
+++ b/tests/trust_metric_all/node/full_node/default_start.rs
@@ -57,6 +57,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .iter()
         .map(|v| Validator {
             pub_key:        v.pub_key.decode(),
+            address:        v.address.as_bytes(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -273,6 +274,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .iter()
         .map(|v| Validator {
             pub_key:        v.pub_key.decode(),
+            address:        v.address.as_bytes(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/tests/trust_metric_all/node/full_node/default_start.rs
+++ b/tests/trust_metric_all/node/full_node/default_start.rs
@@ -162,10 +162,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let mut bootstrap_pairs = vec![];
     if let Some(bootstrap) = &config.network.bootstraps {
         for bootstrap in bootstrap.iter() {
-            bootstrap_pairs.push((
-                bootstrap.pubkey.as_string_trim0x(),
-                bootstrap.address.to_owned(),
-            ));
+            bootstrap_pairs.push((bootstrap.peer_id.to_owned(), bootstrap.address.to_owned()));
         }
     }
 

--- a/tests/trust_metric_all/node/full_node/default_start.rs
+++ b/tests/trust_metric_all/node/full_node/default_start.rs
@@ -56,7 +56,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            address:        v.address.clone(),
+            peer_id:        v.peer_id.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -275,15 +275,17 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            address:        v.address.clone(),
+            peer_id:        v.peer_id.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
         .collect();
 
+    let my_peer_id = Bytes::from(network_service.peer_id().into_bytes());
     let node_info = NodeInfo {
         chain_id:     metadata.chain_id.clone(),
         self_address: my_address.clone(),
+        self_peer_id: my_peer_id,
     };
     let current_header = &current_block.header;
     let block_hash = Hash::digest(current_block.header.encode_fixed()?);
@@ -317,7 +319,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
 
     let mut bls_pub_keys = HashMap::new();
     for validator_extend in metadata.verifier_list.iter() {
-        let address = validator_extend.address.as_bytes();
+        let address = validator_extend.peer_id.decode();
         let hex_pubkey = hex::decode(validator_extend.bls_pub_key.as_string_trim0x())
             .map_err(MainError::FromHex)?;
         let pub_key = BlsPublicKey::try_from(hex_pubkey.as_ref()).map_err(MainError::Crypto)?;
@@ -465,7 +467,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let authority_list = validators
         .iter()
         .map(|v| Node {
-            address:        v.address.as_bytes(),
+            address:        v.peer_id.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
refactor

**What this PR does / why we need it**:
refactor network api
  - rename users_cast t omulticast
  - replace Vec<Address> with Vec<Bytes>, PeerId bytes

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
