### PR TITLE
feat(sync): Limit the maximum height of once sync

### DIFF
--- a/common/apm/src/metrics/consensus.rs
+++ b/common/apm/src/metrics/consensus.rs
@@ -41,12 +41,6 @@ make_auto_flush_static_metric! {
 }
 
 lazy_static! {
-    pub static ref CONSENSUS_HEIGHT_PLUS_PLUS_VEC: IntCounterVec = register_int_counter_vec!(
-        "muta_concensus_height_plus_plus",
-        "Height plus plus by consensus or sync",
-        &["type"]
-    )
-    .unwrap();
     pub static ref CONSENSUS_RESULT_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
         "muta_concensus_result",
         "Total number of consensus result",

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -153,7 +153,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
         } else {
             remote_height + ONCE_SYNC_BLOCK_LIMIT
         };
-    
+
         let mut current_consented_height = current_height;
 
         while current_consented_height < remote_height {

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -492,7 +492,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
     }
 
     fn update_status(&self, ctx: Context, sync_status_agent: StatusAgent) -> ProtocolResult<()> {
-        let sync_status = sync_status_agent.to_inner().clone();
+        let sync_status = sync_status_agent.to_inner();
 
         self.status.replace(sync_status.clone());
         self.adapter.update_status(

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -151,7 +151,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
         let remote_height = if current_height + ONCE_SYNC_BLOCK_LIMIT > remote_height {
             remote_height
         } else {
-            remote_height + ONCE_SYNC_BLOCK_LIMIT
+            current_height + ONCE_SYNC_BLOCK_LIMIT
         };
 
         let mut current_consented_height = current_height;

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -496,7 +496,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
 
         self.status.replace(sync_status.clone());
         self.adapter.update_status(
-            ctx.clone(),
+            ctx,
             sync_status.latest_committed_height,
             sync_status.consensus_interval,
             sync_status.propose_ratio,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
feat

**What this PR does / why we need it**:
Each successful download of 50 blocks will complete synchronization to avoid downloading too many blocks from a single node, which will affect the success rate of network transmission.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
