### PR TITLE
feat(benchmark): add a perf benchmark macro

### DIFF
--- a/benchmark/bench.rs
+++ b/benchmark/bench.rs
@@ -22,3 +22,25 @@ fn bench_execute(b: &mut Bencher) {
 
     benchmark!(req, 1_000, b);
 }
+
+#[rustfmt::skip]
+/// 10 assets bench::perf_execute  ... bench: 109,202,563 ns/iter (+/- 6,378,009)
+/// 100 assets bench::perf_execute  ... bench: 108,859,512 ns/iter (+/- 2,977,622)
+/// 1000 assets bench::bench_execute ... bench: 108,037,404 ns/iter (+/- 4,539,634)
+/// 10000 assets test bench::perf_execute  ... bench: 100,244,123 ns/iter (+/- 18,935,087)
+#[bench]
+fn perf_execute(b: &mut Bencher) {
+    let payload = TransferPayload {
+        asset_id: NATIVE_ASSET_ID.clone(),
+        to:       FEE_INLET_ACCOUNT.clone(),
+        value:    1u64,
+    };
+
+    let req = TransactionRequest {
+        service_name: "asset".to_string(),
+        method:       "transfer".to_string(),
+        payload:      serde_json::to_string(&payload).unwrap(),
+    };
+
+    perf_exec!(1_000, req, 1_000, b);
+}

--- a/benchmark/mod.rs
+++ b/benchmark/mod.rs
@@ -74,6 +74,72 @@ macro_rules! benchmark {
     }};
 }
 
+macro_rules! perf_exec {
+    ($assets_num: expr, $payload: expr, $num: expr, $bencher: expr) => {{
+        let memdb = Arc::new(RocksTrieDB::new("./free-space/state", false, 1024).unwrap());
+
+        let rocks_adapter = Arc::new(RocksAdapter::new("./free-space/block", 1024).unwrap());
+
+        let storage = Arc::new(ImplStorage::new(Arc::clone(&rocks_adapter)));
+        let toml_str = include_str!("./benchmark_genesis.toml");
+        let genesis: Genesis = toml::from_str(toml_str).unwrap();
+
+        let root = ServiceExecutor::create_genesis(
+            genesis.services,
+            Arc::clone(&memdb),
+            Arc::clone(&storage),
+            Arc::new(MockServiceMapping {}),
+        )
+        .unwrap();
+
+        let create_asset_txs = (0..$assets_num)
+            .map(|n| {
+                let payload = asset::types::CreateAssetPayload {
+                    name:   "muta_".to_string() + n.to_string().as_str(),
+                    symbol: "muta_".to_string() + n.to_string().as_str(),
+                    supply: 100_000,
+                };
+
+                construct_stx(TransactionRequest {
+                    service_name: "asset".to_string(),
+                    method:       "create_asset".to_string(),
+                    payload:      serde_json::to_string(&payload).unwrap(),
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let stxs = (0..$num)
+            .map(|_| construct_stx($payload.clone()))
+            .collect::<Vec<_>>();
+
+        let mut params = ExecutorParams {
+            state_root:   root.clone(),
+            height:       1,
+            timestamp:    0,
+            cycles_limit: u64::max_value(),
+            proposer:     PROPOSER_ACCOUNT.clone(),
+        };
+
+        let mut executor = ServiceExecutor::with_root(
+            root,
+            Arc::clone(&memdb),
+            Arc::clone(&storage),
+            Arc::new(MockServiceMapping {}),
+        )
+        .unwrap();
+
+        let resp = executor.exec(Context::new(), &params, &create_asset_txs).unwrap();
+        params.state_root = resp.state_root;
+        params.height += 1;
+        params.timestamp += 2;
+
+        $bencher.iter(|| {
+            let txs = stxs.clone();
+            executor.exec(Context::new(), &params, &txs).unwrap();
+        });
+    }};
+}
+
 mod bench;
 // This is a test service that provides transaction hooks.
 mod governance;

--- a/benchmark/mod.rs
+++ b/benchmark/mod.rs
@@ -128,7 +128,9 @@ macro_rules! perf_exec {
         )
         .unwrap();
 
-        let resp = executor.exec(Context::new(), &params, &create_asset_txs).unwrap();
+        let resp = executor
+            .exec(Context::new(), &params, &create_asset_txs)
+            .unwrap();
         params.state_root = resp.state_root;
         params.height += 1;
         params.timestamp += 2;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
feat

**What this PR does / why we need it**:
Add a perf benchmark macro to do benchmark when assets exist.

```log
10 assets bench::perf_execute  ... bench: 109,202,563 ns/iter (+/- 6,378,009)
100 assets bench::perf_execute  ... bench: 108,859,512 ns/iter (+/- 2,977,622)
1000 assets bench::perf_execute ... bench: 108,037,404 ns/iter (+/- 4,539,634)
10000 asset bench::perf_execute  ... bench: 100,244,123 ns/iter (+/- 18,935,087)
```

It seems that performance has nothing to do with the number of existing assets.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
