### PR TITLE
feat(network): limit connections from same ip

### DIFF
--- a/core/network/src/common.rs
+++ b/core/network/src/common.rs
@@ -174,7 +174,7 @@ impl Future for HeartBeat {
     }
 }
 
-#[derive(Debug, Display, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[derive(Debug, Display, PartialEq, Eq, Serialize, Deserialize, Clone, Hash)]
 #[display(fmt = "{}:{}", host, port)]
 pub struct ConnectedAddr {
     pub host: String,

--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -18,7 +18,7 @@ use crate::{
     common::socket_to_multi_addr,
     connection::ConnectionConfig,
     error::NetworkError,
-    peer_manager::{ArcPeer, PeerManagerConfig, SharedSessionsConfig, TrustMetricConfig},
+    peer_manager::{ArcPeer, PeerManagerConfig, TrustMetricConfig},
     selfcheck::SelfCheckConfig,
     traits::MultiaddrExt,
     PeerIdExt,
@@ -38,6 +38,8 @@ pub const DEFAULT_BUFFER_SIZE: usize = 24 * 1024 * 1024; // same as tentacle
 pub const DEFAULT_MAX_WAIT_STREAMS: usize = 256;
 // Default write timeout
 pub const DEFAULT_WRITE_TIMEOUT: u64 = 10; // seconds
+
+pub const DEFAULT_SAME_IP_CONN_LIMIT: usize = 1;
 
 // Default peer trust metric
 pub const DEFAULT_PEER_TRUST_INTERVAL_DURATION: Duration = Duration::from_secs(60);
@@ -124,6 +126,7 @@ pub struct NetworkConfig {
     pub peer_trust_max_history: Duration,
     pub peer_fatal_ban:         Duration,
     pub peer_soft_ban:          Duration,
+    pub same_ip_conn_limit:     usize,
 
     // identity and encryption
     pub secio_keypair: SecioKeyPair,
@@ -170,6 +173,7 @@ impl NetworkConfig {
             peer_trust_max_history: DEFAULT_PEER_TRUST_MAX_HISTORY_DURATION,
             peer_fatal_ban:         DEFAULT_PEER_FATAL_BAN_DURATION,
             peer_soft_ban:          DEFAULT_PEER_SOFT_BAN_DURATION,
+            same_ip_conn_limit:     DEFAULT_SAME_IP_CONN_LIMIT,
 
             secio_keypair: SecioKeyPair::secp256k1_generated(),
 
@@ -189,6 +193,14 @@ impl NetworkConfig {
     pub fn max_connections(mut self, max: Option<usize>) -> Self {
         if let Some(max) = max {
             self.max_connections = max;
+        }
+
+        self
+    }
+
+    pub fn same_ip_conn_limit(mut self, limit: Option<usize>) -> Self {
+        if let Some(limit) = limit {
+            self.same_ip_conn_limit = limit;
         }
 
         self
@@ -427,17 +439,18 @@ impl From<&NetworkConfig> for PeerManagerConfig {
             TrustMetricConfig::new(config.peer_trust_interval, config.peer_trust_max_history);
 
         PeerManagerConfig {
-            our_id:            config.secio_keypair.peer_id(),
-            pubkey:            config.secio_keypair.public_key(),
-            bootstraps:        config.bootstraps.clone(),
-            allowlist:         config.allowlist.clone(),
-            allowlist_only:    config.allowlist_only,
-            peer_trust_config: Arc::new(peer_trust_config),
-            peer_fatal_ban:    config.peer_fatal_ban,
-            peer_soft_ban:     config.peer_soft_ban,
-            max_connections:   config.max_connections,
-            routine_interval:  config.peer_manager_heart_beat_interval,
-            peer_dat_file:     config.peer_dat_file.clone(),
+            our_id:             config.secio_keypair.peer_id(),
+            pubkey:             config.secio_keypair.public_key(),
+            bootstraps:         config.bootstraps.clone(),
+            allowlist:          config.allowlist.clone(),
+            allowlist_only:     config.allowlist_only,
+            peer_trust_config:  Arc::new(peer_trust_config),
+            peer_fatal_ban:     config.peer_fatal_ban,
+            peer_soft_ban:      config.peer_soft_ban,
+            max_connections:    config.max_connections,
+            same_ip_conn_limit: config.same_ip_conn_limit,
+            routine_interval:   config.peer_manager_heart_beat_interval,
+            peer_dat_file:      config.peer_dat_file.clone(),
         }
     }
 }
@@ -459,16 +472,6 @@ impl From<&NetworkConfig> for SelfCheckConfig {
     fn from(config: &NetworkConfig) -> SelfCheckConfig {
         SelfCheckConfig {
             interval: config.selfcheck_interval,
-        }
-    }
-}
-
-// TODO: checkout max_frame_length
-impl From<&NetworkConfig> for SharedSessionsConfig {
-    fn from(config: &NetworkConfig) -> Self {
-        SharedSessionsConfig {
-            write_timeout:          config.write_timeout,
-            max_stream_window_size: config.max_frame_length,
         }
     }
 }

--- a/core/network/src/connection/control.rs
+++ b/core/network/src/connection/control.rs
@@ -15,10 +15,10 @@ use protocol::{traits::Priority, Bytes};
 use crate::{
     error::NetworkError,
     event::PeerManagerEvent,
-    traits::{MessageSender, NetworkProtocol, SessionBook},
+    traits::{MessageSender, NetworkProtocol, SharedSessionBook},
 };
 
-pub struct ConnectionServiceControl<P: NetworkProtocol, B: SessionBook> {
+pub struct ConnectionServiceControl<P: NetworkProtocol, B: SharedSessionBook> {
     inner:    ServiceControl,
     mgr_srv:  UnboundedSender<PeerManagerEvent>,
     sessions: B,
@@ -27,7 +27,7 @@ pub struct ConnectionServiceControl<P: NetworkProtocol, B: SessionBook> {
     pin_protocol: PhantomData<fn() -> P>,
 }
 
-impl<P: NetworkProtocol, B: SessionBook> ConnectionServiceControl<P, B> {
+impl<P: NetworkProtocol, B: SharedSessionBook> ConnectionServiceControl<P, B> {
     pub fn new(
         control: ServiceControl,
         mgr_srv: UnboundedSender<PeerManagerEvent>,
@@ -84,7 +84,7 @@ impl<P: NetworkProtocol, B: SessionBook> ConnectionServiceControl<P, B> {
     }
 }
 
-impl<P: NetworkProtocol, B: SessionBook + Clone> Clone for ConnectionServiceControl<P, B> {
+impl<P: NetworkProtocol, B: SharedSessionBook + Clone> Clone for ConnectionServiceControl<P, B> {
     fn clone(&self) -> Self {
         ConnectionServiceControl {
             inner:    self.inner.clone(),
@@ -100,7 +100,7 @@ impl<P: NetworkProtocol, B: SessionBook + Clone> Clone for ConnectionServiceCont
 impl<P, B> MessageSender for ConnectionServiceControl<P, B>
 where
     P: NetworkProtocol,
-    B: SessionBook + Send + Sync + Unpin + 'static,
+    B: SharedSessionBook + Send + Sync + Unpin + 'static,
 {
     fn send(&self, tar: TargetSession, msg: Bytes, pri: Priority) -> Result<(), NetworkError> {
         let proto_id = P::message_proto_id();

--- a/core/network/src/connection/mod.rs
+++ b/core/network/src/connection/mod.rs
@@ -24,7 +24,7 @@ use tentacle::{
 use crate::{
     error::NetworkError,
     event::{ConnectionEvent, PeerManagerEvent},
-    traits::{NetworkProtocol, SessionBook},
+    traits::{NetworkProtocol, SharedSessionBook},
 };
 
 pub struct ConnectionConfig {
@@ -114,7 +114,7 @@ impl<P: NetworkProtocol> ConnectionService<P> {
         Ok(())
     }
 
-    pub fn control<B: SessionBook>(
+    pub fn control<B: SharedSessionBook>(
         &self,
         mgr_tx: UnboundedSender<PeerManagerEvent>,
         book: B,

--- a/core/network/src/metrics.rs
+++ b/core/network/src/metrics.rs
@@ -10,7 +10,7 @@ use futures::task::AtomicWaker;
 
 use crate::{
     common::{ConnectedAddr, HeartBeat},
-    traits::SessionBook,
+    traits::SharedSessionBook,
 };
 
 const METRICS_INTERVAL: Duration = Duration::from_secs(1);
@@ -23,7 +23,7 @@ pub(crate) struct Metrics<S> {
 
 impl<S> Metrics<S>
 where
-    S: SessionBook + Send + Unpin + 'static,
+    S: SharedSessionBook + Send + Unpin + 'static,
 {
     pub fn new(sessions: S) -> Self {
         let waker = Arc::new(AtomicWaker::new());
@@ -60,7 +60,7 @@ where
 
 impl<S> Future for Metrics<S>
 where
-    S: SessionBook + Send + Unpin + 'static,
+    S: SharedSessionBook + Send + Unpin + 'static,
 {
     type Output = ();
 

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -4,6 +4,7 @@ mod addr_set;
 mod peer;
 mod retry;
 mod save_restore;
+mod session_book;
 mod shared;
 mod tags;
 mod time;
@@ -15,65 +16,53 @@ pub mod diagnostic;
 use addr_set::PeerAddrSet;
 use retry::Retry;
 use save_restore::{NoPeerDatFile, PeerDatFile, SaveRestore};
+use session_book::{ArcSession, SessionContext};
 use tags::Tags;
 
 pub use peer::{ArcPeer, Connectedness};
-pub use shared::{SharedSessions, SharedSessionsConfig};
+pub use session_book::SessionBook;
+pub use shared::SharedSessions;
 pub use trust_metric::{TrustMetric, TrustMetricConfig};
 
 #[cfg(test)]
 mod test_manager;
 
-use std::{
-    borrow::Borrow,
-    cmp::PartialEq,
-    collections::HashSet,
-    convert::{TryFrom, TryInto},
-    future::Future,
-    hash::{Hash, Hasher},
-    iter::FromIterator,
-    ops::Deref,
-    path::PathBuf,
-    pin::Pin,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
-    sync::Arc,
-    task::{Context, Poll},
-    time::Duration,
-};
+use std::borrow::Borrow;
+use std::cmp::PartialEq;
+use std::collections::HashSet;
+use std::convert::{TryFrom, TryInto};
+use std::future::Future;
+use std::hash::{Hash, Hasher};
+use std::iter::FromIterator;
+use std::ops::Deref;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
 
 use derive_more::Display;
-use futures::{
-    channel::mpsc::{UnboundedReceiver, UnboundedSender},
-    pin_mut,
-    stream::Stream,
-    task::AtomicWaker,
-};
+use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
+use futures::stream::Stream;
+use futures::task::AtomicWaker;
 use log::{debug, error, info, warn};
 use parking_lot::RwLock;
 use protocol::traits::{PeerTag, TrustFeedback};
 use rand::seq::IteratorRandom;
 use serde_derive::{Deserialize, Serialize};
-#[cfg(not(test))]
-use tentacle::context::SessionContext;
-use tentacle::{
-    multiaddr::Multiaddr,
-    secio::{PeerId, PublicKey},
-    service::{SessionType, TargetProtocol},
-    SessionId,
-};
+use tentacle::multiaddr::Multiaddr;
+use tentacle::secio::{PeerId, PublicKey};
+use tentacle::service::{SessionType, TargetProtocol};
+use tentacle::SessionId;
 
-use crate::{
-    common::{resolve_if_unspecified, ConnectedAddr, HeartBeat},
-    error::{NetworkError, PeerIdNotFound},
-    event::{
-        ConnectionErrorKind, ConnectionEvent, ConnectionType, MisbehaviorKind, PeerManagerEvent,
-        SessionErrorKind,
-    },
-    traits::MultiaddrExt,
+use crate::common::{resolve_if_unspecified, HeartBeat};
+use crate::error::{NetworkError, PeerIdNotFound};
+use crate::event::{
+    ConnectionErrorKind, ConnectionEvent, ConnectionType, MisbehaviorKind, PeerManagerEvent,
+    SessionErrorKind,
 };
-
-#[cfg(test)]
-use crate::test::mock::SessionContext;
+use crate::traits::MultiaddrExt;
 
 const REPEATED_CONNECTION_TIMEOUT: u64 = 30; // seconds
 const BACKOFF_BASE: u64 = 2;
@@ -202,91 +191,24 @@ impl Hash for ConnectingAttempt {
     }
 }
 
-#[derive(Debug)]
-struct Session {
-    id:             SessionId,
-    ctx:            Arc<SessionContext>,
-    peer:           ArcPeer,
-    blocked:        AtomicBool,
-    connected_addr: ConnectedAddr,
-}
-
-#[derive(Debug, Clone)]
-struct ArcSession(Arc<Session>);
-
-impl ArcSession {
-    pub fn new(peer: ArcPeer, ctx: Arc<SessionContext>) -> Self {
-        let connected_addr = ConnectedAddr::from(&ctx.address);
-        let session = Session {
-            id: ctx.id,
-            ctx,
-            peer,
-            blocked: AtomicBool::new(false),
-            connected_addr,
-        };
-
-        ArcSession(Arc::new(session))
-    }
-
-    pub fn block(&self) {
-        self.blocked.store(true, Ordering::SeqCst);
-    }
-
-    pub fn is_blocked(&self) -> bool {
-        self.blocked.load(Ordering::SeqCst)
-    }
-
-    pub fn unblock(&self) {
-        self.blocked.store(false, Ordering::SeqCst);
-    }
-}
-
-impl Borrow<SessionId> for ArcSession {
-    fn borrow(&self) -> &SessionId {
-        &self.id
-    }
-}
-
-impl PartialEq for ArcSession {
-    fn eq(&self, other: &ArcSession) -> bool {
-        self.id == other.id
-    }
-}
-
-impl Eq for ArcSession {}
-
-impl Hash for ArcSession {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id.hash(state)
-    }
-}
-
-impl Deref for ArcSession {
-    type Target = Session;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 struct Inner {
     our_id: Arc<PeerId>,
 
+    sessions:  SessionBook,
     consensus: RwLock<HashSet<PeerId>>,
-    sessions:  RwLock<HashSet<ArcSession>>,
     peers:     RwLock<HashSet<ArcPeer>>,
 
     listen: RwLock<HashSet<PeerMultiaddr>>,
 }
 
 impl Inner {
-    pub fn new(our_id: PeerId) -> Self {
+    pub fn new(our_id: PeerId, sessions: SessionBook) -> Self {
         Inner {
             our_id: Arc::new(our_id),
 
+            sessions,
             consensus: Default::default(),
-            sessions:  Default::default(),
-            peers:     Default::default(),
+            peers: Default::default(),
 
             listen: Default::default(),
         }
@@ -305,7 +227,7 @@ impl Inner {
     }
 
     pub fn connected(&self) -> usize {
-        self.sessions.read().len()
+        self.sessions.len()
     }
 
     /// If peer exists, return false
@@ -346,15 +268,15 @@ impl Inner {
     }
 
     pub fn session(&self, sid: SessionId) -> Option<ArcSession> {
-        self.sessions.read().get(&sid).cloned()
+        self.sessions.get(&sid)
     }
 
     pub fn share_sessions(&self) -> Vec<ArcSession> {
-        self.sessions.read().iter().cloned().collect()
+        self.sessions.all()
     }
 
     pub fn remove_session(&self, sid: SessionId) -> Option<ArcSession> {
-        self.sessions.write().take(&sid)
+        self.sessions.remove(&sid)
     }
 
     pub fn package_peers(&self) -> Vec<ArcPeer> {
@@ -381,6 +303,9 @@ pub struct PeerManagerConfig {
     pub allowlist:      Vec<PeerId>,
     /// Only accept/conect peers in allowlist
     pub allowlist_only: bool,
+
+    /// Limit connections from same ip
+    pub same_ip_conn_limit: usize,
 
     /// Trust metric config
     pub peer_trust_config: Arc<TrustMetricConfig>,
@@ -539,8 +464,10 @@ impl PeerManager {
         conn_tx: UnboundedSender<ConnectionEvent>,
     ) -> Self {
         let peer_id = config.our_id.clone();
+        let session_config = session_book::Config::from(&config);
+        let session_book = SessionBook::new(session_config);
 
-        let inner = Arc::new(Inner::new(config.our_id.clone()));
+        let inner = Arc::new(Inner::new(config.our_id.clone(), session_book));
         let bootstraps = HashSet::from_iter(config.bootstraps.clone());
         let waker = Arc::new(AtomicWaker::new());
         let heart_beat = HeartBeat::new(Arc::clone(&waker), config.routine_interval);
@@ -582,7 +509,7 @@ impl PeerManager {
         }
     }
 
-    pub fn share_session_book(&self, config: SharedSessionsConfig) -> SharedSessions {
+    pub fn share_session_book(&self, config: shared::Config) -> SharedSessions {
         SharedSessions::new(Arc::clone(&self.inner), config)
     }
 
@@ -764,7 +691,14 @@ impl PeerManager {
         let session = ArcSession::new(remote_peer.clone(), Arc::clone(&ctx));
         info!("new session from {}", session.connected_addr);
 
-        self.inner.sessions.write().insert(session);
+        if let Err(err) = self.inner.sessions.insert(session) {
+            warn!("insert session {} failed: {}", ctx.id, err);
+
+            remote_peer.mark_disconnected();
+            self.disconnect_session(ctx.id);
+            return;
+        }
+
         remote_peer.mark_connected(ctx.id);
 
         match remote_peer.trust_metric() {
@@ -1270,7 +1204,7 @@ impl Future for PeerManager {
         // Process manager events
         loop {
             let event_rx = &mut self.as_mut().event_rx;
-            pin_mut!(event_rx);
+            futures::pin_mut!(event_rx);
 
             // service ready in common
             let event = crate::service_ready!("peer manager", event_rx.poll_next(ctx));

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -686,14 +686,6 @@ impl PeerManager {
         let session = ArcSession::new(remote_peer.clone(), Arc::clone(&ctx));
         info!("new session from {}", session.connected_addr);
 
-        // Currently we only save accepted peer.
-        // NOTE: We have to save peer first to be able to ban it. Check out
-        // SAME_IP_LIMIT_BAN.
-        // TODO: save to database
-        if !self.inner.contains(&remote_peer_id) {
-            self.inner.add_peer(remote_peer.clone());
-        }
-
         // Always allow peer in allowlist and consensus peer
         if !remote_peer.tags.contains(&PeerTag::AlwaysAllow)
             && !remote_peer.tags.contains(&PeerTag::Consensus)
@@ -711,6 +703,12 @@ impl PeerManager {
                 self.disconnect_session(ctx.id);
                 return;
             }
+        }
+
+        // Currently we only save accepted peer.
+        // TODO: save to database
+        if !self.inner.contains(&remote_peer_id) {
+            self.inner.add_peer(remote_peer.clone());
         }
 
         self.inner.sessions.insert(AcceptableSession(session));

--- a/core/network/src/peer_manager/session_book.rs
+++ b/core/network/src/peer_manager/session_book.rs
@@ -1,0 +1,296 @@
+use std::borrow::Borrow;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use derive_more::Display;
+use parking_lot::RwLock;
+use tentacle::SessionId;
+
+use super::{ArcPeer, PeerManagerConfig};
+use crate::common::ConnectedAddr;
+
+#[cfg(test)]
+pub use crate::test::mock::SessionContext;
+#[cfg(not(test))]
+pub use tentacle::context::SessionContext;
+
+type Host = String;
+type Count = usize;
+
+#[derive(Debug, Display, PartialEq, Eq)]
+pub enum Error {
+    #[display(fmt = "reach same ip connections limit")]
+    ReachSameIPConnLimit,
+}
+
+#[derive(Debug)]
+pub struct Config {
+    same_ip_conn_limit: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            same_ip_conn_limit: 1,
+        }
+    }
+}
+
+impl From<&PeerManagerConfig> for Config {
+    fn from(config: &PeerManagerConfig) -> Config {
+        Config {
+            same_ip_conn_limit: config.same_ip_conn_limit,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Session {
+    pub(crate) id:             SessionId,
+    pub(crate) ctx:            Arc<SessionContext>,
+    pub(crate) peer:           ArcPeer,
+    blocked:                   AtomicBool,
+    pub(crate) connected_addr: ConnectedAddr,
+}
+
+#[derive(Debug, Clone)]
+pub struct ArcSession(Arc<Session>);
+
+impl ArcSession {
+    pub fn new(peer: ArcPeer, ctx: Arc<SessionContext>) -> Self {
+        let connected_addr = ConnectedAddr::from(&ctx.address);
+        let session = Session {
+            id: ctx.id,
+            ctx,
+            peer,
+            blocked: AtomicBool::new(false),
+            connected_addr,
+        };
+
+        ArcSession(Arc::new(session))
+    }
+
+    pub fn block(&self) {
+        self.blocked.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_blocked(&self) -> bool {
+        self.blocked.load(Ordering::SeqCst)
+    }
+
+    pub fn unblock(&self) {
+        self.blocked.store(false, Ordering::SeqCst);
+    }
+}
+
+impl Borrow<SessionId> for ArcSession {
+    fn borrow(&self) -> &SessionId {
+        &self.id
+    }
+}
+
+impl PartialEq for ArcSession {
+    fn eq(&self, other: &ArcSession) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for ArcSession {}
+
+impl Hash for ArcSession {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state)
+    }
+}
+
+impl Deref for ArcSession {
+    type Target = Session;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct SessionBook {
+    config: Config,
+
+    hosts:    RwLock<HashMap<Host, Count>>,
+    sessions: RwLock<HashSet<ArcSession>>,
+}
+
+impl Default for SessionBook {
+    fn default() -> SessionBook {
+        let config = Config::default();
+
+        SessionBook::new(config)
+    }
+}
+
+impl SessionBook {
+    pub fn new(config: Config) -> Self {
+        SessionBook {
+            config,
+            hosts: Default::default(),
+            sessions: Default::default(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.sessions.read().len()
+    }
+
+    pub fn get(&self, sid: &SessionId) -> Option<ArcSession> {
+        self.sessions.read().get(sid).cloned()
+    }
+
+    pub fn all(&self) -> Vec<ArcSession> {
+        self.sessions.read().iter().cloned().collect()
+    }
+
+    pub fn iter_fn<R, F>(&self, f: F) -> R
+    where
+        F: for<'a> FnOnce(&mut dyn Iterator<Item = &'a ArcSession>) -> R,
+    {
+        let sessions = self.sessions.read();
+        f(&mut sessions.iter())
+    }
+
+    pub fn insert(&self, session: ArcSession) -> Result<(), self::Error> {
+        let session_host = &session.connected_addr.host;
+        let host_count = {
+            let mut hosts = self.hosts.write();
+            *hosts.entry(session_host.to_owned()).or_insert(0)
+        };
+
+        if host_count == usize::MAX || host_count + 1 > self.config.same_ip_conn_limit {
+            return Err(self::Error::ReachSameIPConnLimit);
+        }
+
+        {
+            let mut hosts = self.hosts.write();
+            if let Some(count) = hosts.get_mut(session_host) {
+                *count += 1;
+            }
+            self.sessions.write().insert(session);
+        }
+
+        Ok(())
+    }
+
+    pub fn remove(&self, sid: &SessionId) -> Option<ArcSession> {
+        let session = self.sessions.write().take(sid);
+
+        if let Some(connected_addr) = session.as_ref().map(|s| &s.connected_addr) {
+            let session_host = &connected_addr.host;
+            let mut hosts = self.hosts.write();
+
+            if hosts.get(session_host) == Some(&1) {
+                hosts.remove(session_host);
+            } else if let Some(count) = hosts.get_mut(session_host) {
+                *count -= 1;
+            }
+        }
+
+        session
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryInto;
+    use std::sync::Arc;
+
+    use tentacle::multiaddr::Multiaddr;
+    use tentacle::secio::{PeerId, SecioKeyPair};
+    use tentacle::service::SessionType;
+    use tentacle::SessionId;
+
+    use super::{ArcSession, Config, Error, SessionBook};
+    use crate::peer_manager::{ArcPeer, PeerMultiaddr};
+    use crate::test::mock::SessionContext;
+    use crate::traits::MultiaddrExt;
+
+    fn make_multiaddr(port: u16, id: Option<PeerId>) -> Multiaddr {
+        let mut multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
+            .parse::<Multiaddr>()
+            .expect("peer multiaddr");
+
+        if let Some(id) = id {
+            multiaddr.push_id(id);
+        }
+
+        multiaddr
+    }
+
+    fn make_peer_multiaddr(port: u16, id: PeerId) -> PeerMultiaddr {
+        make_multiaddr(port, Some(id))
+            .try_into()
+            .expect("try into peer multiaddr")
+    }
+
+    fn make_peer(port: u16) -> ArcPeer {
+        let keypair = SecioKeyPair::secp256k1_generated();
+        let pubkey = keypair.public_key();
+        let peer_id = pubkey.peer_id();
+        let peer = ArcPeer::from_pubkey(pubkey).expect("make peer");
+        let multiaddr = make_peer_multiaddr(port, peer_id);
+
+        peer.multiaddrs.set(vec![multiaddr]);
+        peer
+    }
+
+    fn make_session(port: u16, sid: SessionId) -> ArcSession {
+        let peer = make_peer(port);
+        let multiaddr = peer.multiaddrs.all_raw().pop().unwrap();
+        let ctx = SessionContext::make(
+            sid,
+            multiaddr,
+            SessionType::Outbound,
+            peer.owned_pubkey().unwrap(),
+        );
+
+        ArcSession::new(peer, Arc::new(ctx))
+    }
+
+    #[test]
+    fn should_reject_session_when_reach_same_ip_conn_limit() {
+        let config = Config {
+            same_ip_conn_limit: 1,
+        };
+        let book = SessionBook::new(config);
+
+        let session = make_session(100, 1.into());
+        assert!(book.insert(session.clone()).is_ok());
+        assert_eq!(
+            book.hosts.read().get(&session.connected_addr.host),
+            Some(&1)
+        );
+
+        let same_ip_session = make_session(101, 2.into());
+        assert_eq!(
+            book.insert(same_ip_session),
+            Err(Error::ReachSameIPConnLimit)
+        );
+    }
+
+    #[test]
+    fn should_reduce_host_count() {
+        let config = Config {
+            same_ip_conn_limit: 5,
+        };
+        let book = SessionBook::new(config);
+
+        let session = make_session(100, 1.into());
+        assert!(book.insert(session.clone()).is_ok());
+        assert_eq!(
+            book.hosts.read().get(&session.connected_addr.host),
+            Some(&1)
+        );
+
+        book.remove(&(1.into()));
+        assert_eq!(book.hosts.read().get(&session.connected_addr.host), None);
+    }
+}

--- a/core/network/src/peer_manager/shared.rs
+++ b/core/network/src/peer_manager/shared.rs
@@ -1,65 +1,69 @@
-use super::{ArcSession, Connectedness, Inner};
-use crate::{common::ConnectedAddr, traits::SessionBook};
+use std::sync::Arc;
 
 use log::debug;
-use parking_lot::RwLock;
 use protocol::traits::PeerTag;
-use tentacle::{secio::PeerId, SessionId};
+use tentacle::secio::PeerId;
+use tentacle::SessionId;
 
-use std::{collections::HashSet, sync::Arc};
+use super::{Connectedness, Inner};
+use crate::common::ConnectedAddr;
+use crate::peer_manager::SessionBook;
+use crate::traits::SharedSessionBook;
+use crate::NetworkConfig;
 
-pub struct SharedSessionsConfig {
+pub struct Config {
     pub max_stream_window_size: usize,
     pub write_timeout:          u64,
+}
+
+// TODO: checkout max_frame_length
+impl From<&NetworkConfig> for Config {
+    fn from(config: &NetworkConfig) -> Self {
+        Config {
+            write_timeout:          config.write_timeout,
+            max_stream_window_size: config.max_frame_length,
+        }
+    }
 }
 
 #[derive(Clone)]
 pub struct SharedSessions {
     inner:  Arc<Inner>,
-    config: Arc<SharedSessionsConfig>,
+    config: Arc<Config>,
 }
 
 impl SharedSessions {
-    pub(super) fn new(inner: Arc<Inner>, config: SharedSessionsConfig) -> Self {
+    pub(super) fn new(inner: Arc<Inner>, config: Config) -> Self {
         SharedSessions {
             inner,
             config: Arc::new(config),
         }
     }
 
-    fn sessions(&self) -> &RwLock<HashSet<ArcSession>> {
+    fn sessions(&self) -> &SessionBook {
         &self.inner.sessions
     }
 }
 
-impl SessionBook for SharedSessions {
+impl SharedSessionBook for SharedSessions {
     fn all_sendable(&self) -> Vec<SessionId> {
-        self.sessions()
-            .read()
-            .iter()
-            .filter(|s| !s.is_blocked())
-            .map(|s| s.id)
-            .collect()
+        self.sessions().iter_fn(|iter| {
+            iter.filter_map(|s| if !s.is_blocked() { Some(s.id) } else { None })
+                .collect()
+        })
     }
 
     fn all_blocked(&self) -> Vec<SessionId> {
-        self.sessions()
-            .read()
-            .iter()
-            .filter(|s| s.is_blocked())
-            .map(|s| s.id)
-            .collect()
+        self.sessions().iter_fn(|iter| {
+            iter.filter_map(|s| if s.is_blocked() { Some(s.id) } else { None })
+                .collect()
+        })
     }
 
     fn refresh_blocked(&self) {
-        let all_blocked = {
-            self.sessions()
-                .read()
-                .iter()
-                .filter(|s| s.is_blocked())
-                .cloned()
-                .collect::<Vec<_>>()
-        };
+        let all_blocked = self
+            .sessions()
+            .iter_fn(|iter| iter.filter(|s| s.is_blocked()).cloned().collect::<Vec<_>>());
 
         for session in all_blocked {
             let pending_data_size = session.ctx.pending_data_size();
@@ -90,29 +94,25 @@ impl SessionBook for SharedSessions {
     }
 
     fn all(&self) -> Vec<SessionId> {
-        self.sessions().read().iter().map(|s| s.id).collect()
+        self.sessions().iter_fn(|iter| iter.map(|s| s.id).collect())
     }
 
     fn connected_addr(&self, sid: SessionId) -> Option<ConnectedAddr> {
         self.sessions()
-            .read()
             .get(&sid)
             .map(|s| s.connected_addr.to_owned())
     }
 
     fn pending_data_size(&self, sid: SessionId) -> usize {
         self.sessions()
-            .read()
             .get(&sid)
             .map(|s| s.ctx.pending_data_size())
             .unwrap_or_else(|| 0)
     }
 
     fn allowlist(&self) -> Vec<PeerId> {
-        self.sessions()
-            .read()
-            .iter()
-            .filter_map(|s| {
+        self.sessions().iter_fn(|iter| {
+            iter.filter_map(|s| {
                 if s.peer.tags.contains(&PeerTag::AlwaysAllow) {
                     Some(s.peer.id.to_owned())
                 } else {
@@ -120,13 +120,14 @@ impl SessionBook for SharedSessions {
                 }
             })
             .collect()
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{SessionBook, SharedSessions, SharedSessionsConfig};
-    use crate::peer_manager::Inner;
+    use super::{Config, SharedSessionBook, SharedSessions};
+    use crate::peer_manager::{Inner, SessionBook};
 
     use tentacle::secio::SecioKeyPair;
 
@@ -134,7 +135,7 @@ mod tests {
 
     #[test]
     fn should_return_unconnected_peer_ids() {
-        let sess_conf = SharedSessionsConfig {
+        let sess_conf = Config {
             max_stream_window_size: 10,
             write_timeout:          10,
         };
@@ -143,7 +144,7 @@ mod tests {
         let pubkey = keypair.public_key();
         let self_peer_id = pubkey.peer_id();
 
-        let inner = Arc::new(Inner::new(self_peer_id));
+        let inner = Arc::new(Inner::new(self_peer_id, SessionBook::default()));
         let sessions = SharedSessions::new(Arc::clone(&inner), sess_conf);
 
         let keypair = SecioKeyPair::secp256k1_generated();

--- a/core/network/src/peer_manager/test_manager.rs
+++ b/core/network/src/peer_manager/test_manager.rs
@@ -2824,6 +2824,10 @@ async fn should_reject_same_ip_connection_when_reach_limit_on_new_session() {
     let same_ip_peer = make_peer(9527);
     let expect_sid = same_ip_peer.session_id();
 
+    // Save same ip peer
+    let inner = mgr.core_inner();
+    inner.add_peer(same_ip_peer.clone());
+
     let sess_ctx = SessionContext::make(
         SessionId::new(99),
         same_ip_peer.multiaddrs.all_raw().pop().unwrap(),
@@ -2837,7 +2841,6 @@ async fn should_reject_same_ip_connection_when_reach_limit_on_new_session() {
     };
     mgr.poll_event(new_session).await;
 
-    let inner = mgr.core_inner();
     assert_eq!(inner.connected(), 1, "should not increase conn count");
     assert_eq!(
         same_ip_peer.session_id(),

--- a/core/network/src/peer_manager/test_manager.rs
+++ b/core/network/src/peer_manager/test_manager.rs
@@ -1,7 +1,8 @@
 use super::{
     time, ArcPeer, Connectedness, ConnectingAttempt, Inner, MisbehaviorKind, PeerManager,
     PeerManagerConfig, PeerMultiaddr, TrustMetric, TrustMetricConfig, GOOD_TRUST_SCORE,
-    MAX_CONNECTING_MARGIN, MAX_RETRY_COUNT, REPEATED_CONNECTION_TIMEOUT, SHORT_ALIVE_SESSION,
+    MAX_CONNECTING_MARGIN, MAX_RETRY_COUNT, REPEATED_CONNECTION_TIMEOUT, SAME_IP_LIMIT_BAN,
+    SHORT_ALIVE_SESSION,
 };
 use crate::{
     common::ConnectedAddr,
@@ -2842,6 +2843,12 @@ async fn should_reject_same_ip_connection_when_reach_limit_on_new_session() {
         same_ip_peer.session_id(),
         expect_sid,
         "should not change peer session id"
+    );
+
+    let inserted_same_ip_peer = inner.peer(&same_ip_peer.id).unwrap();
+    assert_eq!(
+        inserted_same_ip_peer.tags.get_banned_until(),
+        Some(time::now() + SAME_IP_LIMIT_BAN.as_secs())
     );
 
     let conn_event = conn_rx.next().await.expect("should have disconnect event");

--- a/core/network/src/peer_manager/test_manager.rs
+++ b/core/network/src/peer_manager/test_manager.rs
@@ -144,6 +144,7 @@ fn make_manager(
         peer_fatal_ban,
         peer_soft_ban,
         max_connections,
+        same_ip_conn_limit: 99,
         routine_interval: Duration::from_secs(10),
         peer_dat_file,
     };
@@ -249,8 +250,7 @@ async fn should_accept_outbound_connection_and_remove_mached_connecting_on_new_s
     assert_eq!(
         mgr.connecting().len(),
         1,
-        "should have one connecting
-attempt"
+        "should have one connecting attempt"
     );
 
     let sess_ctx = SessionContext::make(
@@ -2205,6 +2205,7 @@ async fn should_only_connect_peers_in_allowlist_if_enable_allowlist_only() {
         peer_fatal_ban,
         peer_soft_ban,
         max_connections: 10,
+        same_ip_conn_limit: 99,
         routine_interval: Duration::from_secs(10),
         peer_dat_file,
     };
@@ -2268,6 +2269,7 @@ async fn should_only_accept_incoming_from_peer_in_allowlist_if_enable_allowlist_
         peer_fatal_ban,
         peer_soft_ban,
         max_connections: 10,
+        same_ip_conn_limit: 9,
         routine_interval: Duration::from_secs(10),
         peer_dat_file,
     };
@@ -2784,4 +2786,67 @@ async fn should_remove_old_consensus_peer_tag_when_tag_consensus() {
     let new_consensus = mgr.core_inner().peer(&new_consensus.id).unwrap();
     assert!(new_consensus.tags.contains(&PeerTag::Consensus));
     assert!(!peer.tags.contains(&PeerTag::Consensus));
+}
+
+#[tokio::test]
+async fn should_reject_same_ip_connection_when_reach_limit_on_new_session() {
+    let manager_pubkey = make_pubkey();
+    let manager_id = manager_pubkey.peer_id();
+    let mut peer_dat_file = std::env::temp_dir();
+    peer_dat_file.push("peer.dat");
+    let peer_trust_config = Arc::new(TrustMetricConfig::default());
+    let peer_fatal_ban = Duration::from_secs(50);
+    let peer_soft_ban = Duration::from_secs(10);
+
+    let config = PeerManagerConfig {
+        our_id: manager_id,
+        pubkey: manager_pubkey,
+        bootstraps: Default::default(),
+        allowlist: vec![],
+        allowlist_only: false,
+        peer_trust_config,
+        peer_fatal_ban,
+        peer_soft_ban,
+        max_connections: 10,
+        same_ip_conn_limit: 1,
+        routine_interval: Duration::from_secs(10),
+        peer_dat_file,
+    };
+
+    let (conn_tx, mut conn_rx) = unbounded();
+    let (mgr_tx, mgr_rx) = unbounded();
+    let manager = PeerManager::new(config, mgr_rx, conn_tx);
+
+    let mut mgr = MockManager::new(manager, mgr_tx);
+    make_sessions(&mut mgr, 1, 5000).await;
+
+    let same_ip_peer = make_peer(9527);
+    let expect_sid = same_ip_peer.session_id();
+
+    let sess_ctx = SessionContext::make(
+        SessionId::new(99),
+        same_ip_peer.multiaddrs.all_raw().pop().unwrap(),
+        SessionType::Outbound,
+        same_ip_peer.owned_pubkey().expect("pubkey"),
+    );
+    let new_session = PeerManagerEvent::NewSession {
+        pid:    same_ip_peer.owned_id(),
+        pubkey: same_ip_peer.owned_pubkey().expect("pubkey"),
+        ctx:    sess_ctx.arced(),
+    };
+    mgr.poll_event(new_session).await;
+
+    let inner = mgr.core_inner();
+    assert_eq!(inner.connected(), 1, "should not increase conn count");
+    assert_eq!(
+        same_ip_peer.session_id(),
+        expect_sid,
+        "should not change peer session id"
+    );
+
+    let conn_event = conn_rx.next().await.expect("should have disconnect event");
+    match conn_event {
+        ConnectionEvent::Disconnect(sid) => assert_eq!(sid, 99.into(), "should be new session id"),
+        _ => panic!("should be disconnect event"),
+    }
 }

--- a/core/network/src/reactor/router.rs
+++ b/core/network/src/reactor/router.rs
@@ -20,7 +20,7 @@ use crate::{
     error::{ErrorKind, NetworkError},
     event::PeerManagerEvent,
     message::{NetworkMessage, RawSessionMessage, SessionMessage},
-    traits::{Compression, SessionBook},
+    traits::{Compression, SharedSessionBook},
 };
 
 pub struct MessageRouter<C, S> {
@@ -46,7 +46,7 @@ pub struct MessageRouter<C, S> {
 impl<C, S> MessageRouter<C, S>
 where
     C: Compression + Send + Unpin + Clone + 'static,
-    S: SessionBook + Send + Unpin + Clone + 'static,
+    S: SharedSessionBook + Send + Unpin + Clone + 'static,
 {
     pub fn new(
         raw_msg_rx: UnboundedReceiver<RawSessionMessage>,
@@ -121,7 +121,7 @@ where
 impl<C, S> Future for MessageRouter<C, S>
 where
     C: Compression + Send + Unpin + Clone + 'static,
-    S: SessionBook + Send + Unpin + Clone + 'static,
+    S: SharedSessionBook + Send + Unpin + Clone + 'static,
 {
     type Output = ();
 

--- a/core/network/src/selfcheck.rs
+++ b/core/network/src/selfcheck.rs
@@ -9,7 +9,7 @@ use std::{
 use futures::task::AtomicWaker;
 use log::info;
 
-use crate::{common::HeartBeat, traits::SessionBook};
+use crate::{common::HeartBeat, traits::SharedSessionBook};
 
 pub struct SelfCheckConfig {
     pub interval: Duration,
@@ -23,7 +23,7 @@ pub(crate) struct SelfCheck<S> {
 
 impl<S> SelfCheck<S>
 where
-    S: SessionBook + Send + Unpin + 'static,
+    S: SharedSessionBook + Send + Unpin + 'static,
 {
     pub fn new(sessions: S, config: SelfCheckConfig) -> Self {
         let waker = Arc::new(AtomicWaker::new());
@@ -66,7 +66,7 @@ where
 
 impl<S> Future for SelfCheck<S>
 where
-    S: SessionBook + Send + Unpin + 'static,
+    S: SharedSessionBook + Send + Unpin + 'static,
 {
     type Output = ();
 

--- a/core/network/src/test/mock.rs
+++ b/core/network/src/test/mock.rs
@@ -1,9 +1,10 @@
-use tentacle::{multiaddr::Multiaddr, secio::PublicKey, service::SessionType, SessionId};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
-};
+use tentacle::multiaddr::Multiaddr;
+use tentacle::secio::PublicKey;
+use tentacle::service::SessionType;
+use tentacle::SessionId;
 
 #[derive(Clone, Debug)]
 pub struct SessionContext {

--- a/core/network/src/traits.rs
+++ b/core/network/src/traits.rs
@@ -56,7 +56,7 @@ pub trait ListenExchangeManager {
     fn misbehave(&mut self, sid: SessionId);
 }
 
-pub trait SessionBook {
+pub trait SharedSessionBook {
     fn all_sendable(&self) -> Vec<SessionId>;
     fn all_blocked(&self) -> Vec<SessionId>;
     fn refresh_blocked(&self);

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,7 @@ pub struct ConfigNetwork {
     pub fatal_ban_duration:         Option<u64>,
     pub soft_ban_duration:          Option<u64>,
     pub max_connected_peers:        Option<usize>,
+    pub same_ip_conn_limit:         Option<usize>,
     pub listening_address:          SocketAddr,
     pub rpc_timeout:                Option<u64>,
     pub selfcheck_interval:         Option<u64>,

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -167,6 +167,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     // Init network
     let network_config = NetworkConfig::new()
         .max_connections(config.network.max_connected_peers)
+        .same_ip_conn_limit(config.network.same_ip_conn_limit)
         .allowlist_only(config.network.allowlist_only)
         .peer_trust_metric(
             config.network.trust_interval_duration,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
feat

**What this PR does / why we need it**:
Restrict connections from same ip. Add ```same_ip_conn_limit``` to network configuration, default value is 1.
We'll reject new connections from ip which reach connection limit.

[DOC PR](https://github.com/nervosnetwork/muta-docs/pull/38)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
