### PR TITLE
fix(MultiSig)!: change interface and substitute adaptive_address for autonomy

### DIFF
--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -185,7 +185,7 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
                 })
                 .collect::<Vec<_>>();
 
-            let owner = if payload.autonomy == true {
+            let owner = if payload.autonomy {
                 address.clone()
             } else {
                 payload.owner.clone()

--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -114,11 +114,9 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
             })
             .collect::<Vec<_>>();
 
-        let owner = payload.owner;
-
         let permission = MultiSigPermission {
             accounts,
-            owner,
+            owner: payload.owner,
             threshold: payload.threshold,
             memo: payload.memo,
         };

--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -24,11 +24,6 @@ use crate::types::{
 const MAX_MULTI_SIGNATURE_RECURSION_DEPTH: u8 = 8;
 const MAX_PERMISSION_ACCOUNTS: u8 = 16;
 
-lazy_static::lazy_static! {
-   // FIXME:
-   pub static ref ADEPTIVE_ADDRESS: Address = "muta14e0lmgck835vm2dfm0w3ckv6svmez8fdgdl705".parse().unwrap();
-}
-
 macro_rules! impl_multisig {
     ($self: expr, $method: ident, $ctx: expr) => {{
         let res = $self.$method($ctx.clone());
@@ -119,11 +114,7 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
             })
             .collect::<Vec<_>>();
 
-        let owner = if payload.owner == ADEPTIVE_ADDRESS.clone() {
-            address.clone()
-        } else {
-            payload.owner.clone()
-        };
+        let owner = payload.owner;
 
         let permission = MultiSigPermission {
             accounts,
@@ -194,7 +185,7 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
                 })
                 .collect::<Vec<_>>();
 
-            let owner = if payload.owner == ADEPTIVE_ADDRESS.clone() {
+            let owner = if payload.autonomy == true {
                 address.clone()
             } else {
                 payload.owner.clone()
@@ -285,10 +276,8 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
                 return ServiceResponse::<()>::from_error(118, "invalid owner".to_owned());
             }
 
-            let new_info = payload.new_account_info.clone();
-
             // check if account contains itself
-            if new_info
+            if payload
                 .addr_with_weight
                 .iter()
                 .map(|a| a.address.clone())
@@ -301,8 +290,8 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
             }
 
             // check sum of weight
-            if new_info.addr_with_weight.is_empty()
-                || new_info.addr_with_weight.len() > MAX_PERMISSION_ACCOUNTS as usize
+            if payload.addr_with_weight.is_empty()
+                || payload.addr_with_weight.len() > MAX_PERMISSION_ACCOUNTS as usize
             {
                 return ServiceResponse::<()>::from_error(
                     110,
@@ -310,14 +299,14 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
                 );
             }
 
-            let weight_sum = new_info
+            let weight_sum = payload
                 .addr_with_weight
                 .iter()
                 .map(|item| item.weight as u32)
                 .sum::<u32>();
 
             // check if sum of the weights is above threshold
-            if new_info.threshold == 0 || weight_sum < new_info.threshold {
+            if payload.threshold == 0 || weight_sum < payload.threshold {
                 return ServiceResponse::<()>::from_error(
                     111,
                     "accounts weight or threshold not valid".to_owned(),
@@ -325,7 +314,7 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
             }
 
             // check the recursion depth
-            if new_info
+            if payload
                 .addr_with_weight
                 .iter()
                 .map(|s| self._is_recursion_depth_overflow(&s.address, 0))
@@ -337,7 +326,7 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
                 );
             }
 
-            let accounts = new_info
+            let accounts = payload
                 .addr_with_weight
                 .iter()
                 .map(|item| Account {
@@ -354,9 +343,9 @@ impl<SDK: ServiceSDK> MultiSignatureService<SDK> {
             self.sdk
                 .set_account_value(&payload.account_address, 0u8, MultiSigPermission {
                     accounts,
-                    owner: new_info.owner,
-                    threshold: new_info.threshold,
-                    memo: new_info.memo,
+                    owner: payload.owner,
+                    threshold: payload.threshold,
+                    memo: payload.memo,
                 });
             return ServiceResponse::<()>::from_succeed(());
         }

--- a/built-in-services/multi-signature/src/tests/curd_test.rs
+++ b/built-in-services/multi-signature/src/tests/curd_test.rs
@@ -5,7 +5,6 @@ use crate::types::{
     MultiSigPermission, RemoveAccountPayload, SetAccountWeightPayload, SetThresholdPayload,
     UpdateAccountPayload,
 };
-use crate::ADEPTIVE_ADDRESS;
 
 use super::*;
 
@@ -26,6 +25,7 @@ fn test_generate_multi_signature() {
     let multi_sig_address =
         service.generate_account(context.clone(), GenerateMultiSigAccountPayload {
             owner:            owner.clone(),
+            autonomy:         false,
             addr_with_weight: accounts,
             threshold:        12,
             memo:             String::new(),
@@ -40,6 +40,7 @@ fn test_generate_multi_signature() {
     let multi_sig_address =
         service.generate_account(context.clone(), GenerateMultiSigAccountPayload {
             owner:            owner.clone(),
+            autonomy:         false,
             addr_with_weight: accounts,
             threshold:        12,
             memo:             String::new(),
@@ -54,6 +55,7 @@ fn test_generate_multi_signature() {
     let multi_sig_address =
         service.generate_account(context.clone(), GenerateMultiSigAccountPayload {
             owner:            owner.clone(),
+            autonomy:         false,
             addr_with_weight: accounts.clone(),
             threshold:        3,
             memo:             String::new(),
@@ -89,6 +91,7 @@ fn test_set_threshold() {
     let multi_sig_address = service
         .generate_account(context.clone(), GenerateMultiSigAccountPayload {
             owner:            owner_address,
+            autonomy:         false,
             addr_with_weight: account_pubkeys,
             threshold:        3,
             memo:             String::new(),
@@ -128,7 +131,8 @@ fn test_adeption_address() {
         .collect::<Vec<_>>();
     let multi_sig_address = service
         .generate_account(context.clone(), GenerateMultiSigAccountPayload {
-            owner:            ADEPTIVE_ADDRESS.clone(),
+            owner:            Address::default(),
+            autonomy:         true,
             addr_with_weight: account_pubkeys,
             threshold:        3,
             memo:             String::new(),
@@ -157,6 +161,7 @@ fn test_add_account() {
     let multi_sig_address = service
         .generate_account(context.clone(), GenerateMultiSigAccountPayload {
             owner:            owner_address.clone(),
+            autonomy:         false,
             addr_with_weight: account_pubkeys.clone(),
             threshold:        3,
             memo:             String::new(),
@@ -210,6 +215,7 @@ fn test_update_account() {
     let multi_sig_address = service
         .generate_account(context, GenerateMultiSigAccountPayload {
             owner:            owner_address.clone(),
+            autonomy:         false,
             addr_with_weight: account_pubkeys,
             threshold:        4,
             memo:             String::new(),
@@ -226,12 +232,10 @@ fn test_update_account() {
     }];
     let res = service.update_account(context.clone(), UpdateAccountPayload {
         account_address:  multi_sig_address.clone(),
-        new_account_info: GenerateMultiSigAccountPayload {
-            owner:            new_owner_address.clone(),
-            addr_with_weight: account_pubkeys,
-            threshold:        1,
-            memo:             String::new(),
-        },
+        owner:            new_owner_address.clone(),
+        addr_with_weight: account_pubkeys,
+        threshold:        1,
+        memo:             String::new(),
     });
     assert!(res.is_error());
 
@@ -242,12 +246,10 @@ fn test_update_account() {
         .collect::<Vec<_>>();
     let res = service.update_account(context, UpdateAccountPayload {
         account_address:  multi_sig_address,
-        new_account_info: GenerateMultiSigAccountPayload {
-            owner:            new_owner_address,
-            addr_with_weight: account_pubkeys,
-            threshold:        1,
-            memo:             String::new(),
-        },
+        owner:            new_owner_address,
+        addr_with_weight: account_pubkeys,
+        threshold:        1,
+        memo:             String::new(),
     });
     assert_eq!(res.is_error(), false);
 }
@@ -267,6 +269,7 @@ fn test_set_weight() {
     let multi_sig_address = service
         .generate_account(context.clone(), GenerateMultiSigAccountPayload {
             owner:            owner_address.clone(),
+            autonomy:         false,
             addr_with_weight: account_pubkeys.clone(),
             threshold:        4,
             memo:             String::new(),
@@ -321,6 +324,7 @@ fn test_remove_account() {
     let multi_sig_address = service
         .generate_account(context.clone(), GenerateMultiSigAccountPayload {
             owner:            owner_address.clone(),
+            autonomy:         false,
             addr_with_weight: account_pubkeys.clone(),
             threshold:        3,
             memo:             String::new(),

--- a/built-in-services/multi-signature/src/tests/recursion_test.rs
+++ b/built-in-services/multi-signature/src/tests/recursion_test.rs
@@ -22,6 +22,7 @@ fn test_recursion_verify_signature() {
             mock_context(cycles_limit, caller.clone()),
             GenerateMultiSigAccountPayload {
                 owner:            owner.clone(),
+                autonomy:         false,
                 addr_with_weight: init_multi_sig_account,
                 threshold:        4,
                 memo:             String::new(),
@@ -46,6 +47,7 @@ fn test_recursion_verify_signature() {
             mock_context(cycles_limit, caller.clone()),
             GenerateMultiSigAccountPayload {
                 owner,
+                autonomy: false,
                 addr_with_weight: multi_sig_account,
                 threshold: 4,
                 memo: String::new(),
@@ -100,6 +102,7 @@ fn test_recursion_depth() {
             mock_context(cycles_limit, caller.clone()),
             GenerateMultiSigAccountPayload {
                 owner:            owner.clone(),
+                autonomy:         false,
                 addr_with_weight: init_multi_sig_account,
                 threshold:        4,
                 memo:             String::new(),
@@ -125,6 +128,7 @@ fn test_recursion_depth() {
             mock_context(cycles_limit, caller.clone()),
             GenerateMultiSigAccountPayload {
                 owner:            owner.clone(),
+                autonomy:         false,
                 addr_with_weight: multi_sig_account,
                 threshold:        4,
                 memo:             String::new(),
@@ -139,6 +143,7 @@ fn test_recursion_depth() {
         mock_context(cycles_limit, caller),
         GenerateMultiSigAccountPayload {
             owner,
+            autonomy: false,
             addr_with_weight: vec![AddressWithWeight {
                 address: sender,
                 weight:  4u8,

--- a/built-in-services/multi-signature/src/types.rs
+++ b/built-in-services/multi-signature/src/types.rs
@@ -33,6 +33,7 @@ pub struct InitGenesisPayload {
 #[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct GenerateMultiSigAccountPayload {
     pub owner:            Address,
+    pub autonomy:         bool,
     pub addr_with_weight: Vec<AddressWithWeight>,
     pub threshold:        u32,
     pub memo:             String,
@@ -101,7 +102,10 @@ pub struct SetThresholdPayload {
 #[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug)]
 pub struct UpdateAccountPayload {
     pub account_address:  Address,
-    pub new_account_info: GenerateMultiSigAccountPayload,
+    pub owner:            Address,
+    pub addr_with_weight: Vec<AddressWithWeight>,
+    pub threshold:        u32,
+    pub memo:             String,
 }
 
 #[derive(RlpFixedCodec, Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]

--- a/devtools/chain/genesis.toml
+++ b/devtools/chain/genesis.toml
@@ -5,7 +5,7 @@ prevhash = "0x44915be5b6c20b0678cf05fcddbbaa832e25d7e6ac538784cd5c24de00d47472"
 name = "asset"
 payload = '''
 {
-    "id": "0xf56924db538e77bb5951eb5ff0d02b88983c49c45eea30e8ae3e7234b311436c",
+   "id": "0xf56924db538e77bb5951eb5ff0d02b88983c49c45eea30e8ae3e7234b311436c",
    "name": "MutaToken",
    "symbol": "MT",
    "supply": 320000011,

--- a/docs/build/gql_api.sh
+++ b/docs/build/gql_api.sh
@@ -18,9 +18,11 @@ if [ ! -z "$1" ]; then
   endpoint=$1
 fi
 
-res_code=$(curl --write-out %{http_code} --silent --output /dev/null \
-            -X POST -d '{"query":"{\n  getBlock(height: \"3\") {\n    header {\n      height\n      preHash\n    }\n    orderedTxHashes\n  }\n}\n"}' \
-            $endpoint)
+#res_code=$(curl --write-out %{http_code} --silent --output /dev/null \
+#            -X POST -d 'query q{\n  getBlock(height:"0x00"){\n    hash \n  }\n}' \
+#            $endpoint)
+
+res_code=$(curl $endpoint --write-out %{http_code} --silent --output /dev/null -H 'content-type: application/json' --data-binary '{"operationName":"q","variables":{},"query":"query q {\n  getBlock(height: \"0x00\") {\n    hash\n  }\n}\n"}')
 
 if [ $res_code -ne 200 ]; then
   echo "$endpoint GraphQL endpoint request failed"

--- a/docs/graphql_api.md
+++ b/docs/graphql_api.md
@@ -19,10 +19,10 @@ node, and then try open http://127.0.0.1:8000/graphiql in the browser.
     * [Block](#block)
     * [BlockHeader](#blockheader)
     * [Event](#event)
-    * [ExecResp](#execresp)
     * [Proof](#proof)
     * [Receipt](#receipt)
     * [ReceiptResponse](#receiptresponse)
+    * [ServiceResponse](#serviceresponse)
     * [SignedTransaction](#signedtransaction)
     * [Validator](#validator)
   * [Inputs](#inputs)
@@ -52,7 +52,7 @@ node, and then try open http://127.0.0.1:8000/graphiql in the browser.
 <tbody>
 <tr>
 <td colspan="2" valign="top"><strong>getBlock</strong></td>
-<td valign="top"><a href="#/graphql_api?id=block">Block</a>!</td>
+<td valign="top"><a href="#/graphql_api?id=block">Block</a></td>
 <td>
 
 Get the block
@@ -66,7 +66,7 @@ Get the block
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>getTransaction</strong></td>
-<td valign="top"><a href="#/graphql_api?id=signedtransaction">SignedTransaction</a>!</td>
+<td valign="top"><a href="#/graphql_api?id=signedtransaction">SignedTransaction</a></td>
 <td>
 
 Get the transaction by hash
@@ -80,7 +80,7 @@ Get the transaction by hash
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>getReceipt</strong></td>
-<td valign="top"><a href="#/graphql_api?id=receipt">Receipt</a>!</td>
+<td valign="top"><a href="#/graphql_api?id=receipt">Receipt</a></td>
 <td>
 
 Get the receipt by transaction hash
@@ -94,7 +94,7 @@ Get the receipt by transaction hash
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>queryService</strong></td>
-<td valign="top"><a href="#/graphql_api?id=execresp">ExecResp</a>!</td>
+<td valign="top"><a href="#/graphql_api?id=serviceresponse">ServiceResponse</a>!</td>
 <td>
 
 query service
@@ -228,6 +228,15 @@ The body section of a block
 
 </td>
 </tr>
+<tr>
+<td colspan="2" valign="top"><strong>hash</strong></td>
+<td valign="top"><a href="#/graphql_api?id=hash">Hash</a>!</td>
+<td>
+
+Hash of the block
+
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -273,7 +282,7 @@ The height to which the block has been executed
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>preHash</strong></td>
+<td colspan="2" valign="top"><strong>prevHash</strong></td>
 <td valign="top"><a href="#/graphql_api?id=hash">Hash</a>!</td>
 <td>
 
@@ -296,6 +305,15 @@ A timestamp that records when the block was created
 <td>
 
 The merkle root of ordered transactions
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderSignedTransactionsHash</strong></td>
+<td valign="top"><a href="#/graphql_api?id=hash">Hash</a>!</td>
+<td>
+
+The hash of ordered signed transactions
 
 </td>
 </tr>
@@ -384,33 +402,13 @@ The version of validator is designed for cross chain
 <td></td>
 </tr>
 <tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#/graphql_api?id=string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>data</strong></td>
 <td valign="top"><a href="#/graphql_api?id=string">String</a>!</td>
-<td></td>
-</tr>
-</tbody>
-</table>
-
-### ExecResp
-
-<table>
-<thead>
-<tr>
-<th align="left">Field</th>
-<th align="right">Argument</th>
-<th align="left">Type</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td colspan="2" valign="top"><strong>ret</strong></td>
-<td valign="top"><a href="#/graphql_api?id=string">String</a>!</td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>isError</strong></td>
-<td valign="top"><a href="#/graphql_api?id=boolean">Boolean</a>!</td>
 <td></td>
 </tr>
 </tbody>
@@ -526,13 +524,38 @@ The verifier of the block header proved
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ret</strong></td>
+<td colspan="2" valign="top"><strong>response</strong></td>
+<td valign="top"><a href="#/graphql_api?id=serviceresponse">ServiceResponse</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ServiceResponse
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#/graphql_api?id=uint64">Uint64</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>succeedData</strong></td>
 <td valign="top"><a href="#/graphql_api?id=string">String</a>!</td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>isError</strong></td>
-<td valign="top"><a href="#/graphql_api?id=boolean">Boolean</a>!</td>
+<td colspan="2" valign="top"><strong>errorMessage</strong></td>
+<td valign="top"><a href="#/graphql_api?id=string">String</a>!</td>
 <td></td>
 </tr>
 </tbody>
@@ -573,6 +596,11 @@ The verifier of the block header proved
 <tr>
 <td colspan="2" valign="top"><strong>timeout</strong></td>
 <td valign="top"><a href="#/graphql_api?id=uint64">Uint64</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sender</strong></td>
+<td valign="top"><a href="#/graphql_api?id=address">Address</a>!</td>
 <td></td>
 </tr>
 <tr>
@@ -623,8 +651,8 @@ Validator address set
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>address</strong></td>
-<td valign="top"><a href="#/graphql_api?id=address">Address</a>!</td>
+<td colspan="2" valign="top"><strong>pubkey</strong></td>
+<td valign="top"><a href="#/graphql_api?id=bytes">Bytes</a>!</td>
 <td></td>
 </tr>
 <tr>
@@ -709,6 +737,11 @@ For security and performance reasons, Muta will only deal with trade request ove
 <tr>
 <td colspan="2" valign="top"><strong>payload</strong></td>
 <td valign="top"><a href="#/graphql_api?id=string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sender</strong></td>
+<td valign="top"><a href="#/graphql_api?id=address">Address</a>!</td>
 <td></td>
 </tr>
 </tbody>

--- a/tests/e2e/multisig.ts
+++ b/tests/e2e/multisig.ts
@@ -11,6 +11,7 @@ interface AddressWithWeight {
 
 interface GenerateMultiSigAccountPayload {
     owner: Address,
+    autonomy:         boolean,
     addr_with_weight: Vec<AddressWithWeight>,
     threshold: u32,
     memo: string,
@@ -30,7 +31,10 @@ interface GetMultiSigAccountResponse {
 
 interface UpdateAccountPayload {
     account_address: Address,
-    new_account_info: GenerateMultiSigAccountPayload
+    owner: Address,
+    addr_with_weight: Vec<AddressWithWeight>,
+    threshold: u32,
+    memo: string,
 }
 
 interface MultiSigPermission {

--- a/tests/e2e/sdk.test.ts
+++ b/tests/e2e/sdk.test.ts
@@ -84,6 +84,7 @@ describe("API test via @mutadev/muta-sdk-js", () => {
 
     var GenerateMultiSigAccountPayload = {
       owner: wangYe.address,
+      autonomy: false,
       addr_with_weight: [{ address: wangYe.address, weight: 1 }, { address: qing.address, weight: 1 }],
       threshold: 2,
       memo: 'welcome to BiYouCun'
@@ -127,16 +128,12 @@ describe("API test via @mutadev/muta-sdk-js", () => {
     expect(Number(balance.code)).toBe(0);
     expect(Number(balance.succeedData.balance)).toBe(2077);
 
-    const newMultiSigAccountPayload = {
+    const updateAccountPayload = {
+      account_address: multiSigAddress,
       owner: wangYe.address,
       addr_with_weight: [{ address: wangYe.address, weight: 3 }, { address: qing.address, weight: 1 }],
       threshold: 4,
       memo: 'welcome to BiYouCun'
-    };
-
-    const updateAccountPayload = {
-      account_address: multiSigAddress,
-      new_account_info: newMultiSigAccountPayload,
     };
 
     const update = await multiSigService.write.update_account(updateAccountPayload);
@@ -148,6 +145,7 @@ describe("API test via @mutadev/muta-sdk-js", () => {
 
     var GenerateMultiSigAccountPayload = {
       owner: wangYe.address,
+      autonomy: false,
       addr_with_weight: [{ address: multiSigAddress, weight: 2 }, { address: fei.address, weight: 1 }],
       threshold: 2,
       memo: 'welcome to CiYouCun'


### PR DESCRIPTION
**What type of PR is this?**

fix(multi-sig)!: change interface and substitute adaptive_address for autonomy

BREAKING CHANGE: the interface is changed and affect on all sdk/clients

**What this PR does / why we need it**:

due to the bech32 format, the adaptive address is not suitable.

so we add 'autonomy' field.

B.T.W. change the UpdateAccountPayload to make it non-ambigious
B.T.W. change the genesis payload to remove ambiguity.

Docs is here
https://github.com/HuobiGroup/huobi-chain-docs/pull/8

Java sdk:
https://github.com/nervosnetwork/muta-sdk-java/pull/24

> due to 2 different iteration, the pr of java sdk has been merged. This is a exclusion this time

Js sdk:

https://github.com/nervosnetwork/muta-sdk-js/pull/23