### PR TITLE
refactor(network)!: remove Address code, use PeerId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ rand = "0.7"
 cita_trie = "2.0"
 core-network = { path = "./core/network", features = ["diagnostic"] }
 tokio = { version = "0.2", features = ["full"] }
-bs58 = "0.3"
 
 [workspace]
 members = [

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -113,7 +113,7 @@ where
 
             MessageTarget::Specified(addr) => {
                 self.network
-                    .users_cast(ctx, end, vec![addr], msg, Priority::High)
+                    .multicast(ctx, end, vec![addr], msg, Priority::High)
                     .await
             }
         }

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -14,6 +14,8 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 use common_apm::muta_apm;
 use common_merkle::Merkle;
 
+use core_network::{PeerId, PeerIdExt};
+
 use protocol::traits::{
     CommonConsensusAdapter, ConsensusAdapter, Context, ExecutorFactory, ExecutorParams,
     ExecutorResp, Gossip, MemPool, MessageTarget, MixedTxHashes, PeerTrust, Priority, Rpc,
@@ -111,9 +113,11 @@ where
                     .await
             }
 
-            MessageTarget::Specified(addr) => {
+            MessageTarget::Specified(pub_key) => {
+                let peer_id_bytes = PeerId::from_pubkey_bytes(pub_key)?.into_bytes_ext();
+
                 self.network
-                    .multicast(ctx, end, vec![addr], msg, Priority::High)
+                    .multicast(ctx, end, [peer_id_bytes], msg, Priority::High)
                     .await
             }
         }

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -462,7 +462,8 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
         pub_key: Bytes,
         msg: OverlordMsg<FixedPill>,
     ) -> Result<(), Box<dyn Error + Send>> {
-        let address = Address::from_pubkey_bytes(pub_key)?;
+        let peer_id =
+            Bytes::from(core_network::peer_id_from_pubkey_bytes(pub_key.clone())?.into_bytes());
 
         match msg {
             OverlordMsg::SignedVote(sv) => {
@@ -472,7 +473,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_SIGNED_VOTE,
-                        MessageTarget::Specified(address),
+                        MessageTarget::Specified(peer_id),
                     )
                     .await?;
             }
@@ -483,7 +484,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_AGGREGATED_VOTE,
-                        MessageTarget::Specified(address),
+                        MessageTarget::Specified(peer_id),
                     )
                     .await?;
             }

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -462,9 +462,6 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
         pub_key: Bytes,
         msg: OverlordMsg<FixedPill>,
     ) -> Result<(), Box<dyn Error + Send>> {
-        let peer_id =
-            Bytes::from(core_network::peer_id_from_pubkey_bytes(pub_key.clone())?.into_bytes());
-
         match msg {
             OverlordMsg::SignedVote(sv) => {
                 let msg = sv.rlp_bytes();
@@ -473,7 +470,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_SIGNED_VOTE,
-                        MessageTarget::Specified(peer_id),
+                        MessageTarget::Specified(pub_key),
                     )
                     .await?;
             }
@@ -484,7 +481,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                         ctx,
                         msg,
                         END_GOSSIP_AGGREGATED_VOTE,
-                        MessageTarget::Specified(peer_id),
+                        MessageTarget::Specified(pub_key),
                     )
                     .await?;
             }

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -572,16 +572,17 @@ mod tests {
             Ok(())
         }
 
-        async fn multicast<M>(
+        async fn multicast<'a, M, P>(
             &self,
             _: Context,
             _: &str,
-            _: Vec<Bytes>,
+            _: P,
             _: M,
             _: Priority,
         ) -> ProtocolResult<()>
         where
             M: MessageCodec,
