### PR TITLE
refactor(consensus)!: replace Validator address bytes with pubkey bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ rand = "0.7"
 cita_trie = "2.0"
 core-network = { path = "./core/network", features = ["diagnostic"] }
 tokio = { version = "0.2", features = ["full"] }
+bs58 = "0.3"
 
 [workspace]
 members = [

--- a/built-in-services/metadata/Cargo.toml
+++ b/built-in-services/metadata/Cargo.toml
@@ -15,10 +15,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rlp = "0.4"
 bytes = "0.5"
-derive_more = "0.15"
+derive_more = "0.99"
 byteorder = "1.3"
 
 [dev-dependencies]
+hex = "0.4"
 cita_trie = "2.0"
 async-trait = "0.1"
 framework = { path = "../../framework" }

--- a/built-in-services/metadata/src/tests/mod.rs
+++ b/built-in-services/metadata/src/tests/mod.rs
@@ -63,8 +63,9 @@ fn mock_metadata() -> Metadata {
         cycles_price:    1,
         interval:        3000,
         verifier_list:   [ValidatorExtend {
-            bls_pub_key: Hex::from_string("0x04188ef9488c19458a963cc57b567adde7db8f8b6bec392d5cb7b67b0abc1ed6cd966edc451f6ac2ef38079460eb965e890d1f576e4039a20467820237cda753f07a8b8febae1ec052190973a1bcf00690ea8fc0168b3fbbccd1c4e402eda5ef22".to_owned()).unwrap(),
-            address:        Address::from_hex("0xCAB8EEA4799C21379C20EF5BAA2CC8AF1BEC475B").unwrap(),
+            bls_pub_key: Hex::from_string("0x0401139331589f32220ec5f41f6faa0f5c3f4d36af011ab014cefd9d8f36b53b04a2031f681d1c9648a2a5d534d742931b0a5a4132da9ee752c1144d6396bed6cfc635c9687258cec9b60b387d35cf9e13f29091e11ae88024d74ca904c0ea3fb3".to_owned()).unwrap(),
+            pub_key:     Hex::from_string("0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004".to_owned()).unwrap(),
+            address:     Address::from_hex("0x76961e339fe2f1f931d84c425754806fb4174c34").unwrap(),
             propose_weight: 1,
             vote_weight:    1,
         }]

--- a/core/api/src/schema/block.rs
+++ b/core/api/src/schema/block.rs
@@ -67,7 +67,7 @@ pub struct Proof {
 #[derive(juniper::GraphQLObject, Clone)]
 #[graphql(description = "Validator address set")]
 pub struct Validator {
-    pub address:        Address,
+    pub pubkey:         Bytes,
     pub propose_weight: i32,
     pub vote_weight:    i32,
 }
@@ -142,7 +142,7 @@ impl From<protocol::types::Proof> for Proof {
 impl From<protocol::types::Validator> for Validator {
     fn from(validator: protocol::types::Validator) -> Self {
         Validator {
-            address:        Address::from(validator.address),
+            pubkey:         Bytes::from(validator.pub_key),
             propose_weight: validator.vote_weight as i32,
             vote_weight:    validator.vote_weight as i32,
         }

--- a/core/consensus/Cargo.toml
+++ b/core/consensus/Cargo.toml
@@ -41,7 +41,6 @@ lazy_static = "1.4"
 num-traits = "0.2"
 rand = "0.7"
 
-
 [features]
 default = []
 random_leader = ["overlord/random_leader"]

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -578,10 +578,12 @@ where
 
         // check validators
         for validator in block.header.validators.iter() {
+            let validator_address = Address::from_pubkey_bytes(validator.pub_key);
+
             if !authority_map.contains_key(&validator.pub_key) {
                 log::error!(
-                    "[consensus] verify_block_header, validator.pub_key: {:?}, authority_map: {:?}",
-                    validator.pub_key,
+                    "[consensus] verify_block_header, validator.address: {:?}, authority_map: {:?}",
+                    validator_address,
                     authority_map
                 );
                 return Err(ConsensusError::VerifyBlockHeader(
@@ -596,8 +598,8 @@ where
                     || node.propose_weight != validator.vote_weight
                 {
                     log::error!(
-                        "[consensus] verify_block_header, validator.pub_key: {:?}, authority_map: {:?}",
-                        validator.pub_key,
+                        "[consensus] verify_block_header, validator.address: {:?}, authority_map: {:?}",
+                        validator_address,
                         authority_map
                     );
                     return Err(ConsensusError::VerifyBlockHeader(

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -578,7 +578,7 @@ where
 
         // check validators
         for validator in block.header.validators.iter() {
-            let validator_address = Address::from_pubkey_bytes(validator.pub_key);
+            let validator_address = Address::from_pubkey_bytes(validator.pub_key.clone());
 
             if !authority_map.contains_key(&validator.pub_key) {
                 log::error!(

--- a/core/consensus/src/consensus.rs
+++ b/core/consensus/src/consensus.rs
@@ -119,12 +119,7 @@ impl<Adapter: ConsensusAdapter + 'static> OverlordConsensus<Adapter> {
             lock,
         ));
 
-        let overlord = Overlord::new(
-            node_info.self_address.as_bytes(),
-            Arc::clone(&engine),
-            crypto,
-            engine,
-        );
+        let overlord = Overlord::new(node_info.self_pub_key, Arc::clone(&engine), crypto, engine);
         let overlord_handler = overlord.get_handler();
         let status = status_agent.to_inner();
 
@@ -182,7 +177,7 @@ pub fn gen_overlord_status(
     let mut authority_list = validators
         .into_iter()
         .map(|v| Node {
-            address:        v.address.as_bytes(),
+            address:        v.pub_key.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -216,7 +211,7 @@ impl<T: overlord::Codec> OverlordMsgExt for OverlordMsg<T> {
             OverlordMsg::AggregatedVote(av) => av.get_height().to_string(),
             OverlordMsg::RichStatus(s) => s.height.to_string(),
             OverlordMsg::SignedChoke(sc) => sc.choke.height.to_string(),
-            OverlordMsg::Stop => "".to_owned(),
+            _ => "".to_owned(),
         }
     }
 
@@ -225,9 +220,8 @@ impl<T: overlord::Codec> OverlordMsgExt for OverlordMsg<T> {
             OverlordMsg::SignedProposal(sp) => sp.proposal.round.to_string(),
             OverlordMsg::SignedVote(sv) => sv.get_round().to_string(),
             OverlordMsg::AggregatedVote(av) => av.get_round().to_string(),
-            OverlordMsg::RichStatus(_) => "".to_owned(),
             OverlordMsg::SignedChoke(sc) => sc.choke.round.to_string(),
-            OverlordMsg::Stop => "".to_owned(),
+            _ => "".to_owned(),
         }
     }
 }

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -454,15 +454,16 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
     /// Only signed vote will be transmit to the relayer.
     #[muta_apm::derive::tracing_span(
         kind = "consensus.engine",
-        logs = "{'address':
-    'Address::from_bytes(addr.clone()).unwrap().as_hex()'}"
+        logs = "{'pub_key': 'hex::encode(pub_key.clone())'}"
     )]
     async fn transmit_to_relayer(
         &self,
         ctx: Context,
-        addr: Bytes,
+        pub_key: Bytes,
         msg: OverlordMsg<FixedPill>,
     ) -> Result<(), Box<dyn Error + Send>> {
+        let address = Address::from_pubkey_bytes(pub_key)?;
+
         match msg {
             OverlordMsg::SignedVote(sv) => {
                 let msg = sv.rlp_bytes();
@@ -471,7 +472,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_SIGNED_VOTE,
-                        MessageTarget::Specified(Address::from_bytes(addr)?),
+                        MessageTarget::Specified(address),
                     )
                     .await?;
             }
@@ -482,7 +483,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_AGGREGATED_VOTE,
-                        MessageTarget::Specified(Address::from_bytes(addr)?),
+                        MessageTarget::Specified(address),
                     )
                     .await?;
             }
@@ -521,7 +522,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             .verifier_list
             .into_iter()
             .map(|v| Node {
-                address:        v.address.as_bytes(),
+                address:        v.pub_key.decode(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })
@@ -760,7 +761,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
 pub fn generate_new_crypto_map(metadata: Metadata) -> ProtocolResult<HashMap<Bytes, BlsPublicKey>> {
     let mut new_addr_pubkey_map = HashMap::new();
     for validator in metadata.verifier_list.into_iter() {
-        let addr = validator.address.as_bytes();
+        let addr = validator.pub_key.decode();
         let hex_pubkey = hex::decode(validator.bls_pub_key.as_string_trim0x()).map_err(|err| {
             ConsensusError::Other(format!("hex decode metadata bls pubkey error {:?}", err))
         })?;
@@ -775,7 +776,7 @@ fn covert_to_overlord_authority(validators: &[Validator]) -> Vec<Node> {
     let mut authority = validators
         .iter()
         .map(|v| Node {
-            address:        v.address.as_bytes(),
+            address:        v.pub_key.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/core/consensus/src/status.rs
+++ b/core/consensus/src/status.rs
@@ -146,7 +146,7 @@ impl CurrentConsensusStatus {
             .verifier_list
             .iter()
             .map(|v| Validator {
-                address:        v.address.clone(),
+                pub_key:        v.pub_key.decode(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -156,8 +156,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
 
     #[muta_apm::derive::tracing_span(
         kind = "consensus.sync",
-        logs = "{'current_height': 'current_height', 'remote_height':
-    'remote_height'}"
+        logs = "{'current_height': 'current_height', 'remote_height': 'remote_height'}"
     )]
     async fn start_sync(
         &self,
@@ -364,11 +363,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
         Ok(())
     }
 
-    #[muta_apm::derive::tracing_span(
-        kind = "consensus.sync",
-        logs = "{'height':
-    'height'}"
-    )]
+    #[muta_apm::derive::tracing_span(kind = "consensus.sync", logs = "{'height': 'height'}")]
     async fn get_rich_block_from_remote(
         &self,
         ctx: Context,
@@ -390,22 +385,14 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
         Ok(RichBlock { block, txs })
     }
 
-    #[muta_apm::derive::tracing_span(
-        kind = "consensus.sync",
-        logs = "{'height':
-    'height'}"
-    )]
+    #[muta_apm::derive::tracing_span(kind = "consensus.sync", logs = "{'height': 'height'}")]
     async fn get_block_from_remote(&self, ctx: Context, height: u64) -> ProtocolResult<Block> {
         self.adapter
             .get_block_from_remote(ctx.clone(), height)
             .await
     }
 
-    #[muta_apm::derive::tracing_span(
-        kind = "consensus.sync",
-        logs = "{'txs_len':
-    'txs.len()'}"
-    )]
+    #[muta_apm::derive::tracing_span(kind = "consensus.sync", logs = "{'txs_len': 'txs.len()'}")]
     async fn save_chain_data(
         &self,
         ctx: Context,

--- a/core/consensus/src/tests/status.rs
+++ b/core/consensus/src/tests/status.rs
@@ -151,6 +151,7 @@ fn mock_validators_extend(len: usize) -> Vec<ValidatorExtend> {
                 "0xd654c7a6747fc2e34808c1ebb1510bfb19b443d639f2fab6dc41fce9f634de37".to_string(),
             )
             .unwrap(),
+            pub_key:        mock_pub_key(),
             address:        mock_address(),
             propose_weight: random::<u32>(),
             vote_weight:    random::<u32>(),
@@ -201,7 +202,7 @@ fn mock_validators(len: usize) -> Vec<Validator> {
 
 fn mock_validator() -> Validator {
     Validator {
-        address:        mock_address(),
+        pub_key:        mock_pub_key().decode(),
         propose_weight: random::<u32>(),
         vote_weight:    random::<u32>(),
     }
@@ -228,6 +229,13 @@ fn mock_hash() -> Hash {
 fn mock_address() -> Address {
     let hash = mock_hash();
     Address::from_hash(hash).unwrap()
+}
+
+fn mock_pub_key() -> Hex {
+    Hex::from_string(
+        "0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004".to_owned(),
+    )
+    .unwrap()
 }
 
 fn get_random_bytes(len: usize) -> Bytes {

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -9,7 +9,6 @@ use futures::lock::Mutex;
 use overlord::types::{AggregatedSignature, AggregatedVote, Node, SignedVote, Vote, VoteType};
 use overlord::{extract_voters, Crypto};
 use parking_lot::RwLock;
-use rlp::encode;
 
 use common_crypto::{
     BlsCommonReference, BlsPrivateKey, BlsPublicKey, HashValue, PrivateKey, PublicKey,
@@ -286,7 +285,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
     ) -> ProtocolResult<Metadata> {
         Ok(Metadata {
             chain_id:        Hash::from_empty(),
-            common_ref:      Hex::from_string("0x3453376d613471795964".to_string()).unwrap(),
+            common_ref:      Hex::from_string("0x5131414c656c5454355a".to_string()).unwrap(),
             timeout_gap:     20,
             cycles_limit:    9999,
             cycles_price:    1,
@@ -351,11 +350,11 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
 
         let authority_map = previous_metadata
             .verifier_list
-            .into_iter()
+            .iter()
             .map(|v| {
-                let address = v.address.as_bytes();
+                let address = v.pub_key.decode();
                 let node = Node {
-                    address:        v.address.as_bytes(),
+                    address:        v.pub_key.decode(),
                     propose_weight: v.propose_weight,
                     vote_weight:    v.vote_weight,
                 };
@@ -365,7 +364,10 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
 
         // check proposer
         if block.header.height != 0
-            && !authority_map.contains_key(&block.header.proposer.as_bytes())
+            && !previous_metadata
+                .verifier_list
+                .iter()
+                .any(|v| v.address == block.header.proposer)
         {
             log::error!(
                 "[consensus] verify_block_header, block.header.proposer: {:?}, authority_map: {:?}",
@@ -377,10 +379,12 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
 
         // check validators
         for validator in block.header.validators.iter() {
-            if !authority_map.contains_key(&validator.address.as_bytes()) {
+            let validator_address = Address::from_pubkey_bytes(validator.pub_key.clone());
+
+            if !authority_map.contains_key(&validator.pub_key) {
                 log::error!(
                     "[consensus] verify_block_header, validator.address: {:?}, authority_map: {:?}",
-                    validator.address,
+                    validator_address,
                     authority_map
                 );
                 return Err(ConsensusError::VerifyBlockHeader(
@@ -389,14 +393,14 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
                 )
                 .into());
             } else {
-                let node = authority_map.get(&validator.address.as_bytes()).unwrap();
+                let node = authority_map.get(&validator.pub_key).unwrap();
 
                 if node.vote_weight != validator.vote_weight
                     || node.propose_weight != validator.vote_weight
                 {
                     log::error!(
                         "[consensus] verify_block_header, validator.address: {:?}, authority_map: {:?}",
-                        validator.address,
+                        validator_address,
                         authority_map
                     );
                     return Err(ConsensusError::VerifyBlockHeader(
@@ -458,7 +462,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             .verifier_list
             .iter()
             .map(|v| Node {
-                address:        v.address.as_bytes(),
+                address:        v.pub_key.decode(),
                 propose_weight: v.propose_weight,
                 vote_weight:    v.vote_weight,
             })
@@ -481,7 +485,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             .verifier_list
             .iter()
             .filter_map(|v| {
-                if signed_voters.contains(&v.address.as_bytes()) {
+                if signed_voters.contains(&v.pub_key.decode()) {
                     Some(v.bls_pub_key.clone())
                 } else {
                     None
@@ -509,9 +513,9 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
         let weight_map = authority_list
             .iter()
             .map(|node| (node.address.clone(), node.vote_weight))
-            .collect::<HashMap<overlord::types::Address, u32>>();
+            .collect::<HashMap<_, _>>();
 
-        self.verity_proof_weight(ctx.clone(), block.header.height, weight_map, signed_voters)?;
+        self.verify_proof_weight(ctx.clone(), block.header.height, weight_map, signed_voters)?;
 
         Ok(())
     }
@@ -537,7 +541,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
             })
     }
 
-    fn verity_proof_weight(
+    fn verify_proof_weight(
         &self,
         _ctx: Context,
         block_height: u64,
@@ -547,21 +551,22 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
         let total_validator_weight: u64 = weight_map.iter().map(|pair| u64::from(*pair.1)).sum();
 
         let mut accumulator = 0u64;
-        for signed_voter_address in signed_voters {
-            if weight_map.contains_key(signed_voter_address.as_ref()) {
-                let weight = weight_map.get(signed_voter_address.as_ref()).ok_or({
+        for signed_voter_address in signed_voters.iter() {
+            if weight_map.contains_key(signed_voter_address) {
+                let weight = weight_map.get(signed_voter_address).ok_or_else(|| {
                     log::error!(
-                        "[consensus] verity_proof_weight,signed_voter_address: {:?}",
-                        signed_voter_address
+                        "[consensus] verify_proof_weight, signed_voter_address: {:?}",
+                        hex::encode(signed_voter_address)
                     );
                     ConsensusError::VerifyProof(block_height, WeightNotFound)
                 })?;
                 accumulator += u64::from(*(weight));
             } else {
                 log::error!(
-                    "[consensus] verity_proof_weight,signed_voter_address: {:?}",
-                    signed_voter_address
+                    "[consensus] verify_proof_weight,signed_voter_address: {:?}",
+                    hex::encode(signed_voter_address)
                 );
+
                 return Err(
                     ConsensusError::VerifyProof(block_height, BlockProofField::Validator).into(),
                 );
@@ -570,7 +575,7 @@ impl CommonConsensusAdapter for MockCommonConsensusAdapter {
 
         if 3 * accumulator <= 2 * total_validator_weight {
             log::error!(
-                "[consensus] verity_proof_weight, accumulator: {}, total: {}",
+                "[consensus] verify_proof_weight, accumulator: {}, total: {}",
                 accumulator,
                 total_validator_weight
             );
@@ -664,12 +669,16 @@ fn mock_chained_rich_block(len: u64, gap: u64, key_tool: &KeyTool) -> (Vec<RichB
             state_root: Hash::from_empty(),
             receipt_root: vec![],
             cycles_used: vec![],
-            proposer: Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773").unwrap(),
+            proposer: Address::from_hex("0x40e680f764a84c3add6753685aecf59700e24a4b").unwrap(),
             proof: last_proof,
             validator_version: 0,
             validators: vec![Validator {
-                address:        Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773")
-                    .unwrap(),
+                pub_key:        Hex::from_string(
+                    "0x025a1f87bd7980510d8d4224e9e521ba2e98865f420c555568b1b71a64977b5e41"
+                        .to_owned(),
+                )
+                .unwrap()
+                .decode(),
                 propose_weight: 5,
                 vote_weight:    5,
             }],
@@ -737,7 +746,7 @@ fn mock_genesis_rich_block() -> RichBlock {
         receipt_root:                   vec![],
         cycles_used:                    vec![],
         proposer:                       Address::from_hex(
-            "0x82c67c421d208fb7015d2da79550212a50f2e773",
+            "0x40e680f764a84c3add6753685aecf59700e24a4b",
         )
         .unwrap(),
         proof:                          Proof {
@@ -749,8 +758,11 @@ fn mock_genesis_rich_block() -> RichBlock {
         },
         validator_version:              0,
         validators:                     vec![Validator {
-            address:        Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773")
-                .unwrap(),
+            pub_key:        Hex::from_string(
+                "0x025a1f87bd7980510d8d4224e9e521ba2e98865f420c555568b1b71a64977b5e41".to_owned(),
+            )
+            .unwrap()
+            .decode(),
             propose_weight: 0,
             vote_weight:    0,
         }],
@@ -846,19 +858,20 @@ fn mock_proof(block_hash: Hash, height: u64, round: u64, key_tool: &KeyTool) -> 
         block_hash: block_hash.as_bytes(),
     };
 
-    let vote_hash = key_tool.overlord_crypto.hash(Bytes::from(encode(&vote)));
+    let vote_hash = key_tool
+        .overlord_crypto
+        .hash(Bytes::from(rlp::encode(&vote)));
     let bls_signature = key_tool.overlord_crypto.sign(vote_hash).unwrap();
     let signed_vote = SignedVote {
-        voter:     key_tool.signer_node.secp_address.as_bytes(),
+        voter:     key_tool.signer_node.secp_public_key.to_bytes(),
         signature: bls_signature,
         vote:      vote.clone(),
     };
 
-    let signed_voter =
-        vec![Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773").unwrap()]
-            .iter()
-            .cloned()
-            .collect::<HashSet<Address>>(); //
+    let signed_voter = vec![key_tool.signer_node.secp_public_key.to_bytes()]
+        .iter()
+        .cloned()
+        .collect::<HashSet<Bytes>>(); //
     let mut bit_map = BitVec::from_elem(3, false);
 
     let mut authority_list: Vec<Node> = key_tool
@@ -866,7 +879,7 @@ fn mock_proof(block_hash: Hash, height: u64, round: u64, key_tool: &KeyTool) -> 
         .clone()
         .iter()
         .map(|v| Node {
-            address:        v.address.as_bytes(),
+            address:        v.pub_key.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -874,7 +887,7 @@ fn mock_proof(block_hash: Hash, height: u64, round: u64, key_tool: &KeyTool) -> 
     authority_list.sort();
 
     for (index, node) in authority_list.iter().enumerate() {
-        if signed_voter.contains(&Address::from_bytes(node.address.clone()).unwrap()) {
+        if signed_voter.contains(&node.address) {
             bit_map.set(index, true);
         }
     }
@@ -894,7 +907,7 @@ fn mock_proof(block_hash: Hash, height: u64, round: u64, key_tool: &KeyTool) -> 
         height,
         round,
         block_hash: block_hash.as_bytes(),
-        leader: key_tool.signer_node.secp_address.as_bytes(),
+        leader: key_tool.signer_node.secp_public_key.to_bytes(),
     };
 
     Proof {
@@ -938,19 +951,13 @@ fn exec_txs(height: u64, txs: &[SignedTransaction]) -> (ExecutorResp, MerkleRoot
 struct SignerNode {
     secp_private_key: Secp256k1PrivateKey,
     secp_public_key:  Secp256k1PublicKey,
-    secp_address:     Address,
 }
 
 impl SignerNode {
-    pub fn new(
-        secp_private_key: Secp256k1PrivateKey,
-        secp_public_key: Secp256k1PublicKey,
-        secp_address: Address,
-    ) -> Self {
+    pub fn new(secp_private_key: Secp256k1PrivateKey, secp_public_key: Secp256k1PublicKey) -> Self {
         SignerNode {
             secp_private_key,
             secp_public_key,
-            secp_address,
         }
     }
 }
@@ -977,18 +984,16 @@ impl KeyTool {
 
 fn get_mock_key_tool() -> KeyTool {
     let hex_privkey =
-        hex::decode("d654c7a6747fc2e34808c1ebb1510bfb19b443d639f2fab6dc41fce9f634de37").unwrap();
+        hex::decode("bd5da51982aa5ccc1bd6cec68ffee0caa708671ba5149390c39e4f660bfe4c49").unwrap();
     let secp_privkey = Secp256k1PrivateKey::try_from(hex_privkey.as_ref()).unwrap();
     let secp_pubkey: Secp256k1PublicKey = secp_privkey.pub_key();
-    let secp_address = Address::from_pubkey_bytes(secp_pubkey.to_bytes()).unwrap();
-
-    let signer_node = SignerNode::new(secp_privkey, secp_pubkey, secp_address);
+    let signer_node = SignerNode::new(secp_privkey, secp_pubkey);
 
     // generate BLS/OverlordCrypto
     let mut bls_priv_key = Vec::new();
     bls_priv_key.extend_from_slice(&[0u8; 16]);
     let mut tmp =
-        hex::decode("d654c7a6747fc2e34808c1ebb1510bfb19b443d639f2fab6dc41fce9f634de37").unwrap();
+        hex::decode("bd5da51982aa5ccc1bd6cec68ffee0caa708671ba5149390c39e4f660bfe4c49").unwrap();
     bls_priv_key.append(&mut tmp);
     let bls_priv_key = BlsPrivateKey::try_from(bls_priv_key.as_ref()).unwrap();
 
@@ -1002,40 +1007,46 @@ fn get_mock_key_tool() -> KeyTool {
 fn get_mock_public_keys_and_common_ref() -> (HashMap<Bytes, BlsPublicKey>, BlsCommonReference) {
     let mut bls_pub_keys: HashMap<Bytes, BlsPublicKey> = HashMap::new();
 
-    // weight = 3
-    let bls_hex = Hex::from_string("0x0403142cf2dc63d122cc31e8245daa661b4b7c47793a9ab14e3c27430e3a835cb50b0bda0ea90480765d73d509e02c15f8031c20a77254fb0a8ec2919f2ed13b02034153776ad30d8fad90da15e0b85cd98cb81fa5f810c62563c8b507ef11604e".to_string()
+    // weight = 5
+    let bls_hex = Hex::from_string("0x04061c1c36a4252e8267ca143d1947f185dd6a04b5cc20f3ec85290e4e631fb67766392fa726120b1235da64fb2e5ffa4813c7dfe67b8019765b231ac0fbb5e5d45b12cf39ba98c02a6f1587bc6f4d8d7b7324efb40d3b6798b3f1792fc414c5df".to_string()
     ).unwrap();
     let bls_hex = hex::decode(bls_hex.as_string_trim0x()).unwrap();
     bls_pub_keys.insert(
-        Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773")
-            .unwrap()
-            .as_bytes(),
+        Hex::from_string(
+            "0x025a1f87bd7980510d8d4224e9e521ba2e98865f420c555568b1b71a64977b5e41".to_owned(),
+        )
+        .unwrap()
+        .decode(),
         BlsPublicKey::try_from(bls_hex.as_ref()).unwrap(),
     );
 
     // weight = 1
-    let bls_hex = Hex::from_string("0x0414a4665f0d3d0a2b034e933a40f8e84a2113b12cdc33c1f17d28a4a5313768cfdb5c1b6d8f9a3e0df54c87d6fb196b1a0e93d284bfe15814f5bce36c4092bdf26c88b77798570a3ac251c630cc7995a89047f51b2a9aebb1046d81d52486be32".to_string()
+    let bls_hex = Hex::from_string("0x0410d89f114ebd98a984fa2e964decc6b7b7542326a1abb6e4725b34c70f4408dbfff312ce163147039a6b07737b25902d082194cfe36b50f81d5106f6ee6ea146c4fbcfc87de87bdcd49ce087c01411b37c520402bd0a40fd13ce550c237362a0".to_string()
     ).unwrap();
     let bls_hex = hex::decode(bls_hex.as_string_trim0x()).unwrap();
     bls_pub_keys.insert(
-        Address::from_hex("0x6c9e6d3ccf42a3e67f6bf132a53a92db3bc065b5")
-            .unwrap()
-            .as_bytes(),
+        Hex::from_string(
+            "0x028206a78f082023be8eed96f8d3c09c006bd827fb47c04950b62d8dfcb4134467".to_owned(),
+        )
+        .unwrap()
+        .decode(),
         BlsPublicKey::try_from(bls_hex.as_ref()).unwrap(),
     );
 
     // weight = 1
-    let bls_hex = Hex::from_string("0x04051326c12edd4eded8a215566390a03896389b80422a652327fc438d64d65f1f60065b69215bb5c0864a46e149ba30d21138ad5981ad6e0c79a357eeb686a4d0cd690caccca169e6393a9b1cc850c203f474276ae71c291a1523ce76f0a8851e".to_string()
+    let bls_hex = Hex::from_string("0x0402de7a497fb892c60aa98e3ec31a2de10d7f0f952aba3764caed202e3874cdb536b4c018c198a7c9354b898f9500ec6812a72f83b72ba3fa31b16be77bedbc056625db790174ee811b3d763bb1bca1fcceaf00333e1b3ba98bfa53e65d9e6488".to_string()
     ).unwrap();
     let bls_hex = hex::decode(bls_hex.as_string_trim0x()).unwrap();
     bls_pub_keys.insert(
-        Address::from_hex("0x9b80c81780b782d03b3cebe0033bb78cb8d855d7")
-            .unwrap()
-            .as_bytes(),
+        Hex::from_string(
+            "0x0230eb18bc3f638750affffff2fe7be468e50feb9cdd5e6af947b3e4505f2ed5e2".to_owned(),
+        )
+        .unwrap()
+        .decode(),
         BlsPublicKey::try_from(bls_hex.as_ref()).unwrap(),
     );
 
-    let hex_common_ref = hex::decode("3453376d613471795964").unwrap();
+    let hex_common_ref = hex::decode("5131414c656c5454355a").unwrap();
     let common_ref: BlsCommonReference =
         std::str::from_utf8(hex_common_ref.as_ref()).unwrap().into();
 
@@ -1045,71 +1056,66 @@ fn get_mock_public_keys_and_common_ref() -> (HashMap<Bytes, BlsPublicKey>, BlsCo
 fn mock_verifier_list() -> Vec<ValidatorExtend> {
     vec![
         ValidatorExtend {
-
-            bls_pub_key: Hex::from_string("0x0403142cf2dc63d122cc31e8245daa661b4b7c47793a9ab14e3c27430e3a835cb50b0bda0ea90480765d73d509e02c15f8031c20a77254fb0a8ec2919f2ed13b02034153776ad30d8fad90da15e0b85cd98cb81fa5f810c62563c8b507ef11604e".to_owned()).unwrap(),
-            address:        Address::from_hex("0x82c67c421d208fb7015d2da79550212a50f2e773").unwrap(),
+            bls_pub_key: Hex::from_string("0x04061c1c36a4252e8267ca143d1947f185dd6a04b5cc20f3ec85290e4e631fb67766392fa726120b1235da64fb2e5ffa4813c7dfe67b8019765b231ac0fbb5e5d45b12cf39ba98c02a6f1587bc6f4d8d7b7324efb40d3b6798b3f1792fc414c5df".to_owned()).unwrap(),
+            pub_key: Hex::from_string("0x025a1f87bd7980510d8d4224e9e521ba2e98865f420c555568b1b71a64977b5e41".to_owned()).unwrap(),
+            address: Address::from_hex("0x40e680f764a84c3add6753685aecf59700e24a4b").unwrap(),
             propose_weight: 5,
             vote_weight:    5,
         },
         ValidatorExtend {
-            bls_pub_key: Hex::from_string("0x0414a4665f0d3d0a2b034e933a40f8e84a2113b12cdc33c1f17d28a4a5313768cfdb5c1b6d8f9a3e0df54c87d6fb196b1a0e93d284bfe15814f5bce36c4092bdf26c88b77798570a3ac251c630cc7995a89047f51b2a9aebb1046d81d52486be32".to_owned()).unwrap(),
-            address:        Address::from_hex("0x6c9e6d3ccf42a3e67f6bf132a53a92db3bc065b5").unwrap(),
+            bls_pub_key: Hex::from_string("0x0410d89f114ebd98a984fa2e964decc6b7b7542326a1abb6e4725b34c70f4408dbfff312ce163147039a6b07737b25902d082194cfe36b50f81d5106f6ee6ea146c4fbcfc87de87bdcd49ce087c01411b37c520402bd0a40fd13ce550c237362a0".to_owned()).unwrap(),
+            pub_key: Hex::from_string("0x028206a78f082023be8eed96f8d3c09c006bd827fb47c04950b62d8dfcb4134467".to_owned()).unwrap(),
+            address: Address::from_hex("0x8b1de21fb70dc97256f756fbdb04f91891e329bf").unwrap(),
             propose_weight: 1,
             vote_weight:    1,
         },
         ValidatorExtend {
-            bls_pub_key: Hex::from_string("0x04051326c12edd4eded8a215566390a03896389b80422a652327fc438d64d65f1f60065b69215bb5c0864a46e149ba30d21138ad5981ad6e0c79a357eeb686a4d0cd690caccca169e6393a9b1cc850c203f474276ae71c291a1523ce76f0a8851e".to_owned()).unwrap(),
-            address:        Address::from_hex("0x9b80c81780b782d03b3cebe0033bb78cb8d855d7").unwrap(),
+            bls_pub_key: Hex::from_string("0x0402de7a497fb892c60aa98e3ec31a2de10d7f0f952aba3764caed202e3874cdb536b4c018c198a7c9354b898f9500ec6812a72f83b72ba3fa31b16be77bedbc056625db790174ee811b3d763bb1bca1fcceaf00333e1b3ba98bfa53e65d9e6488".to_owned()).unwrap(),
+            pub_key: Hex::from_string("0x0230eb18bc3f638750affffff2fe7be468e50feb9cdd5e6af947b3e4505f2ed5e2".to_owned()).unwrap(),
+            address: Address::from_hex("0x8af94238483ea5660f3d30674db9b0ee683d9948").unwrap(),
             propose_weight: 1,
             vote_weight:    1,
         },
     ]
 }
 
+#[rustfmt::skip]
 // {
-// "common_ref": "3453376d613471795964",
-// "keypairs": [
-// {
-// "index": 1,
-// "private_key":
-// "d654c7a6747fc2e34808c1ebb1510bfb19b443d639f2fab6dc41fce9f634de37",
-// "public_key":
-// "03eacfbe0c216b9afd1370da335a49f49b88a4a34cc99c15885812e36bfab774fd",
-// "address": "82c67c421d208fb7015d2da79550212a50f2e773",
-// "bls_public_key":
-// "0403142cf2dc63d122cc31e8245daa661b4b7c47793a9ab14e3c27430e3a835cb50b0bda0ea90480765d73d509e02c15f8031c20a77254fb0a8ec2919f2ed13b02034153776ad30d8fad90da15e0b85cd98cb81fa5f810c62563c8b507ef11604e"
-// },
-// {
-// "index": 2,
-// "private_key":
-// "aa0374de198a4ba1187e4a41b316e159ab256ce129bcc76c10d746edfe6f82e5",
-// "public_key":
-// "03bf246a94a98a4c96a71a02187b8bc98539f853287800a7fa38d67b2ed9643bd2",
-// "address": "6c9e6d3ccf42a3e67f6bf132a53a92db3bc065b5",
-// "bls_public_key":
-// "0414a4665f0d3d0a2b034e933a40f8e84a2113b12cdc33c1f17d28a4a5313768cfdb5c1b6d8f9a3e0df54c87d6fb196b1a0e93d284bfe15814f5bce36c4092bdf26c88b77798570a3ac251c630cc7995a89047f51b2a9aebb1046d81d52486be32"
-// },
-// {
-// "index": 3,
-// "private_key":
-// "0c27b03412cae1df9cd7374c2eab1daff1023721f9930f44d7f5a0f8172a2b32",
-// "public_key":
-// "028b1e157e441a3cd6f2f6116ecac24235c02e1d66471407484fba5dca44242a8f",
-// "address": "9b80c81780b782d03b3cebe0033bb78cb8d855d7",
-// "bls_public_key":
-// "04051326c12edd4eded8a215566390a03896389b80422a652327fc438d64d65f1f60065b69215bb5c0864a46e149ba30d21138ad5981ad6e0c79a357eeb686a4d0cd690caccca169e6393a9b1cc850c203f474276ae71c291a1523ce76f0a8851e"
-// },
-// {
-// "index": 4,
-// "private_key":
-// "fc57fc08dc883891b88292a2d2915050b9a09c8a6096dfb04372bdd15162665e",
-// "public_key":
-// "03c00ce1cb83fbf8151c98d110d8cc4d83a6884fcee27916d416882ce42ae5925c",
-// "address": "0804d72af82a05733df54a72278a73629b4bea17",
-// "bls_public_key":
-// "040d606915df9b432acf66cdd9338d240fe781fb05249957201613113dda384960022649e9fd9e8b66c8962bb5e223d30405c5590e8d9cae893384ace1789d61a73b325e638ef5ee1c47d3b2a5a863e19b54fbfc881b5cc0b8bb05fce04d514807"
-// }
-// ]
+//   "common_ref": "0x5131414c656c5454355a",
+//   "keypairs": [
+//     {
+//       "index": 1,
+//       "private_key": "0xbd5da51982aa5ccc1bd6cec68ffee0caa708671ba5149390c39e4f660bfe4c49",
+//       "public_key": "0x025a1f87bd7980510d8d4224e9e521ba2e98865f420c555568b1b71a64977b5e41",
+//       "address": "0x40e680f764a84c3add6753685aecf59700e24a4b",
+//       "peer_id": "0x1220c8007bb2f04b921ec052df4836a5c81e658c8975e4b514da3cefbc64cb824932",
+//       "bls_public_key": "0x04061c1c36a4252e8267ca143d1947f185dd6a04b5cc20f3ec85290e4e631fb67766392fa726120b1235da64fb2e5ffa4813c7dfe67b8019765b231ac0fbb5e5d45b12cf39ba98c02a6f1587bc6f4d8d7b7324efb40d3b6798b3f1792fc414c5df"
+//     },
+//     {
+//       "index": 2,
+//       "private_key": "0xabec0e3a9cc9e5722a8582f5fd7cbaada11a12b0f2733873699aa1c17218f35a",
+//       "public_key": "0x028206a78f082023be8eed96f8d3c09c006bd827fb47c04950b62d8dfcb4134467",
+//       "address": "0x8b1de21fb70dc97256f756fbdb04f91891e329bf",
+//       "peer_id": "0x122095c712e8fc94f2febfd4eb21a05dbc78ed2b45a7135e7a72422cfa69a22bf14c",
+//       "bls_public_key": "0x0410d89f114ebd98a984fa2e964decc6b7b7542326a1abb6e4725b34c70f4408dbfff312ce163147039a6b07737b25902d082194cfe36b50f81d5106f6ee6ea146c4fbcfc87de87bdcd49ce087c01411b37c520402bd0a40fd13ce550c237362a0"
+//     },
+//     {
+//       "index": 3,
+//       "private_key": "0x1c43ffb8a5110b37bf2fba6678760fee4cf5a408526c1ef00f28b8f574df1d92",
+//       "public_key": "0x0230eb18bc3f638750affffff2fe7be468e50feb9cdd5e6af947b3e4505f2ed5e2",
+//       "address": "0x8af94238483ea5660f3d30674db9b0ee683d9948",
+//       "peer_id": "0x122024ff8439058d2fa71492e7606547dadc0e0d8bda3c240cca50b6066fa813b1c2",
+//       "bls_public_key": "0x0402de7a497fb892c60aa98e3ec31a2de10d7f0f952aba3764caed202e3874cdb536b4c018c198a7c9354b898f9500ec6812a72f83b72ba3fa31b16be77bedbc056625db790174ee811b3d763bb1bca1fcceaf00333e1b3ba98bfa53e65d9e6488"
+//     },
+//     {
+//       "index": 4,
+//       "private_key": "0x598e505735b9237fcb6736a3a69bb8e7c8293ca4a9b3458b9cbeb1207d2b421f",
+//       "public_key": "0x036fa093c97cbacf1094abd51d3799f9b0920a8decb27f3d126fff37854b58fbb6",
+//       "address": "0x8fff53935d33415ba794d9d81e710872727f9a2d",
+//       "peer_id": "0x122008bbfbff46a3ad94dabb521d0f57e37c3e09b716496be22282e1b560f93963f1",
+//       "bls_public_key": "0x0407d5cd1321e00c596c5c10bc1fd07fad1bf56b3b8e262ae49b1d220a21fcdcf1232862dc51db3673b1337a44d9d04a991415f3afc872e188e2208e7a71ba3d86352a0ad10f5938dfeeb9594c1091ff29051b5baaee825c62c9487835daad9fa8"
+//     }
+//   ]
 // }
 
 fn assert_sync(status: CurrentConsensusStatus, latest_block: Block) {

--- a/core/consensus/src/util.rs
+++ b/core/consensus/src/util.rs
@@ -114,11 +114,11 @@ impl Crypto for OverlordCrypto {
 impl OverlordCrypto {
     pub fn new(
         private_key: BlsPrivateKey,
-        addr_pubkey: HashMap<Bytes, BlsPublicKey>,
+        pubkey_to_bls_pubkey: HashMap<Bytes, BlsPublicKey>,
         common_ref: BlsCommonReference,
     ) -> Self {
         OverlordCrypto {
-            addr_pubkey: RwLock::new(addr_pubkey),
+            addr_pubkey: RwLock::new(pubkey_to_bls_pubkey),
             private_key,
             common_ref,
         }

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -1,5 +1,5 @@
 # crypto
-privkey = "0x45c56be699dca666191ad3446897e0f480da234da896270202514a0e1a587c3f"
+privkey = "0x4a33067c449635c434cc758ed5f595e1f5653debc45233997c93814c31f710d5"
 
 # db config
 data_path = "./devtools/chain/data"
@@ -20,7 +20,7 @@ rpc_timeout = 10
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
-pubkey = "0x031288a6788678c25952eba8693b2f278f66e2187004b64ac09416d07f83f96d5b"
+pubkey = "0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004"
 address = "0.0.0.0:1888"
 
 [mempool]

--- a/devtools/chain/genesis.toml
+++ b/devtools/chain/genesis.toml
@@ -18,15 +18,16 @@ name = "metadata"
 payload = '''
 {
     "chain_id": "0xb6a4d7da21443f5e816e8700eea87610e6d769657d6b8ec73028457bf2ca4036",
-    "common_ref": "0x703873635a6b51513451",
+    "common_ref": "0x6853675068394a6a7450",
     "timeout_gap": 20,
     "cycles_limit": 1000000,
     "cycles_price": 1,
     "interval": 3000,
     "verifier_list": [
         {
-            "bls_pub_key": "0x04188ef9488c19458a963cc57b567adde7db8f8b6bec392d5cb7b67b0abc1ed6cd966edc451f6ac2ef38079460eb965e890d1f576e4039a20467820237cda753f07a8b8febae1ec052190973a1bcf00690ea8fc0168b3fbbccd1c4e402eda5ef22",
-            "address": "0xf8389d774afdad8755ef8e629e5a154fddc6325a",
+            "bls_pub_key": "0x0401139331589f32220ec5f41f6faa0f5c3f4d36af011ab014cefd9d8f36b53b04a2031f681d1c9648a2a5d534d742931b0a5a4132da9ee752c1144d6396bed6cfc635c9687258cec9b60b387d35cf9e13f29091e11ae88024d74ca904c0ea3fb3",
+            "pub_key": "0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004",
+            "address": "0x76961e339fe2f1f931d84c425754806fb4174c34",
             "propose_weight": 1,
             "vote_weight": 1
         }

--- a/devtools/keypair/Cargo.toml
+++ b/devtools/keypair/Cargo.toml
@@ -20,4 +20,4 @@ protocol = { version = "0.1.0-alpha.1", package = "muta-protocol" }
 rand = "0.7"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-tentacle-secio = { version = "0.1", features = [ "flatc" ] }
+tentacle-secio = { version = "0.1", features = [ "molc" ] }

--- a/devtools/keypair/src/main.rs
+++ b/devtools/keypair/src/main.rs
@@ -21,6 +21,7 @@ struct Keypair {
     pub private_key:    String,
     pub public_key:     String,
     pub address:        String,
+    pub peer_id:        String,
     pub bls_public_key: String,
 }
 
@@ -70,10 +71,11 @@ pub fn main() {
         };
         let keypair = SecioKeyPair::secp256k1_raw_key(seckey.as_ref()).expect("secp256k1 keypair");
         let pubkey = keypair.to_public_key().inner();
-        let user_addr = Address::from_pubkey_bytes(pubkey.into()).expect("user addr");
+        let user_addr = Address::from_pubkey_bytes(pubkey.clone().into()).expect("user addr");
 
         k.private_key = add_0x(hex::encode(seckey.as_ref()));
-        k.public_key = add_0x(hex::encode(keypair.to_public_key().inner()));
+        k.public_key = add_0x(hex::encode(pubkey));
+        k.peer_id = keypair.to_public_key().peer_id().to_base58();
         k.address = add_0x(user_addr.as_hex());
 
         let priv_key =

--- a/examples/config-1.toml
+++ b/examples/config-1.toml
@@ -1,5 +1,5 @@
 data_path = "./devtools/chain/data/1"
-privkey = "0x592d6f62cd5c3464d4956ea585ec7007bcf5217eb89cc50bf14eea95f3b09706"
+privkey = "0x4a33067c449635c434cc758ed5f595e1f5653debc45233997c93814c31f710d5"
 
 [network]
 listening_address = "0.0.0.0:1337"

--- a/examples/config-2.toml
+++ b/examples/config-2.toml
@@ -1,12 +1,12 @@
 data_path = "./devtools/chain/data/2"
-privkey = "0x8b41630934fc7df92a016af88aae477bd173118fb72113f31db8a950230b029f"
+privkey = "0x86756d9074b984526f6780a46958b7b358565a7ef14aa4185854ee95b77b126c"
 
 [network]
 listening_address = "0.0.0.0:1338"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-pubkey = "0x02fa3a27712962a70e3e474363f38661f6a9e56f9cc91efd0d343713d51f3fa355"
+pubkey = "0x03080670d0160566c2afda5e0ae1a19300161a26e08b2ae954258504aa5b20e6ff"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/config-3.toml
+++ b/examples/config-3.toml
@@ -1,12 +1,12 @@
 data_path = "./devtools/chain/data/3"
-privkey = "0x28f53779b60e261ba68cdccefcc6a152136df8cb794e067ec76dc5a02c8f2ccf"
+privkey = "0x4dc6d3fe1181c2df13e41ff6e99233bfe1a58767d463759ab9ba1ce7d9f85b8d"
 
 [network]
 listening_address = "0.0.0.0:1339"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-pubkey = "0x02fa3a27712962a70e3e474363f38661f6a9e56f9cc91efd0d343713d51f3fa355"
+pubkey = "0x039395a060de0f8d4b23fc4c37509703d096d549361f756f07df29f9545f9f234f"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/config-4.toml
+++ b/examples/config-4.toml
@@ -1,12 +1,12 @@
 data_path = "./devtools/chain/data/4"
-privkey = "0x8e065679aa8b1185406c7514343073cd8c1695218925c9b2d5e98c3483d71d81"
+privkey = "0xd96f7e0fc7f73295dfb7d4d8edb621d7581456fb0eedde75b8a92ecb8cb84b98"
 
 [network]
 listening_address = "0.0.0.0:1340"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-pubkey = "0x02fa3a27712962a70e3e474363f38661f6a9e56f9cc91efd0d343713d51f3fa355"
+pubkey = "0x038aa869ca5e2f092a8b9de0c60c57adb0836d9ca277c0eccdae2833460f027106"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/genesis.toml
+++ b/examples/genesis.toml
@@ -18,33 +18,37 @@ name = "metadata"
 payload = '''
 {
     "chain_id": "0xb6a4d7da21443f5e816e8700eea87610e6d769657d6b8ec73028457bf2ca4036",
-    "common_ref": "0x7446645045376b553041",
+    "common_ref": "0x6853675068394a6a7450",
     "timeout_gap": 20,
     "cycles_limit": 999999999999,
     "cycles_price": 1,
     "interval": 3000,
     "verifier_list": [
         {
-            "bls_pub_key": "0x040386a8ac1cce6fd90c31effa628bc8513cbd625c752ca76ade6ff37b97edbdfb97d94caeddd261d9e2fd6b5456aecc100ea730ddee3c94f040a54152ded330a4e409f39bfbc34b286536790fef8bbaf734431679ba6a8d5d6994e557e82306df",
-            "address": "0x12d8baf8c4efb32a7983efac2d8535fe57deb756",
+            "bls_pub_key": "0x0401139331589f32220ec5f41f6faa0f5c3f4d36af011ab014cefd9d8f36b53b04a2031f681d1c9648a2a5d534d742931b0a5a4132da9ee752c1144d6396bed6cfc635c9687258cec9b60b387d35cf9e13f29091e11ae88024d74ca904c0ea3fb3",
+            "pub_key": "0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004",
+            "address": "0x76961e339fe2f1f931d84c425754806fb4174c34",
             "propose_weight": 1,
             "vote_weight": 1
         },
         {
-            "bls_pub_key": "0x040e7b00b59d37d4d735041ea1b69a55cd7fd80e920b5d70d85d051af6b847c3aec5b412b128f85ad8b4c6bac0561105a80fa8dd5f60cd42c3a2da0fd0b946fa3d761b1d21c569e0958b847da22dec14a132121027006df8c5d4ccf7caf8535f70",
-            "address": "0xa55e1261a73116c755291140e427caa0cbb5309e",
+            "bls_pub_key": "0x04070c98bb4b0974fe57be878d4dc1776c6f28250ecc8014101c4ff47baeabb6cb375ad5bca4b58e512d12f9d549ab472718c7ea57e8fd53de5141f79e4dd575fed85281e1e9cd3fc8a13ab787868fe804d833e5ee4c26eb5b1d01eedb2dc33e71",
+            "pub_key": "0x03080670d0160566c2afda5e0ae1a19300161a26e08b2ae954258504aa5b20e6ff",
+            "address": "0xaba7c0b7d5017f68232e515a2a60d609bb42439f",
             "propose_weight": 1,
             "vote_weight": 1
         },
         {
-            "bls_pub_key": "0x0413584a15f1dec552bb12233bf73a886ed49a3f56c68eda080743577005417635c9ac72a528a961a0e14a2df3a50a5c660641f446f629788486d7935d4ad4918035ce884a98bbaaa4c96307a2428729cba694329a693ce60c02e13b039c6a8978",
-            "address": "0x78ef0eff2fb9f569d86d75d22b69ea8407f6f092",
+            "bls_pub_key": "0x04093d17f53695ef66952e99c885a3375d586fee84f1270a75b961ca2109700c73328e77f0db68fdebd2f6cf06605226cb0836da2040c6a154935fcc8b73d71be816965645686333a80a9900055bfb7f66133473658e259c63687ef39c32a94844",
+            "pub_key": "0x039395a060de0f8d4b23fc4c37509703d096d549361f756f07df29f9545f9f234f",
+            "address": "0x24facaaa473b104112b99c193149acea72d986f4",
             "propose_weight": 1,
             "vote_weight": 1
         },
         {
-            "bls_pub_key": "0x041611b7da94a7fb7a8ff1c802bbf61da689f8d6f974d99466adeb1f47bcaff70470b6f279763abeb0cec5565abcfcb4ce13e79b8c310f0d1b26605b61ac2c04e0efcedbae18e763a86adb7a0e8ed0fcb1dc11fded12583972403815a7aa3dc300",
-            "address": "0x103252cad4e0380fe57a0c73f549f1ee2c9ea8e8",
+            "bls_pub_key": "0x040514607ef22ce9ea0e47496ac19104148e7b5f47acf74654c8e4798848cf426c7c65ea9c0dacd3a08155f249a6edf41a141a4bf5c4fcf3e2b0c8d7a6f6c5fc5c34c8e2601d466bb1c80aa9c7827ffab3d20039aa4bd39f107b691ebd6617bdcf",
+            "pub_key": "0x038aa869ca5e2f092a8b9de0c60c57adb0836d9ca277c0eccdae2833460f027106",
+            "address": "0xd3a26fd39c6d6abe2d0f9dbf2831cc389308c53b",
             "propose_weight": 1,
             "vote_weight": 1
         }

--- a/framework/src/binding/tests/sdk.rs
+++ b/framework/src/binding/tests/sdk.rs
@@ -197,6 +197,10 @@ pub fn mock_address() -> Address {
     Address::from_hash(hash).unwrap()
 }
 
+pub fn mock_pub_key(s: &'static str) -> Bytes {
+    Hash::digest(Bytes::from(s)).as_bytes()
+}
+
 pub fn mock_hash() -> Hash {
     Hash::digest(Bytes::from("mock"))
 }
@@ -277,9 +281,9 @@ pub fn mock_event() -> Event {
 // Mock Block
 // #####################
 
-pub fn mock_validator() -> Validator {
+pub fn mock_validator(s: &'static str) -> Validator {
     Validator {
-        address:        mock_address(),
+        pub_key:        mock_pub_key(s),
         propose_weight: 1,
         vote_weight:    1,
     }
@@ -312,10 +316,10 @@ pub fn mock_block_header() -> BlockHeader {
         proof:                          mock_proof(),
         validator_version:              1,
         validators:                     vec![
-            mock_validator(),
-            mock_validator(),
-            mock_validator(),
-            mock_validator(),
+            mock_validator("a"),
+            mock_validator("b"),
+            mock_validator("c"),
+            mock_validator("d"),
         ],
     }
 }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -27,6 +27,7 @@ cita_trie = "2.0"
 json = "0.12"
 byteorder = "1.3"
 muta-codec-derive = "0.2"
+bs58 = "0.3"
 
 [dev-dependencies]
 rayon = "1.3"

--- a/protocol/src/codec/block.rs
+++ b/protocol/src/codec/block.rs
@@ -94,8 +94,8 @@ pub struct Proof {
 
 #[derive(Clone, Message)]
 pub struct Validator {
-    #[prost(message, tag = "1")]
-    pub address: Option<Address>,
+    #[prost(bytes, tag = "1")]
+    pub pub_key: Vec<u8>,
 
     #[prost(uint32, tag = "2")]
     pub propose_weight: u32,
@@ -297,12 +297,10 @@ impl TryFrom<Proof> for block::Proof {
 
 impl From<block::Validator> for Validator {
     fn from(validator: block::Validator) -> Validator {
-        let address = Some(Address::from(validator.address));
-
         Validator {
-            address,
+            pub_key:        validator.pub_key.to_vec(),
             propose_weight: validator.propose_weight,
-            vote_weight: validator.vote_weight,
+            vote_weight:    validator.vote_weight,
         }
     }
 }
@@ -311,10 +309,8 @@ impl TryFrom<Validator> for block::Validator {
     type Error = ProtocolError;
 
     fn try_from(validator: Validator) -> Result<block::Validator, Self::Error> {
-        let address = field!(validator.address, "Validator", "address")?;
-
         let validator = block::Validator {
-            address:        protocol_primitive::Address::try_from(address)?,
+            pub_key:        Bytes::from(validator.pub_key),
             propose_weight: validator.propose_weight,
             vote_weight:    validator.vote_weight,
         };

--- a/protocol/src/fixed_codec/tests/mod.rs
+++ b/protocol/src/fixed_codec/tests/mod.rs
@@ -100,7 +100,7 @@ pub fn mock_sign_tx() -> SignedTransaction {
 
 pub fn mock_validator() -> Validator {
     Validator {
-        address:        mock_address(),
+        pub_key:        get_random_bytes(32),
         propose_weight: 1,
         vote_weight:    1,
     }

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -19,6 +19,7 @@ pub enum MessageTarget {
 #[derive(Debug, Clone)]
 pub struct NodeInfo {
     pub chain_id:     Hash,
+    pub self_pub_key: Bytes,
     pub self_address: Address,
 }
 
@@ -144,7 +145,7 @@ pub trait CommonConsensusAdapter: Send + Sync {
         vote_pubkeys: Vec<Hex>,
     ) -> ProtocolResult<()>;
 
-    fn verity_proof_weight(
+    fn verify_proof_weight(
         &self,
         ctx: Context,
         block_height: u64,

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -61,7 +61,7 @@ pub struct Proof {
 
 #[derive(RlpFixedCodec, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Validator {
-    pub address:        Address,
+    pub pub_key:        Bytes,
     pub propose_weight: u32,
     pub vote_weight:    u32,
 }

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -57,7 +57,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            address:        v.address.clone(),
+            pub_key:        v.pub_key.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -298,7 +298,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            address:        v.address.clone(),
+            pub_key:        v.pub_key.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -307,6 +307,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let node_info = NodeInfo {
         chain_id:     metadata.chain_id.clone(),
         self_address: my_address.clone(),
+        self_pub_key: my_pubkey.to_bytes(),
     };
     let current_header = &current_block.header;
     let block_hash = Hash::digest(current_block.header.encode_fixed()?);
@@ -345,7 +346,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
 
     let mut bls_pub_keys = HashMap::new();
     for validator_extend in metadata.verifier_list.iter() {
-        let address = validator_extend.address.as_bytes();
+        let address = validator_extend.pub_key.decode();
         let hex_pubkey = hex::decode(validator_extend.bls_pub_key.as_string_trim0x())
             .map_err(MainError::FromHex)?;
         let pub_key = BlsPublicKey::try_from(hex_pubkey.as_ref()).map_err(MainError::Crypto)?;
@@ -492,7 +493,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let authority_list = validators
         .iter()
         .map(|v| Node {
-            address:        v.address.as_bytes(),
+            address:        v.pub_key.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -10,11 +10,11 @@
     "prettier": "prettier --write **/*.{js,ts,graphql}"
   },
   "dependencies": {
-    "@mutadev/account": "0.2.0-dev+pr315.0",
-    "@mutadev/client": "0.2.0-dev+pr315.0",
-    "@mutadev/muta-sdk": "0.2.0-dev+pr315.0",
-    "@mutadev/service": "0.2.0-dev+pr315.0",
-    "@mutadev/utils": "0.2.0-dev+pr315.0",
+    "@mutadev/account": "0.2.0-pr348.0",
+    "@mutadev/client": "0.2.0-pr348.0",
+    "@mutadev/muta-sdk": "0.2.0-pr348.0",
+    "@mutadev/service": "0.2.0-pr348.0",
+    "@mutadev/utils": "0.2.0-pr348.0",
     "@types/node": "^14.0.14",
     "@types/node-fetch": "^2.5.7",
     "apollo-boost": "^0.4.4",

--- a/tests/e2e/sdk.test.ts
+++ b/tests/e2e/sdk.test.ts
@@ -1,10 +1,10 @@
-import { Account } from '@mutadev/account';
 import { AssetService } from '@mutadev/service'
-import { toHex } from '@mutadev/utils';
-import { retry } from '@mutadev/client';
 import * as sdk from '@mutadev/muta-sdk';
 import { mutaClient } from './utils';
 import { MultiSigService } from './multisig';
+
+const { Account, retry } = sdk;
+const { toHex } = sdk.utils;
 
 describe("API test via @mutadev/muta-sdk-js", () => {
   test("getLatestBlock", async () => {

--- a/tests/e2e/yarn.lock
+++ b/tests/e2e/yarn.lock
@@ -345,104 +345,104 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@mutadev/account@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/account/-/account-0.2.0-dev.tgz#3b8b26499305debf4b291ba06ea65296a815a3e7"
-  integrity sha512-iwSeQ4dK7NjIN07S5gkN2fgeu6w2UxJNRItezQ55mm66Lxu21bR33k4Kqr/YKo/34D+JX1UPdhtyzolbPFVCDA==
+"@mutadev/account@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/account/-/account-0.2.0-pr348.0.tgz#2baea03a8829765c9d31e5f073052e61ed7c30fd"
+  integrity sha512-4eMMDb9LulFguzJ9TQowfh7gEEztxJCv5HpcsJhZV+ncdhWG3QxfnEjyCJvAOBNYIC9BK6pvLfd/VfzRZLfhiA==
   dependencies:
-    "@mutadev/defaults" "0.2.0-dev+pr315.0"
-    "@mutadev/utils" "0.2.0-dev+pr315.0"
+    "@mutadev/defaults" "0.2.0-pr348.0"
+    "@mutadev/utils" "0.2.0-pr348.0"
 
-"@mutadev/client-raw@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/client-raw/-/client-raw-0.2.0-dev.tgz#d7b66689f43f6f875c54bda75b073ee4876ac4f1"
-  integrity sha512-cWQbqwzAAJIONIRLwW5oVs5Zdy+QjpIDV1EYLqRDyeulbHItMb+Cc9S0aOD0iD/fGpfz9h8BmyX+8RWYV4AVUg==
+"@mutadev/client-raw@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/client-raw/-/client-raw-0.2.0-pr348.0.tgz#f3fb184f48aeb75c64d95d7349648c8ae6d34458"
+  integrity sha512-6Y+XQfN8SVaV+AF7yYz/m5Z3M6EYNOf+YcGJjNWC/FByRcsW8IltFvgj1UiW4z0xWgiavNAh+v+rHgmqjDC+LA==
   dependencies:
     graphql-request "^1.8.2"
     graphql-tag "^2.10.1"
 
-"@mutadev/client@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/client/-/client-0.2.0-dev.tgz#ba1562b6298fffb4fdbf52e1ba85606073a736cb"
-  integrity sha512-NL0XKxcmuCaTr8XUl2oam37fV08go6SNpEOvJP+yvOfxp00kZ4Sqv1P/r/ZNJo+tRwfbk81QHl3tJ9ZZURPF5A==
+"@mutadev/client@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/client/-/client-0.2.0-pr348.0.tgz#4aab4a87f2262cb0e8540c98b7ab5d31feccb98a"
+  integrity sha512-yXs3f6/QXsaj1BB8DU0iVQbdAW2nzQOPfwzgfIwie3dXd+a3PVnV6rPwR1fu+JatN5vXELbQGAVNj6XU8Rob2A==
   dependencies:
-    "@mutadev/client-raw" "0.2.0-dev+pr315.0"
-    "@mutadev/defaults" "0.2.0-dev+pr315.0"
-    "@mutadev/shared" "0.2.0-dev+pr315.0"
-    "@mutadev/types" "0.2.0-dev+pr315.0"
-    "@mutadev/utils" "0.2.0-dev+pr315.0"
+    "@mutadev/client-raw" "0.2.0-pr348.0"
+    "@mutadev/defaults" "0.2.0-pr348.0"
+    "@mutadev/shared" "0.2.0-pr348.0"
+    "@mutadev/types" "0.2.0-pr348.0"
+    "@mutadev/utils" "0.2.0-pr348.0"
     "@types/lodash" "^4.14.149"
     invariant "^2.2.4"
     lodash "^4.17.15"
     p-limit "^2.3.0"
     utility-types "^3.10.0"
 
-"@mutadev/defaults@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/defaults/-/defaults-0.2.0-dev.tgz#549e1504a12c4a9c7a4a6a76dcd6db79059a6805"
-  integrity sha512-wZgPUmknBOq0po7TZZKtHREYLXJvjokUoPFcdcqO0loLE2mNoFUm5VSBtUBNLh3nt1hm/m14uliTFUhp3+M/Mw==
+"@mutadev/defaults@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/defaults/-/defaults-0.2.0-pr348.0.tgz#d9c566b15c21d3fcce0bb5956be0e460a5c9dce7"
+  integrity sha512-pUMVWtfw3PH3Ymmw6X1Q1mi47Y1n0fAx1CxwirVwhMhWmey9dbaFvGEdbd81zEQkj4pya8AUPPG2QYlq2gOIIg==
 
-"@mutadev/muta-sdk@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/muta-sdk/-/muta-sdk-0.2.0-dev.tgz#b2f57a3f8a61b96c01edc32de14001ee98a753e7"
-  integrity sha512-+iQ0WO80VYlGg+sIvzwX4KDtvvsbhgedEMjVTq96iaY+AmfV/SEZiFT691cHP3MA7lRvjkKK0ZxnxGbcjsZr5w==
+"@mutadev/muta-sdk@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/muta-sdk/-/muta-sdk-0.2.0-pr348.0.tgz#38cb52f2d35ef0cff690c3eba1b677671bab2e9b"
+  integrity sha512-xBVS4Cl4K93cwMk3B6xfO1UhP4KERtt3CMBDxwOE9OQuMLT5yzzmEaM+h0OvWtQG53oaiC5MHYaNr2fRYd57Og==
   dependencies:
-    "@mutadev/account" "0.2.0-dev+pr315.0"
-    "@mutadev/client" "0.2.0-dev+pr315.0"
-    "@mutadev/defaults" "0.2.0-dev+pr315.0"
-    "@mutadev/shared" "0.2.0-dev+pr315.0"
-    "@mutadev/types" "0.2.0-dev+pr315.0"
-    "@mutadev/wallet" "0.2.0-dev+pr315.0"
+    "@mutadev/account" "0.2.0-pr348.0"
+    "@mutadev/client" "0.2.0-pr348.0"
+    "@mutadev/defaults" "0.2.0-pr348.0"
+    "@mutadev/shared" "0.2.0-pr348.0"
+    "@mutadev/types" "0.2.0-pr348.0"
+    "@mutadev/wallet" "0.2.0-pr348.0"
     utility-types "^3.10.0"
 
-"@mutadev/service@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/service/-/service-0.2.0-dev.tgz#84e88ec1aa35be5a7defb4b391608b52f125c7f1"
-  integrity sha512-5C/dbM1OWFDpgQJrO1xUW+Eb3AHu1Q10o3IC05pZpPaZCP3iu3kdwrZ5ZQORLT72epEcUoFsoc8RWE+b2rGcbA==
+"@mutadev/service@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/service/-/service-0.2.0-pr348.0.tgz#952fc80122ce9edfcdf1a22b91c3da881e0a23a0"
+  integrity sha512-teqP9aWtKCR9vEsuJABV5hxQyM8KPHMNTGjENQAbI7XIx/kNl3xR/csds+3VsFVDu1A74zK09RE81ei/eKjDkA==
   dependencies:
-    "@mutadev/account" "0.2.0-dev+pr315.0"
-    "@mutadev/client" "0.2.0-dev+pr315.0"
-    "@mutadev/shared" "0.2.0-dev+pr315.0"
-    "@mutadev/types" "0.2.0-dev+pr315.0"
-    "@mutadev/utils" "0.2.0-dev+pr315.0"
+    "@mutadev/account" "0.2.0-pr348.0"
+    "@mutadev/client" "0.2.0-pr348.0"
+    "@mutadev/shared" "0.2.0-pr348.0"
+    "@mutadev/types" "0.2.0-pr348.0"
+    "@mutadev/utils" "0.2.0-pr348.0"
     lodash "^4.17.15"
     utility-types "^3.10.0"
 
-"@mutadev/shared@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/shared/-/shared-0.2.0-dev.tgz#ef7177c0755d6b9bdd9ff2e897784dcf2dce7fcc"
-  integrity sha512-IuZoX6mPrddiPWETAe5utrDMJ4QAOY6/v6G+m7WX3oPzYZ/Loey+1D+ZCb2XLKjcmkYJ7l4RUwIq+DnxmPsHlA==
+"@mutadev/shared@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/shared/-/shared-0.2.0-pr348.0.tgz#9edf60a6308a845bb9d4938bc665b178ba9f3320"
+  integrity sha512-UP8jjqjfb+yU6qIVCThn3zVIksZPeb12yNmkWeD3+pqZGVUbzgro7X1j10m2D4mccPyr+A8Vl0xqzNf1O7V+MA==
   dependencies:
     "@types/invariant" "^2.2.4"
     bignumber.js "^9.0.0"
     invariant "^2.2.4"
 
-"@mutadev/types@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/types/-/types-0.2.0-dev.tgz#9342877bdf78ae9a86a30f0798242ca47039c1cf"
-  integrity sha512-FVEW4Hy5OBa7r+06grARAjJvvkR/wXiS+YeJrjWA/NDsUqwmZ1nOcHMrD9ulUZq1sEJQsDElvjo9ZeTFFwz0Xw==
+"@mutadev/types@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/types/-/types-0.2.0-pr348.0.tgz#6a442135ab55a877fac50f3e37e7c4d96dbd1f48"
+  integrity sha512-R210g63pjRbJFqexnA48aIuTVCOlIZm41Mtncm4PYbT28mw4LbHpzmQF7HPkBboRT5FpLGelg2P71tTLBZjp5w==
   dependencies:
     bignumber.js "^9.0.0"
 
-"@mutadev/utils@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/utils/-/utils-0.2.0-dev.tgz#9a89ca196a654cd194f251fa0b67ab0dfdf4484b"
-  integrity sha512-xY7K3Vz7mCporHA5hvsyoJOF0nOHRGUQ3UF70TlIkzQ4C4tPBSuIapDLZu8+tZfEPLxRIa/dYNd/tJMnIV4zhQ==
+"@mutadev/utils@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/utils/-/utils-0.2.0-pr348.0.tgz#405899f3d9f66205b8b8c8540a18453a63381961"
+  integrity sha512-zEspWMVy5FJMaXGlcrxfOX+IzHZvqZw7DrTUttSlJpXOmxNwpExT0QPPruLoZbnZTF17gOZkW+tlMEtRUkZ8gQ==
   dependencies:
-    "@mutadev/types" "0.2.0-dev+pr315.0"
+    "@mutadev/types" "0.2.0-pr348.0"
     json-bigint "^0.3.0"
     keccak "^3.0.0"
     randombytes "^2.1.0"
     rlp "^2.2.5"
     secp256k1 "^4.0.0"
 
-"@mutadev/wallet@0.2.0-dev+pr315.0":
-  version "0.2.0-dev"
-  resolved "https://registry.yarnpkg.com/@mutadev/wallet/-/wallet-0.2.0-dev.tgz#3fddedbef9db7d144d39d635c41b8f39de6bb957"
-  integrity sha512-/6m2nPfz/GhVPg9EeKz/LrHVvoGQREjrFCYXZ5N2fCa9J08W8oNy4CcTynZpaDnekt22veBCHDeG0GTs61R3lg==
+"@mutadev/wallet@0.2.0-pr348.0":
+  version "0.2.0-pr348.0"
+  resolved "https://registry.yarnpkg.com/@mutadev/wallet/-/wallet-0.2.0-pr348.0.tgz#a0f6d00bd8460670ccbe0ebfa696e3e68b71da2d"
+  integrity sha512-5W1nfqDyEu/ETNyoEZbEA/X4FJ9HnBJFAK2QMxfsjZYiAmLZcgHJ8xwNTtUwxjsi5L7XF4UAYm56nZtYTNbyoQ==
   dependencies:
-    "@mutadev/account" "0.2.0-dev+pr315.0"
-    "@mutadev/utils" "0.2.0-dev+pr315.0"
+    "@mutadev/account" "0.2.0-pr348.0"
+    "@mutadev/utils" "0.2.0-pr348.0"
     bip39 "^3.0.2"
     hdkey "^1.1.1"
 

--- a/tests/trust_metric_all/node/full_node/default_start.rs
+++ b/tests/trust_metric_all/node/full_node/default_start.rs
@@ -56,7 +56,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            address:        v.address.clone(),
+            pub_key:        v.pub_key.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -275,7 +275,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         .verifier_list
         .iter()
         .map(|v| Validator {
-            address:        v.address.clone(),
+            pub_key:        v.pub_key.decode(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })
@@ -284,6 +284,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let node_info = NodeInfo {
         chain_id:     metadata.chain_id.clone(),
         self_address: my_address.clone(),
+        self_pub_key: my_pubkey.to_bytes(),
     };
     let current_header = &current_block.header;
     let block_hash = Hash::digest(current_block.header.encode_fixed()?);
@@ -317,7 +318,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
 
     let mut bls_pub_keys = HashMap::new();
     for validator_extend in metadata.verifier_list.iter() {
-        let address = validator_extend.address.as_bytes();
+        let address = validator_extend.pub_key.decode();
         let hex_pubkey = hex::decode(validator_extend.bls_pub_key.as_string_trim0x())
             .map_err(MainError::FromHex)?;
         let pub_key = BlsPublicKey::try_from(hex_pubkey.as_ref()).map_err(MainError::Crypto)?;
@@ -465,7 +466,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let authority_list = validators
         .iter()
         .map(|v| Node {
-            address:        v.address.as_bytes(),
+            address:        v.pub_key.clone(),
             propose_weight: v.propose_weight,
             vote_weight:    v.vote_weight,
         })


### PR DESCRIPTION
BREAKING CHANGE:
- replace Validator address bytes with pubkey bytes

<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
change

**What this PR does / why we need it**:
Replace ```Validator``` address bytes with public key bytes. Network now maintain two states, one use ```Address```, one use ```PeerId```. This change will remove ```Address``` completely from network.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
