### PR TITLE
fix(mempool): Ensure that there are no duplicate transactions in the order transaction

### DIFF
--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -19,6 +19,7 @@ use std::error::Error;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+use std::collections::HashSet;
 
 use async_trait::async_trait;
 use derive_more::Display;
@@ -308,6 +309,8 @@ where
         height: Option<u64>,
         order_tx_hashes: Vec<Hash>,
     ) -> ProtocolResult<()> {
+        check_dup_order_hashes(&order_tx_hashes)?;
+
         let unknown_hashes = self.show_unknown_txs(order_tx_hashes).await;
         if !unknown_hashes.is_empty() {
             let unknown_len = unknown_hashes.len();
@@ -369,6 +372,20 @@ where
     }
 }
 
+fn check_dup_order_hashes(order_tx_hashes: &[Hash]) -> ProtocolResult<()> {
+    let mut dup_set = HashSet::with_capacity(order_tx_hashes.len());
+
+    for hash in order_tx_hashes.iter() {
+        if dup_set.contains(hash){
+            return Err(MemPoolError::EnsureDup{ hash: hash.clone() }.into())
+        }
+
+        dup_set.insert(hash.clone());
+    }
+
+    Ok(())
+}
+
 pub enum TxType {
     NewTx,
     ProposeTx,
@@ -411,6 +428,9 @@ pub enum MemPoolError {
 
     #[display(fmt = "Pull txs, require: {}, response: {}", require, response)]
     EnsureBreak { require: usize, response: usize },
+
+    #[display(fmt = "There is duplication in order transactions. duplication tx_hash {:?}", hash)]
+    EnsureDup { hash: Hash },
 
     #[display(fmt = "Fetch full txs, require: {}, response: {}", require, response)]
     MisMatch { require: usize, response: usize },

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -15,11 +15,11 @@ pub use adapter::message::{
 pub use adapter::DefaultMemPoolAdapter;
 pub use adapter::{DEFAULT_BROADCAST_TXS_INTERVAL, DEFAULT_BROADCAST_TXS_SIZE};
 
+use std::collections::HashSet;
 use std::error::Error;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use std::collections::HashSet;
 
 use async_trait::async_trait;
 use derive_more::Display;
@@ -376,8 +376,8 @@ fn check_dup_order_hashes(order_tx_hashes: &[Hash]) -> ProtocolResult<()> {
     let mut dup_set = HashSet::with_capacity(order_tx_hashes.len());
 
     for hash in order_tx_hashes.iter() {
-        if dup_set.contains(hash){
-            return Err(MemPoolError::EnsureDup{ hash: hash.clone() }.into())
+        if dup_set.contains(hash) {
+            return Err(MemPoolError::EnsureDup { hash: hash.clone() }.into());
         }
 
         dup_set.insert(hash.clone());
@@ -429,7 +429,10 @@ pub enum MemPoolError {
     #[display(fmt = "Pull txs, require: {}, response: {}", require, response)]
     EnsureBreak { require: usize, response: usize },
 
-    #[display(fmt = "There is duplication in order transactions. duplication tx_hash {:?}", hash)]
+    #[display(
+        fmt = "There is duplication in order transactions. duplication tx_hash {:?}",
+        hash
+    )]
     EnsureDup { hash: Hash },
 
     #[display(fmt = "Fetch full txs, require: {}, response: {}", require, response)]

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(async_closure, test)]
-#![allow(clippy::suspicious_else_formatting)]
+#![allow(clippy::suspicious_else_formatting, clippy::mutable_key_type)]
 
 mod adapter;
 mod context;

--- a/core/mempool/src/tests/mempool.rs
+++ b/core/mempool/src/tests/mempool.rs
@@ -31,6 +31,26 @@ macro_rules! insert {
     };
 }
 
+#[test]
+fn test_dup_order_hashes() {
+    let hashes = vec![
+        Hash::digest(Bytes::from("test1")),
+        Hash::digest(Bytes::from("test2")),
+        Hash::digest(Bytes::from("test3")),
+        Hash::digest(Bytes::from("test4")),
+        Hash::digest(Bytes::from("test2")),
+    ];
+    assert_eq!(check_dup_order_hashes(&hashes).is_err(), true);
+
+    let hashes = vec![
+        Hash::digest(Bytes::from("test1")),
+        Hash::digest(Bytes::from("test2")),
+        Hash::digest(Bytes::from("test3")),
+        Hash::digest(Bytes::from("test4")),
+    ];
+    assert_eq!(check_dup_order_hashes(&hashes).is_err(), false);
+}
+
 #[tokio::test]
 async fn test_insert() {
     // 1. insertion under pool size.

--- a/core/mempool/src/tests/mod.rs
+++ b/core/mempool/src/tests/mod.rs
@@ -20,7 +20,7 @@ use protocol::traits::{Context, MemPool, MemPoolAdapter, MixedTxHashes};
 use protocol::types::{Address, Hash, RawTransaction, SignedTransaction, TransactionRequest};
 use protocol::{Bytes, ProtocolResult};
 
-use crate::{HashMemPool, MemPoolError, check_dup_order_hashes};
+use crate::{check_dup_order_hashes, HashMemPool, MemPoolError};
 
 const CYCLE_LIMIT: u64 = 1_000_000;
 const TX_NUM_LIMIT: u64 = 10_000;

--- a/core/mempool/src/tests/mod.rs
+++ b/core/mempool/src/tests/mod.rs
@@ -20,7 +20,7 @@ use protocol::traits::{Context, MemPool, MemPoolAdapter, MixedTxHashes};
 use protocol::types::{Address, Hash, RawTransaction, SignedTransaction, TransactionRequest};
 use protocol::{Bytes, ProtocolResult};
 
-use crate::{HashMemPool, MemPoolError};
+use crate::{HashMemPool, MemPoolError, check_dup_order_hashes};
 
 const CYCLE_LIMIT: u64 = 1_000_000;
 const TX_NUM_LIMIT: u64 = 10_000;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
Fix a security issue

**What this PR does / why we need it**:
The `ensure_order_txs` needs to ensure that there is no duplicate transaction hash in `order_transactions` so that avoid bad nodes that package a block that contains repeated transactions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