+            P: AsRef<[Bytes]> + Send + 'a,
         {
             unreachable!()
         }

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -519,7 +519,6 @@ mod tests {
 
     use protocol::{
         traits::{Context, Gossip, MessageCodec, Priority},
-        types::Address,
         Bytes, ProtocolResult,
     };
 
@@ -573,11 +572,11 @@ mod tests {
             Ok(())
         }
 
-        async fn users_cast<M>(
+        async fn multicast<M>(
             &self,
             _: Context,
             _: &str,
-            _: Vec<Address>,
+            _: Vec<Bytes>,
             _: M,
             _: Priority,
         ) -> ProtocolResult<()>

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -32,7 +32,6 @@ tentacle-identify = { git = "https://github.com/zeroqn/p2p", branch = "v0.3.0.al
 tokio = { version = "0.2", features = ["macros", "rt-core"]}
 hostname = "0.3"
 lazy_static = "1.4"
-bs58 = "0.3"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -32,6 +32,7 @@ tentacle-identify = { git = "https://github.com/zeroqn/p2p", branch = "v0.3.0.al
 tokio = { version = "0.2", features = ["macros", "rt-core"]}
 hostname = "0.3"
 lazy_static = "1.4"
+bs58 = "0.3"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/core/network/src/common.rs
+++ b/core/network/src/common.rs
@@ -1,13 +1,12 @@
-use crate::{error::NetworkError, traits::MultiaddrExt};
+use crate::traits::MultiaddrExt;
 
 use derive_more::Display;
 use futures::{pin_mut, task::AtomicWaker};
 use futures_timer::Delay;
-use protocol::Bytes;
 use serde_derive::{Deserialize, Serialize};
 use tentacle::{
     multiaddr::{Multiaddr, Protocol},
-    secio::{PeerId, PublicKey},
+    secio::PeerId,
 };
 
 use std::{
@@ -43,17 +42,6 @@ macro_rules! service_ready {
             }
         }
     };
-}
-
-pub fn peer_id_from_bytes(bytes: Bytes) -> Result<PeerId, NetworkError> {
-    PeerId::from_bytes(bytes.to_vec()).map_err(|_| NetworkError::InvalidPeerId)
-}
-
-pub fn peer_id_from_pubkey_bytes(bytes: Bytes) -> Result<PeerId, NetworkError> {
-    let pubkey =
-        PublicKey::secp256k1_raw_key(&bytes).map_err(|_| NetworkError::InvalidPublicKey)?;
-
-    Ok(PeerId::from_public_key(&pubkey))
 }
 
 pub fn socket_to_multi_addr(socket_addr: SocketAddr) -> Multiaddr {

--- a/core/network/src/common.rs
+++ b/core/network/src/common.rs
@@ -1,3 +1,15 @@
+use crate::{error::NetworkError, traits::MultiaddrExt};
+
+use derive_more::Display;
+use futures::{pin_mut, task::AtomicWaker};
+use futures_timer::Delay;
+use protocol::Bytes;
+use serde_derive::{Deserialize, Serialize};
+use tentacle::{
+    multiaddr::{Multiaddr, Protocol},
+    secio::{PeerId, PublicKey},
+};
+
 use std::{
     borrow::Cow,
     future::Future,
@@ -9,17 +21,6 @@ use std::{
     time::{Duration, Instant},
     vec::IntoIter,
 };
-
-use derive_more::Display;
-use futures::{pin_mut, task::AtomicWaker};
-use futures_timer::Delay;
-use serde_derive::{Deserialize, Serialize};
-use tentacle::{
-    multiaddr::{Multiaddr, Protocol},
-    secio::PeerId,
-};
-
-use crate::traits::MultiaddrExt;
 
 #[macro_export]
 macro_rules! loop_ready {
@@ -42,6 +43,17 @@ macro_rules! service_ready {
             }
         }
     };
+}
+
+pub fn peer_id_from_bytes(bytes: Bytes) -> Result<PeerId, NetworkError> {
+    PeerId::from_bytes(bytes.to_vec()).map_err(|_| NetworkError::InvalidPeerId)
+}
+
+pub fn peer_id_from_pubkey_bytes(bytes: Bytes) -> Result<PeerId, NetworkError> {
+    let pubkey =
+        PublicKey::secp256k1_raw_key(&bytes).map_err(|_| NetworkError::InvalidPublicKey)?;
+
+    Ok(PeerId::from_public_key(&pubkey))
 }
 
 pub fn socket_to_multi_addr(socket_addr: SocketAddr) -> Multiaddr {

--- a/core/network/src/error.rs
+++ b/core/network/src/error.rs
@@ -95,14 +95,12 @@ pub enum NetworkError {
     },
 
     #[display(
-        fmt = "send incompletely, unconnected {:?} unknown {:?}, other {:?}",
+        fmt = "send incompletely, unconnected {:?}, other {:?}",
         unconnected,
-        unknown,
         other
     )]
-    UserSend {
-        unconnected: Option<Vec<Address>>,
-        unknown:     Option<Vec<Address>>,
+    MultiCast {
+        unconnected: Option<Vec<PeerId>>,
         other:       Option<Box<dyn Error + Send>>,
     },
 
@@ -117,6 +115,9 @@ pub enum NetworkError {
 
     #[display(fmt = "cannot decode private key bytes")]
     InvalidPrivateKey,
+
+    #[display(fmt = "cannot decode peer id")]
+    InvalidPeerId,
 
     #[display(fmt = "unsupported peer address {}", _0)]
     UnexpectedPeerAddr(String),
@@ -181,6 +182,12 @@ impl From<std::io::Error> for NetworkError {
 impl From<tentacle::error::TransportErrorKind> for NetworkError {
     fn from(err: tentacle::error::TransportErrorKind) -> NetworkError {
         NetworkError::Transport(err)
+    }
+}
+
+impl From<NetworkError> for Box<dyn Error + Send> {
+    fn from(err: NetworkError) -> Box<dyn Error + Send> {
+        err.boxed()
     }
 }
 

--- a/core/network/src/event.rs
+++ b/core/network/src/event.rs
@@ -170,6 +170,8 @@ pub enum PeerManagerEvent {
         feedback: TrustFeedback,
     },
 
+    // FIXME: Reomve Whitelist
+    #[allow(dead_code)]
     #[display(fmt = "whitelist peers by chain addresses {:?}", chain_addrs)]
     WhitelistPeersByChainAddr { chain_addrs: Vec<Address> },
 

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -26,5 +26,39 @@ pub use service::{NetworkService, NetworkServiceHandle};
 #[cfg(feature = "diagnostic")]
 pub use peer_manager::diagnostic::{DiagnosticEvent, TrustReport};
 
-pub use common::peer_id_from_pubkey_bytes;
 pub use tentacle::secio::PeerId;
+
+use error::NetworkError;
+use protocol::Bytes;
+use tentacle::secio::PublicKey;
+
+pub trait PeerIdExt {
+    fn from_pubkey_bytes<'a, B: AsRef<[u8]> + 'a>(bytes: B) -> Result<PeerId, NetworkError> {
+        let pubkey = PublicKey::secp256k1_raw_key(bytes.as_ref())
+            .map_err(|_| NetworkError::InvalidPublicKey)?;
+
+        Ok(PeerId::from_public_key(&pubkey))
+    }
+
+    fn from_bytes<'a, B: AsRef<[u8]> + 'a>(bytes: B) -> Result<PeerId, NetworkError> {
+        PeerId::from_bytes(bytes.as_ref().to_vec()).map_err(|_| NetworkError::InvalidPeerId)
+    }
+
+    fn to_string(&self) -> String;
+
+    fn into_bytes_ext(self) -> Bytes;
+
+    fn from_str_ext<'a, S: AsRef<str> + 'a>(s: S) -> Result<PeerId, NetworkError> {
+        s.as_ref().parse().map_err(|_| NetworkError::InvalidPeerId)
+    }
+}
+
+impl PeerIdExt for PeerId {
+    fn into_bytes_ext(self) -> Bytes {
+        Bytes::from(self.into_bytes())
+    }
+
+    fn to_string(&self) -> String {
+        self.to_base58()
+    }
+}

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -25,3 +25,6 @@ pub use service::{NetworkService, NetworkServiceHandle};
 
 #[cfg(feature = "diagnostic")]
 pub use peer_manager::diagnostic::{DiagnosticEvent, TrustReport};
+
+pub use common::peer_id_from_pubkey_bytes;
+pub use tentacle::secio::PeerId;

--- a/core/network/src/peer_manager/diagnostic.rs
+++ b/core/network/src/peer_manager/diagnostic.rs
@@ -2,8 +2,8 @@ use super::{Inner, WORSE_TRUST_SCALAR_RATIO};
 use crate::event::PeerManagerEvent;
 
 use derive_more::Display;
-use protocol::{traits::TrustFeedback, types::Address};
-use tentacle::SessionId;
+use protocol::traits::TrustFeedback;
+use tentacle::{secio::PeerId, SessionId};
 
 use std::sync::Arc;
 
@@ -70,10 +70,8 @@ impl Diagnostic {
         Diagnostic(inner)
     }
 
-    pub fn session_by_chain(&self, addr: &Address) -> Option<SessionId> {
-        let chain = self.0.chain.read();
-
-        match chain.get(addr).map(|peer| peer.session_id()) {
+    pub fn session(&self, peer_id: &PeerId) -> Option<SessionId> {
+        match self.0.peer(peer_id).map(|p| p.session_id()) {
             Some(sid) if sid != SessionId::new(0) => Some(sid),
             _ => None,
         }

--- a/core/network/src/peer_manager/shared.rs
+++ b/core/network/src/peer_manager/shared.rs
@@ -73,37 +73,20 @@ impl SessionBook for SharedSessions {
         }
     }
 
-    fn by_chain(&self, addrs: Vec<Address>) -> (Vec<SessionId>, Vec<Address>) {
-        let chain = self.inner.chain.read();
-
+    fn peers(&self, pids: Vec<PeerId>) -> (Vec<SessionId>, Vec<PeerId>) {
         let mut connected = Vec::new();
         let mut unconnected = Vec::new();
-        for addr in addrs {
-            match chain.get(&addr) {
+
+        for peer_id in pids {
+            match self.inner.peer(&peer_id) {
                 Some(peer) if peer.connectedness() == Connectedness::Connected => {
-                    connected.push(peer.session_id());
+                    connected.push(peer.session_id())
                 }
-                _ => unconnected.push(addr),
+                _ => unconnected.push(peer_id),
             }
         }
 
         (connected, unconnected)
-    }
-
-    fn peers_by_chain(&self, addrs: Vec<Address>) -> (Vec<PeerId>, Vec<Address>) {
-        let chain = self.inner.chain.read();
-
-        let mut peers = Vec::new();
-        let mut unknown = Vec::new();
-        for addr in addrs {
-            if let Some(peer) = chain.get(&addr) {
-                peers.push(peer.owned_id());
-            } else {
-                unknown.push(addr);
-            }
-        }
-
-        (peers, unknown)
     }
 
     fn all(&self) -> Vec<SessionId> {
@@ -138,14 +121,14 @@ impl SessionBook for SharedSessions {
 #[cfg(test)]
 mod tests {
     use super::{SessionBook, SharedSessions, SharedSessionsConfig};
-    use crate::peer_manager::{Inner, Peer};
+    use crate::peer_manager::Inner;
 
     use tentacle::secio::SecioKeyPair;
 
     use std::sync::Arc;
 
     #[test]
-    fn should_push_not_found_chain_addr_to_unconneded_on_by_chain() {
+    fn should_return_unconnected_peer_ids() {
         let sess_conf = SharedSessionsConfig {
             max_stream_window_size: 10,
             write_timeout:          10,
@@ -156,17 +139,10 @@ mod tests {
 
         let keypair = SecioKeyPair::secp256k1_generated();
         let pubkey = keypair.public_key();
-        let chain_addr = Peer::pubkey_to_chain_addr(&pubkey).expect("chain addr");
+        let peer_id = pubkey.peer_id();
+        assert!(inner.peer(&peer_id).is_none(), "should not be registered");
 
-        assert!(
-            inner.peer_by_chain(&chain_addr).is_none(),
-            "should not be registered"
-        );
-
-        let (_, unconnected) = sessions.by_chain(vec![chain_addr.clone()]);
-        assert!(
-            unconnected.contains(&chain_addr),
-            "should be inserted to unconnected"
-        );
+        let (_, unconnected) = sessions.peers(vec![peer_id.clone()]);
+        assert!(unconnected.contains(&peer_id));
     }
 }

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -66,16 +66,17 @@ impl Gossip for NetworkServiceHandle {
         self.gossip.broadcast(cx, end, msg, p).await
     }
 
-    async fn multicast<M>(
+    async fn multicast<'a, M, P>(
         &self,
         cx: Context,
         end: &str,
-        peer_ids: Vec<Bytes>,
+        peer_ids: P,
         msg: M,
         p: Priority,
     ) -> ProtocolResult<()>
     where
         M: MessageCodec,
+        P: AsRef<[Bytes]> + Send + 'a,
     {
         self.gossip.multicast(cx, end, peer_ids, msg, p).await
     }

--- a/core/network/src/traits.rs
+++ b/core/network/src/traits.rs
@@ -31,7 +31,7 @@ pub trait NetworkProtocol {
 #[async_trait]
 pub trait MessageSender {
     fn send(&self, tar: TargetSession, msg: Bytes, pri: Priority) -> Result<(), NetworkError>;
-    async fn users_send(&self, users: Vec<Address>, msg: Bytes, pri: Priority) -> Result<(), NetworkError>;
+    async fn multisend(&self, peers: Vec<PeerId>, msg: Bytes, pri: Priority) -> Result<(), NetworkError>;
 }
 
 pub trait Compression {
@@ -61,8 +61,7 @@ pub trait SessionBook {
     fn all_sendable(&self) -> Vec<SessionId>;
     fn all_blocked(&self) -> Vec<SessionId>;
     fn refresh_blocked(&self);
-    fn by_chain(&self, addrs: Vec<Address>) -> (Vec<SessionId>, Vec<Address>);
-    fn peers_by_chain(&self, addrs: Vec<Address>) -> (Vec<PeerId>, Vec<Address>);
+    fn peers(&self, pids: Vec<PeerId>) -> (Vec<SessionId>, Vec<PeerId>);
     fn all(&self) -> Vec<SessionId>;
     fn connected_addr(&self, sid: SessionId) -> Option<ConnectedAddr>;
     fn pending_data_size(&self, sid: SessionId) -> usize;

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -20,7 +20,7 @@ rpc_timeout = 10
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
-pubkey = "0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004"
+peer_id = "QmeG2AjWkLbK5ThySV7TrX5KuFryPsaM8GBgDs6Ch1Z5xJ"
 address = "0.0.0.0:1888"
 
 [mempool]

--- a/examples/config-2.toml
+++ b/examples/config-2.toml
@@ -6,7 +6,7 @@ listening_address = "0.0.0.0:1338"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-pubkey = "0x03080670d0160566c2afda5e0ae1a19300161a26e08b2ae954258504aa5b20e6ff"
+peer_id = "QmeG2AjWkLbK5ThySV7TrX5KuFryPsaM8GBgDs6Ch1Z5xJ"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/config-3.toml
+++ b/examples/config-3.toml
@@ -6,7 +6,7 @@ listening_address = "0.0.0.0:1339"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-pubkey = "0x039395a060de0f8d4b23fc4c37509703d096d549361f756f07df29f9545f9f234f"
+peer_id = "QmeG2AjWkLbK5ThySV7TrX5KuFryPsaM8GBgDs6Ch1Z5xJ"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/examples/config-4.toml
+++ b/examples/config-4.toml
@@ -6,7 +6,7 @@ listening_address = "0.0.0.0:1340"
 rpc_timeout = 10
 
 [[network.bootstraps]]
-pubkey = "0x038aa869ca5e2f092a8b9de0c60c57adb0836d9ca277c0eccdae2833460f027106"
+peer_id = "QmeG2AjWkLbK5ThySV7TrX5KuFryPsaM8GBgDs6Ch1Z5xJ"
 address = "localhost:1337" # Replace it with your IP
 
 [graphql]

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -27,7 +27,6 @@ cita_trie = "2.0"
 json = "0.12"
 byteorder = "1.3"
 muta-codec-derive = "0.2"
-bs58 = "0.3"
 
 [dev-dependencies]
 rayon = "1.3"

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -13,7 +13,7 @@ use crate::{traits::mempool::MixedTxHashes, ProtocolResult};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MessageTarget {
     Broadcast,
-    Specified(Address),
+    Specified(Bytes),
 }
 
 #[derive(Debug, Clone)]

--- a/protocol/src/traits/network.rs
+++ b/protocol/src/traits/network.rs
@@ -68,16 +68,17 @@ pub trait Gossip: Send + Sync {
     where
         M: MessageCodec;
 
-    async fn multicast<M>(
+    async fn multicast<'a, M, P>(
         &self,
         cx: Context,
         end: &str,
-        peer_ids: Vec<Bytes>,
+        peer_ids: P,
         msg: M,
         p: Priority,
     ) -> ProtocolResult<()>
     where
-        M: MessageCodec;
+        M: MessageCodec,
+        P: AsRef<[Bytes]> + Send + 'a;
 }
 
 #[async_trait]

--- a/protocol/src/traits/network.rs
+++ b/protocol/src/traits/network.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
-use crate::{traits::Context, types::Address, ProtocolError, ProtocolErrorKind, ProtocolResult};
+use crate::{traits::Context, ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 #[derive(Debug)]
 pub enum Priority {
@@ -68,11 +68,11 @@ pub trait Gossip: Send + Sync {
     where
         M: MessageCodec;
 
-    async fn users_cast<M>(
+    async fn multicast<M>(
         &self,
         cx: Context,
         end: &str,
-        users: Vec<Address>,
+        peer_ids: Vec<Bytes>,
         msg: M,
         p: Priority,
     ) -> ProtocolResult<()>

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,7 @@ pub struct ConfigNetwork {
 
 #[derive(Debug, Deserialize)]
 pub struct ConfigNetworkBootstrap {
-    pub pubkey:  Hex,
+    pub peer_id: String,
     pub address: String,
 }
 

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -181,10 +181,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let mut bootstrap_pairs = vec![];
     if let Some(bootstrap) = &config.network.bootstraps {
         for bootstrap in bootstrap.iter() {
-            bootstrap_pairs.push((
-                bootstrap.pubkey.as_string_trim0x(),
-                bootstrap.address.to_owned(),
-            ));
+            bootstrap_pairs.push((bootstrap.peer_id.to_owned(), bootstrap.address.to_owned()));
         }
     }
 

--- a/tests/trust_metric_all/node/client_node.rs
+++ b/tests/trust_metric_all/node/client_node.rs
@@ -184,7 +184,7 @@ impl ClientNode {
         let ctx = Context::new().with_value::<usize>("session_id", sid);
         let peers = vec![Bytes::from(self.remote_peer_id.clone().into_bytes())];
 
-        match self.multicast::<M>(ctx, endpoint, peers, msg, High).await {
+        match self.multicast(ctx, endpoint, peers, msg, High).await {
             Err(_) if !self.connected() => Err(ClientNodeError::NotConnected),
             Err(e) => {
                 let err_msg = format!("broadcast to {} {}", endpoint, e);
@@ -296,10 +296,7 @@ fn full_node_peer_id() -> PeerId {
     let mut bootstraps = config.network.bootstraps.expect("config.toml full node");
     let full_node = bootstraps.pop().expect("there should be one bootstrap");
 
-    let peer_id_bytes = bs58::decode(full_node.peer_id)
-        .into_vec()
-        .expect("decode base58 peer id");
-    PeerId::from_bytes(peer_id_bytes).expect("peer id from")
+    full_node.peer_id.parse().expect("parse peer id")
 }
 
 fn mock_block(height: u64) -> Block {

--- a/tests/trust_metric_all/node/client_node.rs
+++ b/tests/trust_metric_all/node/client_node.rs
@@ -13,7 +13,7 @@ use core_consensus::message::{
     FixedBlock, FixedHeight, BROADCAST_HEIGHT, RPC_RESP_SYNC_PULL_BLOCK, RPC_SYNC_PULL_BLOCK,
 };
 use core_network::{
-    DiagnosticEvent, NetworkConfig, NetworkService, NetworkServiceHandle, TrustReport,
+    DiagnosticEvent, NetworkConfig, NetworkService, NetworkServiceHandle, PeerId, TrustReport,
 };
 use derive_more::Display;
 use protocol::{
@@ -82,22 +82,21 @@ impl MessageHandler for ReceiveRemoteHeight {
 }
 
 pub struct ClientNode {
-    pub network:           NetworkServiceHandle,
-    pub remote_chain_addr: Address,
-    pub priv_key:          Secp256k1PrivateKey,
-    pub sync:              Sync,
+    pub network:        NetworkServiceHandle,
+    pub remote_peer_id: PeerId,
+    pub priv_key:       Secp256k1PrivateKey,
+    pub sync:           Sync,
 }
 
 pub async fn connect(full_node_port: u16, listen_port: u16, sync: Sync) -> ClientNode {
-    let full_node_hex_pubkey = full_node_hex_pubkey();
-    let full_node_chain_addr = full_node_chain_addr(&full_node_hex_pubkey);
+    let full_node_peer_id = full_node_peer_id();
     let full_node_addr = format!("127.0.0.1:{}", full_node_port);
 
     let config = NetworkConfig::new()
         .ping_interval(consts::NETWORK_PING_INTERVAL)
         .peer_trust_metric(consts::NETWORK_TRUST_METRIC_INTERVAL, None)
         .expect("peer trust")
-        .bootstraps(vec![(full_node_hex_pubkey, full_node_addr)])
+        .bootstraps(vec![(full_node_peer_id.to_base58(), full_node_addr)])
         .expect("test node config");
     let priv_key = Secp256k1PrivateKey::generate(&mut rand::rngs::OsRng);
 
@@ -144,7 +143,7 @@ pub async fn connect(full_node_port: u16, listen_port: u16, sync: Sync) -> Clien
 
     ClientNode {
         network: handle,
-        remote_chain_addr: full_node_chain_addr,
+        remote_peer_id: full_node_peer_id,
         priv_key,
         sync,
     }
@@ -158,17 +157,17 @@ impl ClientNode {
 
     pub fn connected(&self) -> bool {
         let diagnostic = &self.network.diagnostic;
-        let opt_session = diagnostic.session_by_chain(&self.remote_chain_addr);
+        let opt_session = diagnostic.session(&self.remote_peer_id);
 
         self.sync.is_connected() && opt_session.is_some()
     }
 
-    pub fn connected_session(&self, addr: &Address) -> Option<usize> {
+    pub fn connected_session(&self, peer_id: &PeerId) -> Option<usize> {
         if !self.connected() {
             None
         } else {
             let diagnostic = &self.network.diagnostic;
-            let opt_session = diagnostic.session_by_chain(addr);
+            let opt_session = diagnostic.session(peer_id);
 
             opt_session.map(|sid| sid.value())
         }
@@ -177,15 +176,15 @@ impl ClientNode {
     pub async fn broadcast<M: MessageCodec>(&self, endpoint: &str, msg: M) -> ClientResult<()> {
         use Priority::High;
 
-        let sid = match self.connected_session(&self.remote_chain_addr) {
+        let sid = match self.connected_session(&self.remote_peer_id) {
             Some(sid) => sid,
             None => return Err(ClientNodeError::NotConnected),
         };
 
         let ctx = Context::new().with_value::<usize>("session_id", sid);
-        let users = vec![self.remote_chain_addr.clone()];
+        let peers = vec![Bytes::from(self.remote_peer_id.clone().into_bytes())];
 
-        match self.users_cast::<M>(ctx, endpoint, users, msg, High).await {
+        match self.multicast::<M>(ctx, endpoint, peers, msg, High).await {
             Err(_) if !self.connected() => Err(ClientNodeError::NotConnected),
             Err(e) => {
                 let err_msg = format!("broadcast to {} {}", endpoint, e);
@@ -200,7 +199,7 @@ impl ClientNode {
         M: MessageCodec,
         R: MessageCodec,
     {
-        let sid = match self.connected_session(&self.remote_chain_addr) {
+        let sid = match self.connected_session(&self.remote_peer_id) {
             Some(sid) => sid,
             None => return Err(ClientNodeError::NotConnected),
         };
@@ -290,19 +289,17 @@ impl Deref for ClientNode {
     }
 }
 
-fn full_node_hex_pubkey() -> String {
+fn full_node_peer_id() -> PeerId {
     let config: Config =
         common_config_parser::parse(&consts::CHAIN_CONFIG_PATH).expect("parse chain config.toml");
 
     let mut bootstraps = config.network.bootstraps.expect("config.toml full node");
     let full_node = bootstraps.pop().expect("there should be one bootstrap");
 
-    full_node.pubkey.as_string_trim0x()
-}
-
-fn full_node_chain_addr(hex_pubkey: &str) -> Address {
-    let pubkey = hex::decode(hex_pubkey).expect("decode hex full node pubkey");
-    Address::from_pubkey_bytes(pubkey.into()).expect("full node chain address")
+    let peer_id_bytes = bs58::decode(full_node.peer_id)
+        .into_vec()
+        .expect("decode base58 peer id");
+    PeerId::from_bytes(peer_id_bytes).expect("peer id from")
 }
 
 fn mock_block(height: u64) -> Block {

--- a/tests/trust_metric_all/node/config.rs
+++ b/tests/trust_metric_all/node/config.rs
@@ -30,7 +30,7 @@ pub struct ConfigNetwork {
 
 #[derive(Debug, Deserialize)]
 pub struct ConfigNetworkBootstrap {
-    pub pubkey:  Hex,
+    pub peer_id: String,
     pub address: String,
 }
 

--- a/tests/trust_metric_all/node/full_node/default_start.rs
+++ b/tests/trust_metric_all/node/full_node/default_start.rs
@@ -162,10 +162,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let mut bootstrap_pairs = vec![];
     if let Some(bootstrap) = &config.network.bootstraps {
         for bootstrap in bootstrap.iter() {
-            bootstrap_pairs.push((
-                bootstrap.pubkey.as_string_trim0x(),
-                bootstrap.address.to_owned(),
-            ));
+            bootstrap_pairs.push((bootstrap.peer_id.to_owned(), bootstrap.address.to_owned()));
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
refactor

**What this PR does / why we need it**:

BREAKING CHANGE:
- rename users_cast to multicast, take peer id bytes instead
- bootstrap configuration take peer id instead of pubkey hex

Follow #354 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
