### PR TITLE
refactor(service): change service interface return type

### DIFF
--- a/benchmark/governance/mod.rs
+++ b/benchmark/governance/mod.rs
@@ -9,6 +9,7 @@ use derive_more::{Display, From};
 
 use binding_macro::{genesis, hook_after, service, tx_hook_after, tx_hook_before};
 use protocol::traits::{ExecutorParams, ServiceResponse, ServiceSDK, StoreMap};
+use protocol::try_service_response;
 use protocol::types::{Address, Hash, ServiceContext, ServiceContextParams};
 
 use asset::types::TransferPayload;
@@ -86,10 +87,9 @@ impl<A: Assets, SDK: ServiceSDK> GovernanceService<A, SDK> {
         };
 
         // Pledge the tx failure fee before executed the transaction.
-        match self.asset.transfer_(&ctx, payload) {
-            Ok(_) => ServiceResponse::from_succeed("".to_owned()),
-            Err(e) => ServiceResponse::from_error(e.code, e.error_message),
-        }
+        let res = self.asset.transfer_(&ctx, payload);
+        try_service_response!(res);
+        ServiceResponse::from_succeed(String::new())
     }
 
     #[tx_hook_after]
@@ -108,10 +108,9 @@ impl<A: Assets, SDK: ServiceSDK> GovernanceService<A, SDK> {
             value:    1,
         };
 
-        match self.asset.transfer_(&ctx, payload) {
-            Ok(_) => ServiceResponse::from_succeed("".to_owned()),
-            Err(e) => ServiceResponse::from_error(e.code, e.error_message),
-        }
+        let res = self.asset.transfer_(&ctx, payload);
+        try_service_response!(res);
+        ServiceResponse::from_succeed(String::new())
     }
 
     #[hook_after]

--- a/built-in-services/metadata/src/lib.rs
+++ b/built-in-services/metadata/src/lib.rs
@@ -5,6 +5,8 @@ use binding_macro::{cycles, genesis, service};
 use protocol::traits::{ExecutorParams, ServiceResponse, ServiceSDK};
 use protocol::types::{Metadata, ServiceContext, METADATA_KEY};
 
+pub const METADATA_SERVICE_NAME: &str = "metadata";
+
 pub trait MetaData {
     fn get_(&self, ctx: &ServiceContext) -> ServiceResponse<Metadata>;
 }

--- a/built-in-services/metadata/src/lib.rs
+++ b/built-in-services/metadata/src/lib.rs
@@ -5,29 +5,8 @@ use binding_macro::{cycles, genesis, service};
 use protocol::traits::{ExecutorParams, ServiceResponse, ServiceSDK};
 use protocol::types::{Metadata, ServiceContext, METADATA_KEY};
 
