### PR TITLE
fix(consensus): Add timestamp checking

### DIFF
--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -1057,12 +1057,12 @@ mod tests {
         assert_eq!(validate_timestamp(10, 11, consensus_interval), false);
 
         // current 10 == proposal 10. true
-        assert_eq!(validate_timestamp(10, 10, consensus_interval), false);
+        assert_eq!(validate_timestamp(10, 10, consensus_interval), true);
 
         // (current 20 > proposal 9) > consensus_interval false
         assert_eq!(validate_timestamp(20, 9, consensus_interval), false);
 
-        // (current 20 > proposal 10) == consensus_interval false
+        // (current 20 > proposal 10) == consensus_interval true
         assert_eq!(validate_timestamp(20, 10, consensus_interval), true);
 
         // (current 20 == proposal 11) < consensus_interval true

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -986,25 +986,6 @@ where
     }
 }
 
-fn validate_timestamp(
-    current_timestamp: u64,
-    proposal_timestamp: u64,
-    consensus_interval: u64,
-) -> bool {
-    // this node timestamp should be longer than the proposal timestamp
-    if proposal_timestamp > current_timestamp {
-        return false;
-    }
-
-    // The interval between the two should not be greater than 'consensus_time'.
-    let time_gap = current_timestamp - proposal_timestamp;
-    if time_gap > consensus_interval {
-        return false;
-    }
-
-    true
-}
-
 fn gen_executed_info(
     ctx: Context,
     exec_resp: ExecutorResp,
@@ -1030,33 +1011,5 @@ fn gen_executed_info(
         receipt_root: receipt,
         confirm_root: order_root,
         state_root: exec_resp.state_root,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::validate_timestamp;
-
-    #[test]
-    fn test_validate_timestamp() {
-        let consensus_interval = 10;
-
-        // current 10 > proposal 1 > true
-        assert_eq!(validate_timestamp(10, 1, consensus_interval), true);
-
-        // current 10 < proposal 11. false
-        assert_eq!(validate_timestamp(10, 11, consensus_interval), false);
-
-        // current 10 == proposal 10. true
-        assert_eq!(validate_timestamp(10, 10, consensus_interval), true);
-
-        // (current 20 > proposal 9) > consensus_interval false
-        assert_eq!(validate_timestamp(20, 9, consensus_interval), false);
-
-        // (current 20 > proposal 10) == consensus_interval true
-        assert_eq!(validate_timestamp(20, 10, consensus_interval), true);
-
-        // (current 20 == proposal 11) < consensus_interval true
-        assert_eq!(validate_timestamp(20, 11, consensus_interval), true);
     }
 }

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -35,7 +35,7 @@ use crate::message::{
     BROADCAST_HEIGHT, RPC_SYNC_PULL_BLOCK, RPC_SYNC_PULL_PROOF, RPC_SYNC_PULL_TXS,
 };
 use crate::status::{ExecutedInfo, StatusAgent};
-use crate::util::{convert_hex_to_bls_pubkeys, time_now, ExecuteInfo, OverlordCrypto};
+use crate::util::{convert_hex_to_bls_pubkeys, ExecuteInfo, OverlordCrypto};
 use crate::BlockHeaderField::{PreviousBlockHash, ProofHash, Proposer};
 use crate::BlockProofField::{BitMap, HashMismatch, HeightMismatch, Signature, WeightNotFound};
 use crate::{BlockHeaderField, BlockProofField, ConsensusError};
@@ -572,20 +572,6 @@ where
                 (address, node)
             })
             .collect::<HashMap<_, _>>();
-
-        // verify block timestamp.
-        let timestamp = block.header.timestamp;
-        let current_timestamp = time_now();
-        let consensus_interval = previous_metadata.interval;
-
-        // The previous block timestamp should be less than proposal timestamp.
-        if previous_block.header.timestamp > timestamp {
-            return Err(ConsensusError::InvalidTimestamp.into());
-        }
-
-        if !validate_timestamp(current_timestamp, timestamp, consensus_interval) {
-            return Err(ConsensusError::InvalidTimestamp.into());
-        }
 
         // TODO: useless check
         // check proposer

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -577,8 +577,8 @@ where
         let timestamp = block.header.timestamp;
         let current_timestamp = time_now();
         let consensus_interval = previous_metadata.interval;
-        
-        // The last block timestamp should be less than proposal timestamp.
+
+        // The previous block timestamp should be less than proposal timestamp.
         if previous_block.header.timestamp > timestamp {
             return Err(ConsensusError::InvalidTimestamp.into());
         }

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -579,7 +579,7 @@ where
         let consensus_interval = previous_metadata.interval;
 
         if !validate_timestamp(current_timestamp, timestamp, consensus_interval) {
-            return Err(ConsensusError::InvalidTimestamp);
+            return Err(ConsensusError::InvalidTimestamp.into());
         }
 
         // TODO: useless check
@@ -997,11 +997,13 @@ where
 
 fn validate_timestamp(current_timestamp: u64, proposal_timestamp: u64, consensus_interval: u64) -> bool {
     // this node timestamp should be longer than the proposal timestamp
-    if proposal_timestamp < current_timestamp {
+    if proposal_timestamp > current_timestamp {
         return false
     }
 
-    if proposal_timestamp > (proposal_timestamp + consensus_interval) {
+    // The interval between the two should not be greater than 'consensus_time'.
+    let time_gap = current_timestamp - proposal_timestamp;
+    if time_gap > consensus_interval {
         return false
     }
 
@@ -1033,5 +1035,33 @@ fn gen_executed_info(
         receipt_root: receipt,
         confirm_root: order_root,
         state_root: exec_resp.state_root,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_timestamp;
+
+    #[test]
+    fn test_validate_timestamp() {
+        let consensus_interval = 10;
+
+        // current 10 > proposal 1 > true
+        assert_eq!(validate_timestamp(10, 1, consensus_interval), true);
+
+        // current 10 < proposal 11. false
+        assert_eq!(validate_timestamp(10, 11, consensus_interval), false);
+
+         // current 10 == proposal 10. true
+        assert_eq!(validate_timestamp(10, 10, consensus_interval), false);
+
+        // (current 20 > proposal 9) > consensus_interval false
+        assert_eq!(validate_timestamp(20, 9, consensus_interval), false);
+
+        // (current 20 > proposal 10) == consensus_interval false
+        assert_eq!(validate_timestamp(20, 10, consensus_interval), true);
+
+        // (current 20 == proposal 11) < consensus_interval true
+        assert_eq!(validate_timestamp(20, 11, consensus_interval), true);
     }
 }

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -577,6 +577,11 @@ where
         let timestamp = block.header.timestamp;
         let current_timestamp = time_now();
         let consensus_interval = previous_metadata.interval;
+        
+        // The last block timestamp should be less than proposal timestamp.
+        if previous_block.header.timestamp > timestamp {
+            return Err(ConsensusError::InvalidTimestamp.into());
+        }
 
         if !validate_timestamp(current_timestamp, timestamp, consensus_interval) {
             return Err(ConsensusError::InvalidTimestamp.into());

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -572,8 +572,8 @@ where
                 (address, node)
             })
             .collect::<HashMap<_, _>>();
-        
-         // verify block timestamp.
+
+        // verify block timestamp.
         let timestamp = block.header.timestamp;
         let current_timestamp = time_now();
         let consensus_interval = previous_metadata.interval;
@@ -995,16 +995,20 @@ where
     }
 }
 