-macro_rules! impl_meatdata {
-    ($self: expr, $method: ident, $ctx: expr) => {{
-        let res = $self.$method($ctx.clone());
-        if res.is_error() {
-            Err(ServiceResponse::from_error(res.code, res.error_message))
-        } else {
-            Ok(res.succeed_data)
-        }
-    }};
-    ($self: expr, $method: ident, $ctx: expr, $payload: expr) => {{
-        let res = $self.$method($ctx.clone(), $payload);
-        if res.is_error() {
-            Err(ServiceResponse::from_error(res.code, res.error_message))
-        } else {
-            Ok(res.succeed_data)
-        }
-    }};
-}
-
-pub const METADATA_SERVICE_NAME: &str = "metadata";
-
 pub trait MetaData {
-    fn get_(&self, ctx: &ServiceContext) -> Result<Metadata, ServiceResponse<()>>;
+    fn get_(&self, ctx: &ServiceContext) -> ServiceResponse<Metadata>;
 }
 
 pub struct MetadataService<SDK> {
@@ -35,8 +14,8 @@ pub struct MetadataService<SDK> {
 }
 
 impl<SDK: ServiceSDK> MetaData for MetadataService<SDK> {
-    fn get_(&self, ctx: &ServiceContext) -> Result<Metadata, ServiceResponse<()>> {
-        impl_meatdata!(self, get_metadata, ctx)
+    fn get_(&self, ctx: &ServiceContext) -> ServiceResponse<Metadata> {
+        self.get_metadata(ctx.clone())
     }
 }
 

--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -20,6 +20,7 @@ use crate::types::{
     UpdateAccountPayload, VerifySignaturePayload, Witness,
 };
 
+pub const MULTI_SIG_SERVICE_NAME: &str = "multi_signature";
 const MAX_MULTI_SIGNATURE_RECURSION_DEPTH: u8 = 8;
 const MAX_PERMISSION_ACCOUNTS: u8 = 16;
 

--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 use std::panic::catch_unwind;
 
 use binding_macro::{cycles, genesis, service};
-
 use common_crypto::{Crypto, Secp256k1};
 use protocol::traits::{ExecutorParams, ServiceResponse, ServiceSDK};
 use protocol::types::{Address, Bytes, Hash, ServiceContext, SignedTransaction};
@@ -24,38 +23,23 @@ use crate::types::{
 const MAX_MULTI_SIGNATURE_RECURSION_DEPTH: u8 = 8;
 const MAX_PERMISSION_ACCOUNTS: u8 = 16;
 
-macro_rules! impl_multisig {
-    ($self: expr, $method: ident, $ctx: expr) => {{
-        let res = $self.$method($ctx.clone());
-        if res.is_error() {
-            Err(ServiceResponse::from_error(res.code, res.error_message))
-        } else {
-            Ok(res.succeed_data)
-        }
-    }};
-    ($self: expr, $method: ident, $ctx: expr, $payload: expr) => {{
-        let res = $self.$method($ctx.clone(), $payload);
-        if res.is_error() {
-            Err(ServiceResponse::from_error(res.code, res.error_message))
-        } else {
-            Ok(res.succeed_data)
-        }
-    }};
+lazy_static::lazy_static! {
+   // FIXME:
+   pub static ref ADEPTIVE_ADDRESS: Address = "muta14e0lmgck835vm2dfm0w3ckv6svmez8fdgdl705".parse().unwrap();
 }
-pub const MULTI_SIG_SERVICE_NAME: &str = "multi_signature";
 
 pub trait MultiSignature {
     fn verify_signature_(
         &self,
         ctx: &ServiceContext,
         payload: SignedTransaction,
-    ) -> Result<(), ServiceResponse<()>>;
+    ) -> ServiceResponse<()>;
 
     fn generate_account_(
         &mut self,
         ctx: &ServiceContext,
         payload: GenerateMultiSigAccountPayload,
-    ) -> Result<GenerateMultiSigAccountResponse, ServiceResponse<()>>;
+    ) -> ServiceResponse<GenerateMultiSigAccountResponse>;
 }
 
 pub struct MultiSignatureService<SDK> {
@@ -67,16 +51,16 @@ impl<SDK: ServiceSDK> MultiSignature for MultiSignatureService<SDK> {
         &self,
         ctx: &ServiceContext,
         payload: SignedTransaction,
-    ) -> Result<(), ServiceResponse<()>> {
-        impl_multisig!(self, verify_signature, ctx, payload)
+    ) -> ServiceResponse<()> {
+        self.verify_signature(ctx.clone(), payload)
     }
 
     fn generate_account_(
         &mut self,
         ctx: &ServiceContext,
         payload: GenerateMultiSigAccountPayload,
-    ) -> Result<GenerateMultiSigAccountResponse, ServiceResponse<()>> {
-        impl_multisig!(self, generate_account, ctx, payload)
+    ) -> ServiceResponse<GenerateMultiSigAccountResponse> {
+        self.generate_account(ctx.clone(), payload)
     }
 }
 

--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -24,11 +24,6 @@ pub const MULTI_SIG_SERVICE_NAME: &str = "multi_signature";
 const MAX_MULTI_SIGNATURE_RECURSION_DEPTH: u8 = 8;
 const MAX_PERMISSION_ACCOUNTS: u8 = 16;
 
-lazy_static::lazy_static! {
-   // FIXME:
-   pub static ref ADEPTIVE_ADDRESS: Address = "muta14e0lmgck835vm2dfm0w3ckv6svmez8fdgdl705".parse().unwrap();
-}
-
 pub trait MultiSignature {
     fn verify_signature_(
         &self,

--- a/protocol/src/traits/binding.rs
+++ b/protocol/src/traits/binding.rs
@@ -5,6 +5,16 @@ use crate::traits::{ExecutorParams, ServiceResponse};
 use crate::types::{Address, Block, Hash, MerkleRoot, Receipt, ServiceContext, SignedTransaction};
 use crate::ProtocolResult;
 
+#[macro_export]
+macro_rules! try_service_response {
+    ($service_resp: expr) => {{
+        if $service_resp.is_error() {
+            return ServiceResponse::from_error($service_resp.code, $service_resp.error_message);
+        }
+        $service_resp.succeed_data
+    }};
+}
+
 pub trait SDKFactory<SDK: ServiceSDK> {
     fn get_sdk(&self, name: &str) -> ProtocolResult<SDK>;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
refactor

**What this PR does / why we need it**:
* Change service interface return type from `Result<T, ServiceResponse<()>>` to `ServiceResponse<T>`.
* Add a `try_service_response` macro for handling service response.

e.g.
```rust
/// Expand code
/// let balance = {
///     if resp.is_error() {
///         return ServiceResponse::from_error(resp.code, resp.error_message);     
///     }
///     resp.succeed_data
/// };
let resp = asset.balance_(ctx, payload);
let balance = try_service_response!(resp);
```

The corresponding doc PR is https://github.com/nervosnetwork/muta-docs/pull/36/files

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