-fn validate_timestamp(current_timestamp: u64, proposal_timestamp: u64, consensus_interval: u64) -> bool {
+fn validate_timestamp(
+    current_timestamp: u64,
+    proposal_timestamp: u64,
+    consensus_interval: u64,
+) -> bool {
     // this node timestamp should be longer than the proposal timestamp
     if proposal_timestamp > current_timestamp {
-        return false
+        return false;
     }
 
     // The interval between the two should not be greater than 'consensus_time'.
     let time_gap = current_timestamp - proposal_timestamp;
     if time_gap > consensus_interval {
-        return false
+        return false;
     }
 
     true
@@ -1052,7 +1056,7 @@ mod tests {
         // current 10 < proposal 11. false
         assert_eq!(validate_timestamp(10, 11, consensus_interval), false);
 
-         // current 10 == proposal 10. true
+        // current 10 == proposal 10. true
         assert_eq!(validate_timestamp(10, 10, consensus_interval), false);
 
         // (current 20 > proposal 9) > consensus_interval false

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -193,7 +193,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                 .adapter
                 .get_block_by_height(ctx.clone(), block.inner.block.header.height - 1)
                 .await?;
-            
+
             // verify block timestamp.
             let timestamp = block.inner.block.header.timestamp;
             let current_timestamp = time_now();
@@ -207,7 +207,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             if !validate_timestamp(current_timestamp, timestamp, consensus_interval) {
                 return Err(ConsensusError::InvalidTimestamp.into());
             }
-            
+
             self.adapter
                 .verify_proof(
                     ctx.clone(),

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -32,7 +32,7 @@ use crate::message::{
     END_GOSSIP_SIGNED_VOTE,
 };
 use crate::status::StatusAgent;
-use crate::util::{check_list_roots, time_now, digest_signed_transactions, OverlordCrypto};
+use crate::util::{check_list_roots, digest_signed_transactions, time_now, OverlordCrypto};
 use crate::wal::SignedTxsWAL;
 use crate::ConsensusError;
 

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::error::Error;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use futures::lock::Mutex;
@@ -32,7 +32,7 @@ use crate::message::{
     END_GOSSIP_SIGNED_VOTE,
 };
 use crate::status::StatusAgent;
-use crate::util::{check_list_roots, digest_signed_transactions, OverlordCrypto};
+use crate::util::{check_list_roots, time_now, digest_signed_transactions, OverlordCrypto};
 use crate::wal::SignedTxsWAL;
 use crate::ConsensusError;
 
@@ -798,13 +798,6 @@ fn covert_to_overlord_authority(validators: &[Validator]) -> Vec<Node> {
         .collect::<Vec<_>>();
     authority.sort();
     authority
-}
-
-fn time_now() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64
 }
 
 async fn sync_txs<CA: ConsensusAdapter>(

--- a/core/consensus/src/lib.rs
+++ b/core/consensus/src/lib.rs
@@ -103,6 +103,7 @@ pub enum ConsensusError {
     #[display(fmt = "Consensus missed pill cooresponding {:?}", _0)]
     MissingPill(Hash),
 
+    /// Invalid timestamp
     #[display(fmt = "Consensus invalid timestamp")]
     InvalidTimestamp,
 

--- a/core/consensus/src/lib.rs
+++ b/core/consensus/src/lib.rs
@@ -103,6 +103,9 @@ pub enum ConsensusError {
     #[display(fmt = "Consensus missed pill cooresponding {:?}", _0)]
     MissingPill(Hash),
 
+    #[display(fmt = "Consensus invalid timestamp")]
+    InvalidTimestamp,
+
     /// Consensus missed the block header.
     #[display(fmt = "Consensus missed block header of {} block", _0)]
     MissingBlockHeader(u64),

--- a/core/consensus/src/util.rs
+++ b/core/consensus/src/util.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::error::Error;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use bytes::buf::BufMut;
 use bytes::BytesMut;
@@ -16,6 +17,13 @@ use protocol::fixed_codec::FixedCodec;
 use protocol::traits::Context;
 use protocol::types::{Address, Hash, Hex, MerkleRoot, SignedTransaction};
 use protocol::{Bytes, ProtocolError, ProtocolResult};
+
+pub fn time_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
 
 pub struct OverlordCrypto {
     private_key: BlsPrivateKey,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
fixed a potential security problem.

**What this PR does / why we need it**:
If the timestamp of the proposal is not verified, the bad node will be able to pass an arbitrarily large time, causing a huge fluctuation in the blockchain time.

So, we should limit the proposal's timestamp to two conditions:
1. The previous block timestamp should be less than proposal timestamp.
2. this node timestamp should be longer than the proposal timestamp

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
