### PR TITLE
feat(network): limit inbound and outbound connections

### DIFF
--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -458,19 +458,20 @@ impl From<&NetworkConfig> for PeerManagerConfig {
             TrustMetricConfig::new(config.peer_trust_interval, config.peer_trust_max_history);
 
         PeerManagerConfig {
-            our_id:             config.secio_keypair.peer_id(),
-            pubkey:             config.secio_keypair.public_key(),
-            bootstraps:         config.bootstraps.clone(),
-            allowlist:          config.allowlist.clone(),
-            allowlist_only:     config.allowlist_only,
-            peer_trust_config:  Arc::new(peer_trust_config),
-            peer_fatal_ban:     config.peer_fatal_ban,
-            peer_soft_ban:      config.peer_soft_ban,
-            max_connections:    config.max_connections,
-            same_ip_conn_limit: config.same_ip_conn_limit,
-            inbound_conn_limit: config.inbound_conn_limit,
-            routine_interval:   config.peer_manager_heart_beat_interval,
-            peer_dat_file:      config.peer_dat_file.clone(),
+            our_id:              config.secio_keypair.peer_id(),
+            pubkey:              config.secio_keypair.public_key(),
+            bootstraps:          config.bootstraps.clone(),
+            allowlist:           config.allowlist.clone(),
+            allowlist_only:      config.allowlist_only,
+            peer_trust_config:   Arc::new(peer_trust_config),
+            peer_fatal_ban:      config.peer_fatal_ban,
+            peer_soft_ban:       config.peer_soft_ban,
+            max_connections:     config.max_connections,
+            same_ip_conn_limit:  config.same_ip_conn_limit,
+            inbound_conn_limit:  config.inbound_conn_limit,
+            outbound_conn_limit: config.max_connections - config.inbound_conn_limit,
+            routine_interval:    config.peer_manager_heart_beat_interval,
+            peer_dat_file:       config.peer_dat_file.clone(),
         }
     }
 }

--- a/core/network/src/error.rs
+++ b/core/network/src/error.rs
@@ -146,6 +146,9 @@ pub enum NetworkError {
     #[display(fmt = "transport {}", _0)]
     Transport(tentacle::error::TransportErrorKind),
 
+    #[display(fmt = "inbound connection limit is equal or smaller than max connections")]
+    InboundLimitEqualOrSmallerThanMaxConn,
+
     #[display(fmt = "internal error: {}", _0)]
     Internal(Box<dyn Error + Send>),
 }

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -287,6 +287,11 @@ impl Inner {
     fn restore(&self, peers: Vec<ArcPeer>) {
         self.peers.write().extend(peers);
     }
+
+    #[cfg(test)]
+    fn outbound_count(&self) -> usize {
+        self.sessions.outbound_count()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -307,6 +312,9 @@ pub struct PeerManagerConfig {
 
     /// Limit connections from same ip
     pub same_ip_conn_limit: usize,
+
+    /// Limit inbound connections
+    pub inbound_conn_limit: usize,
 
     /// Trust metric config
     pub peer_trust_config: Arc<TrustMetricConfig>,

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -288,7 +288,6 @@ impl Inner {
         self.peers.write().extend(peers);
     }
 
-    #[cfg(test)]
     fn outbound_count(&self) -> usize {
         self.sessions.outbound_count()
     }
@@ -315,6 +314,9 @@ pub struct PeerManagerConfig {
 
     /// Limit inbound connections
     pub inbound_conn_limit: usize,
+
+    /// Limit outbound connections
+    pub outbound_conn_limit: usize,
 
     /// Trust metric config
     pub peer_trust_config: Arc<TrustMetricConfig>,
@@ -1244,10 +1246,12 @@ impl Future for PeerManager {
 
         // Check connecting count
         let connected_count = self.inner.connected();
-        let connection_attempts = connected_count + self.connecting.len();
-        let max_connection_attempts = self.config.max_connections + MAX_CONNECTING_MARGIN;
+        let outbound_count = self.inner.outbound_count();
+        let connection_attempts = outbound_count + self.connecting.len();
+        let max_connection_attempts = self.config.outbound_conn_limit + MAX_CONNECTING_MARGIN;
 
         if connected_count < self.config.max_connections
+            && outbound_count < self.config.outbound_conn_limit
             && connection_attempts < max_connection_attempts
         {
             let filter_good_peer = |peer: &ArcPeer| -> bool {

--- a/core/network/src/peer_manager/session_book.rs
+++ b/core/network/src/peer_manager/session_book.rs
@@ -58,7 +58,7 @@ impl From<&PeerManagerConfig> for Config {
         Config {
             same_ip_conn_limit:  config.same_ip_conn_limit,
             inbound_conn_limit:  config.inbound_conn_limit,
-            outbound_conn_limit: config.max_connections - config.inbound_conn_limit,
+            outbound_conn_limit: config.outbound_conn_limit,
         }
     }
 }

--- a/core/network/src/peer_manager/session_book.rs
+++ b/core/network/src/peer_manager/session_book.rs
@@ -2,15 +2,19 @@ use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use derive_more::Display;
 use parking_lot::RwLock;
+use tentacle::service::SessionType;
 use tentacle::SessionId;
 
 use super::{ArcPeer, PeerManagerConfig};
 use crate::common::ConnectedAddr;
+use crate::config::{
+    DEFAULT_INBOUND_CONN_LIMIT, DEFAULT_MAX_CONNECTIONS, DEFAULT_SAME_IP_CONN_LIMIT,
+};
 
 #[cfg(test)]
 pub use crate::test::mock::SessionContext;
@@ -24,17 +28,27 @@ type Count = usize;
 pub enum Error {
     #[display(fmt = "reach same ip connections limit")]
     ReachSameIPConnLimit,
+
+    #[display(fmt = "reach inbound connections limit")]
+    ReachInboundConnLimit,
+
+    #[display(fmt = "reach outbound connections limit")]
+    ReachOutboundConnLimit,
 }
 
 #[derive(Debug)]
 pub struct Config {
-    same_ip_conn_limit: usize,
+    same_ip_conn_limit:  usize,
+    inbound_conn_limit:  usize,
+    outbound_conn_limit: usize,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Config {
-            same_ip_conn_limit: 1,
+            same_ip_conn_limit:  DEFAULT_SAME_IP_CONN_LIMIT,
+            inbound_conn_limit:  DEFAULT_INBOUND_CONN_LIMIT,
+            outbound_conn_limit: DEFAULT_MAX_CONNECTIONS - DEFAULT_INBOUND_CONN_LIMIT,
         }
     }
 }
@@ -42,7 +56,9 @@ impl Default for Config {
 impl From<&PeerManagerConfig> for Config {
     fn from(config: &PeerManagerConfig) -> Config {
         Config {
-            same_ip_conn_limit: config.same_ip_conn_limit,
+            same_ip_conn_limit:  config.same_ip_conn_limit,
+            inbound_conn_limit:  config.inbound_conn_limit,
+            outbound_conn_limit: config.max_connections - config.inbound_conn_limit,
         }
     }
 }
@@ -71,6 +87,10 @@ impl ArcSession {
         };
 
         ArcSession(Arc::new(session))
+    }
+
+    pub fn ty(&self) -> SessionType {
+        self.ctx.ty
     }
 
     pub fn block(&self) {
@@ -121,6 +141,9 @@ pub struct SessionBook {
 
     hosts:    RwLock<HashMap<Host, Count>>,
     sessions: RwLock<HashSet<ArcSession>>,
+
+    inbound_count:  AtomicUsize,
+    outbound_count: AtomicUsize,
 }
 
 impl Default for SessionBook {
@@ -137,6 +160,8 @@ impl SessionBook {
             config,
             hosts: Default::default(),
             sessions: Default::default(),
+            inbound_count: AtomicUsize::new(0),
+            outbound_count: AtomicUsize::new(0),
         }
     }
 
@@ -160,6 +185,14 @@ impl SessionBook {
         f(&mut sessions.iter())
     }
 
+    pub fn inbound_count(&self) -> usize {
+        self.inbound_count.load(Ordering::SeqCst)
+    }
+
+    pub fn outbound_count(&self) -> usize {
+        self.outbound_count.load(Ordering::SeqCst)
+    }
+
     pub fn acceptable(&self, session: &ArcSession) -> Result<(), self::Error> {
         let session_host = &session.connected_addr.host;
         let host_count = {
@@ -171,7 +204,15 @@ impl SessionBook {
             return Err(self::Error::ReachSameIPConnLimit);
         }
 
-        Ok(())
+        match session.ty() {
+            SessionType::Inbound if self.inbound_count() >= self.config.inbound_conn_limit => {
+                Err(self::Error::ReachInboundConnLimit)
+            }
+            SessionType::Outbound if self.outbound_count() >= self.config.outbound_conn_limit => {
+                Err(self::Error::ReachOutboundConnLimit)
+            }
+            _ => Ok(()),
+        }
     }
 
     pub fn insert(&self, AcceptableSession(session): AcceptableSession) {
@@ -182,6 +223,11 @@ impl SessionBook {
             .entry(session_host.to_owned())
             .and_modify(|c| *c += 1)
             .or_insert(1);
+
+        match session.ty() {
+            SessionType::Inbound => self.inbound_count.fetch_add(1, Ordering::SeqCst),
+            SessionType::Outbound => self.outbound_count.fetch_add(1, Ordering::SeqCst),
+        };
 
         self.sessions.write().insert(session);
     }
@@ -198,6 +244,13 @@ impl SessionBook {
             } else if let Some(count) = hosts.get_mut(session_host) {
                 *count -= 1;
             }
+        }
+
+        if let Some(ty) = session.as_ref().map(|s| s.ty()) {
+            match ty {
+                SessionType::Inbound => self.inbound_count.fetch_sub(1, Ordering::SeqCst),
+                SessionType::Outbound => self.outbound_count.fetch_sub(1, Ordering::SeqCst),
+            };
         }
 
         session
@@ -248,15 +301,10 @@ mod tests {
         peer
     }
 
-    fn make_session(port: u16, sid: SessionId) -> ArcSession {
+    fn make_session(port: u16, sid: SessionId, ty: SessionType) -> ArcSession {
         let peer = make_peer(port);
         let multiaddr = peer.multiaddrs.all_raw().pop().unwrap();
-        let ctx = SessionContext::make(
-            sid,
-            multiaddr,
-            SessionType::Outbound,
-            peer.owned_pubkey().unwrap(),
-        );
+        let ctx = SessionContext::make(sid, multiaddr, ty, peer.owned_pubkey().unwrap());
 
         ArcSession::new(peer, Arc::new(ctx))
     }
@@ -264,11 +312,13 @@ mod tests {
     #[test]
     fn should_reject_session_when_reach_same_ip_conn_limit() {
         let config = Config {
-            same_ip_conn_limit: 1,
+            same_ip_conn_limit:  1,
+            inbound_conn_limit:  20,
+            outbound_conn_limit: 20,
         };
         let book = SessionBook::new(config);
 
-        let session = make_session(100, 1.into());
+        let session = make_session(100, 1.into(), SessionType::Inbound);
         assert!(book.acceptable(&session).is_ok());
 
         book.insert(AcceptableSession(session.clone()));
@@ -277,7 +327,7 @@ mod tests {
             Some(&1)
         );
 
-        let same_ip_session = make_session(101, 2.into());
+        let same_ip_session = make_session(101, 2.into(), SessionType::Inbound);
         assert_eq!(
             book.acceptable(&same_ip_session),
             Err(Error::ReachSameIPConnLimit)
@@ -287,11 +337,13 @@ mod tests {
     #[test]
     fn should_reduce_host_count() {
         let config = Config {
-            same_ip_conn_limit: 5,
+            same_ip_conn_limit:  5,
+            inbound_conn_limit:  20,
+            outbound_conn_limit: 20,
         };
         let book = SessionBook::new(config);
 
-        let session = make_session(100, 1.into());
+        let session = make_session(100, 1.into(), SessionType::Inbound);
         assert!(book.acceptable(&session).is_ok());
 
         book.insert(AcceptableSession(session.clone()));
@@ -302,5 +354,57 @@ mod tests {
 
         book.remove(&(1.into()));
         assert_eq!(book.hosts.read().get(&session.connected_addr.host), None);
+    }
+
+    #[test]
+    fn should_reject_inbound_session_when_reach_inbound_limit() {
+        let config = Config {
+            same_ip_conn_limit:  5,
+            inbound_conn_limit:  1,
+            outbound_conn_limit: 20,
+        };
+        let book = SessionBook::new(config);
+
+        let session = make_session(100, 1.into(), SessionType::Inbound);
+        assert!(book.acceptable(&session).is_ok());
+
+        book.insert(AcceptableSession(session.clone()));
+        assert_eq!(
+            book.hosts.read().get(&session.connected_addr.host),
+            Some(&1)
+        );
+        assert_eq!(book.inbound_count(), 1);
+
+        let same_ip_session = make_session(101, 2.into(), SessionType::Inbound);
+        assert_eq!(
+            book.acceptable(&same_ip_session),
+            Err(Error::ReachInboundConnLimit)
+        );
+    }
+
+    #[test]
+    fn should_reject_outbound_session_when_reach_outbound_limit() {
+        let config = Config {
+            same_ip_conn_limit:  5,
+            inbound_conn_limit:  10,
+            outbound_conn_limit: 1,
+        };
+        let book = SessionBook::new(config);
+
+        let session = make_session(100, 1.into(), SessionType::Outbound);
+        assert!(book.acceptable(&session).is_ok());
+
+        book.insert(AcceptableSession(session.clone()));
+        assert_eq!(
+            book.hosts.read().get(&session.connected_addr.host),
+            Some(&1)
+        );
+        assert_eq!(book.outbound_count(), 1);
+
+        let same_ip_session = make_session(101, 2.into(), SessionType::Outbound);
+        assert_eq!(
+            book.acceptable(&same_ip_session),
+            Err(Error::ReachOutboundConnLimit)
+        );
     }
 }

--- a/core/network/src/peer_manager/test_manager.rs
+++ b/core/network/src/peer_manager/test_manager.rs
@@ -134,6 +134,7 @@ fn make_manager(
     let peer_trust_config = Arc::new(TrustMetricConfig::default());
     let peer_fatal_ban = Duration::from_secs(50);
     let peer_soft_ban = Duration::from_secs(10);
+    let inbound_conn_limit = max_connections / 2;
 
     let config = PeerManagerConfig {
         our_id: manager_id,
@@ -146,7 +147,8 @@ fn make_manager(
         peer_soft_ban,
         max_connections,
         same_ip_conn_limit: max_connections,
-        inbound_conn_limit: max_connections / 2,
+        inbound_conn_limit,
+        outbound_conn_limit: max_connections - inbound_conn_limit,
         routine_interval: Duration::from_secs(10),
         peer_dat_file,
     };
@@ -163,7 +165,12 @@ fn make_pubkey() -> PublicKey {
     keypair.public_key()
 }
 
-async fn make_sessions(mgr: &mut MockManager, num: u16, init_port: u16) -> Vec<ArcPeer> {
+async fn make_sessions(
+    mgr: &mut MockManager,
+    num: u16,
+    init_port: u16,
+    sess_ty: SessionType,
+) -> Vec<ArcPeer> {
     let mut next_sid = 1;
     let mut peers = Vec::with_capacity(num as usize);
     let inbound_limit = mgr.config().inbound_conn_limit;
@@ -175,10 +182,11 @@ async fn make_sessions(mgr: &mut MockManager, num: u16, init_port: u16) -> Vec<A
         let remote_pid = remote_pubkey.peer_id();
         let remote_addr = make_multiaddr(init_port + n, Some(remote_pid.clone()));
 
-        let ty = if inner.outbound_count() == outbound_limit {
+        let ty = if sess_ty == SessionType::Outbound && inner.outbound_count() == outbound_limit {
+            // Switch to create inbound session
             SessionType::Inbound
         } else {
-            SessionType::Outbound
+            sess_ty
         };
 
         let sess_ctx = SessionContext::make(
@@ -426,7 +434,7 @@ async fn should_enforce_id_in_multiaddr_on_new_session() {
 #[tokio::test]
 async fn should_add_new_outbound_multiaddr_to_peer_on_new_session() {
     let (mut mgr, _conn_rx) = make_manager(2, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let inner = mgr.core_inner();
     assert_eq!(inner.connected(), 1, "should have one without bootstrap");
@@ -464,7 +472,7 @@ async fn should_add_new_outbound_multiaddr_to_peer_on_new_session() {
 #[tokio::test]
 async fn should_always_remove_inbound_multiaddr_even_if_we_reach_max_connections_on_new_session() {
     let (mut mgr, _conn_rx) = make_manager(0, 2);
-    let _remote_peers = make_sessions(&mut mgr, 2, 5000).await;
+    let _remote_peers = make_sessions(&mut mgr, 2, 5000, SessionType::Outbound).await;
 
     let inner = mgr.core_inner();
     let test_peer = make_peer(9527);
@@ -537,7 +545,7 @@ async fn should_remove_matched_peer_inbound_address_from_ctx_even_if_it_doesnt_h
 #[tokio::test]
 async fn should_reject_new_connection_for_same_peer_on_new_session() {
     let (mut mgr, mut conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let expect_sid = test_peer.session_id();
@@ -573,7 +581,7 @@ async fn should_reject_new_connection_for_same_peer_on_new_session() {
 #[tokio::test]
 async fn should_keep_new_connection_for_error_outdated_peer_session_on_new_session() {
     let (mut mgr, mut conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let inner = mgr.core_inner();
     let test_peer = remote_peers.first().expect("get first peer");
@@ -608,7 +616,7 @@ async fn should_keep_new_connection_for_error_outdated_peer_session_on_new_sessi
 #[tokio::test]
 async fn should_reject_new_connections_when_we_reach_max_connections_on_new_session() {
     let (mut mgr, mut conn_rx) = make_manager(0, 10); // set max to 10
-    let _remote_peers = make_sessions(&mut mgr, 10, 7000).await;
+    let _remote_peers = make_sessions(&mut mgr, 10, 7000, SessionType::Outbound).await;
 
     let remote_pubkey = make_pubkey();
     let remote_addr = make_multiaddr(2077, Some(remote_pubkey.peer_id()));
@@ -640,7 +648,7 @@ async fn should_reject_new_connections_when_we_reach_max_connections_on_new_sess
 async fn should_remove_connecting_even_if_session_is_reject_due_to_reach_max_connections_on_new_session(
 ) {
     let (mut mgr, mut conn_rx) = make_manager(0, 5); // set max to 5
-    let _remote_peers = make_sessions(&mut mgr, 5, 7000).await;
+    let _remote_peers = make_sessions(&mut mgr, 5, 7000, SessionType::Outbound).await;
 
     let test_peer = make_peer(2020);
     let inner = mgr.core_inner();
@@ -739,7 +747,7 @@ async fn should_start_trust_metric_on_connected_peer_on_new_session() {
 #[tokio::test]
 async fn should_replace_low_quality_peer_with_better_one_due_to_max_connections_on_new_session() {
     let (mut mgr, mut conn_rx) = make_manager(0, 10);
-    let remote_peers = make_sessions(&mut mgr, 10, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 10, 5000, SessionType::Outbound).await;
     let target_peer = remote_peers.first().expect("get first peer");
     let peer_trust_config = Arc::new(TrustMetricConfig::default());
 
@@ -796,7 +804,7 @@ async fn should_replace_low_quality_peer_with_better_one_due_to_max_connections_
 async fn should_not_replace_any_peer_if_incoming_hasnt_trust_score_due_to_max_connections_on_new_session(
 ) {
     let (mut mgr, mut conn_rx) = make_manager(0, 10);
-    let remote_peers = make_sessions(&mut mgr, 10, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 10, 5000, SessionType::Outbound).await;
     let target_peer = remote_peers.first().expect("get first peer");
     let peer_trust_config = Arc::new(TrustMetricConfig::default());
 
@@ -844,7 +852,7 @@ async fn should_not_replace_any_peer_if_incoming_hasnt_trust_score_due_to_max_co
 #[tokio::test]
 async fn should_not_replace_any_higher_score_peer_due_to_max_connections_on_new_session() {
     let (mut mgr, mut conn_rx) = make_manager(0, 10);
-    let remote_peers = make_sessions(&mut mgr, 10, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 10, 5000, SessionType::Outbound).await;
     let target_peer = remote_peers.first().expect("get first peer");
     let peer_trust_config = Arc::new(TrustMetricConfig::default());
 
@@ -900,7 +908,7 @@ async fn should_not_replace_any_higher_score_peer_due_to_max_connections_on_new_
 async fn should_not_replace_peer_in_allowlist_with_better_score_peer_due_to_max_connections_on_new_session(
 ) {
     let (mut mgr, mut conn_rx) = make_manager(0, 1);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let target_peer = remote_peers.first().expect("get first peer");
     let peer_trust_config = Arc::new(TrustMetricConfig::default());
 
@@ -957,7 +965,7 @@ async fn should_not_replace_peer_in_allowlist_with_better_score_peer_due_to_max_
 #[tokio::test]
 async fn should_not_replace_peer_not_old_enough_due_to_max_connections_on_new_session() {
     let (mut mgr, mut conn_rx) = make_manager(0, 10);
-    let remote_peers = make_sessions(&mut mgr, 10, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 10, 5000, SessionType::Outbound).await;
     let target_peer = remote_peers.first().expect("get first peer");
     let peer_trust_config = Arc::new(TrustMetricConfig::default());
 
@@ -1009,7 +1017,7 @@ async fn should_not_replace_peer_not_old_enough_due_to_max_connections_on_new_se
 #[tokio::test]
 async fn should_remove_session_on_session_closed() {
     let (mut mgr, _conn_rx) = make_manager(2, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     assert_eq!(
@@ -1045,7 +1053,7 @@ async fn should_remove_session_on_session_closed() {
 #[tokio::test]
 async fn should_pause_trust_metric_on_session_closed() {
     let (mut mgr, _conn_rx) = make_manager(2, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first");
 
     let session_closed = PeerManagerEvent::SessionClosed {
@@ -1061,7 +1069,7 @@ async fn should_pause_trust_metric_on_session_closed() {
 #[tokio::test]
 async fn should_increase_retry_for_short_alive_session_on_session_closed() {
     let (mut mgr, _conn_rx) = make_manager(2, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
     assert_eq!(
         test_peer.retry.count(),
@@ -1335,7 +1343,7 @@ async fn should_wait_for_other_connecting_multiaddrs_if_we_dont_give_up_peer_on_
 #[tokio::test]
 async fn should_ensure_disconnect_session_on_session_failed() {
     let (mut mgr, mut conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let expect_sid = test_peer.session_id();
@@ -1366,7 +1374,7 @@ async fn should_ensure_disconnect_session_on_session_failed() {
 #[tokio::test]
 async fn should_increase_retry_for_io_error_on_session_failed() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let expect_sid = test_peer.session_id();
@@ -1384,7 +1392,7 @@ async fn should_increase_retry_for_io_error_on_session_failed() {
 #[tokio::test]
 async fn should_give_up_peer_for_protocol_error_on_session_failed() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let expect_sid = test_peer.session_id();
@@ -1409,7 +1417,7 @@ async fn should_give_up_peer_for_protocol_error_on_session_failed() {
 #[tokio::test]
 async fn should_give_up_peer_for_unexpected_error_on_session_failed() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let expect_sid = test_peer.session_id();
@@ -1434,7 +1442,7 @@ async fn should_give_up_peer_for_unexpected_error_on_session_failed() {
 #[tokio::test]
 async fn should_reduce_trust_score_on_session_failed() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
 
     let trust_metric = test_peer.trust_metric().expect("get trust metric");
@@ -1461,7 +1469,7 @@ async fn should_reduce_trust_score_on_session_failed() {
 #[tokio::test]
 async fn should_update_peer_alive_on_peer_alive() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let old_alive = test_peer.alive();
@@ -1484,7 +1492,7 @@ async fn should_update_peer_alive_on_peer_alive() {
 #[tokio::test]
 async fn should_reset_peer_retry_on_peer_alive() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     assert_eq!(test_peer.retry.count(), 0, "should have 0 retry");
@@ -1503,7 +1511,7 @@ async fn should_reset_peer_retry_on_peer_alive() {
 #[tokio::test]
 async fn should_disconnect_peer_on_misbehave() {
     let (mut mgr, mut conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let expect_sid = test_peer.session_id();
@@ -1529,7 +1537,7 @@ async fn should_disconnect_peer_on_misbehave() {
 #[tokio::test]
 async fn should_reduce_trust_score_on_misbehave() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
 
     let trust_metric = test_peer.trust_metric().expect("get trust metric");
@@ -1555,7 +1563,7 @@ async fn should_reduce_trust_score_on_misbehave() {
 #[tokio::test]
 async fn should_increase_retry_for_ping_timeout_on_misbehave() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let peer_misbehave = PeerManagerEvent::Misbehave {
@@ -1572,7 +1580,7 @@ async fn should_increase_retry_for_ping_timeout_on_misbehave() {
 #[tokio::test]
 async fn should_give_up_peer_for_ping_unexpect_on_misbehave() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let peer_misbehave = PeerManagerEvent::Misbehave {
@@ -1593,7 +1601,7 @@ async fn should_give_up_peer_for_ping_unexpect_on_misbehave() {
 #[tokio::test]
 async fn should_give_up_peer_for_discovery_on_misbehave() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let peer_misbehave = PeerManagerEvent::Misbehave {
@@ -1614,7 +1622,7 @@ async fn should_give_up_peer_for_discovery_on_misbehave() {
 #[tokio::test]
 async fn should_mark_session_blocked_on_session_blocked() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let sess_ctx = SessionContext::make(
@@ -1638,7 +1646,7 @@ async fn should_mark_session_blocked_on_session_blocked() {
 #[tokio::test]
 async fn should_add_one_bad_event_on_session_blocked() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     let trust_metric = test_peer.trust_metric().expect("get trust metric");
@@ -1862,7 +1870,7 @@ async fn should_skip_our_listen_multiaddrs_on_discover_multi_addrs() {
 #[tokio::test]
 async fn should_add_multiaddrs_to_peer_on_identified_addrs() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first");
     let old_multiaddrs_len = test_peer.multiaddrs.len();
 
@@ -1892,7 +1900,7 @@ async fn should_add_multiaddrs_to_peer_on_identified_addrs() {
 #[tokio::test]
 async fn should_push_id_to_multiaddrs_if_not_included_on_identified_addrs() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first");
     let test_multiaddr = make_multiaddr(2077, None);
 
@@ -1917,7 +1925,7 @@ async fn should_push_id_to_multiaddrs_if_not_included_on_identified_addrs() {
 #[tokio::test]
 async fn should_not_reset_exist_multiaddr_failure_count_on_identified_addrs() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first");
     let test_multiaddr = test_peer.multiaddrs.all().pop().expect("multiaddr");
 
@@ -1944,7 +1952,7 @@ async fn should_not_reset_exist_multiaddr_failure_count_on_identified_addrs() {
 #[tokio::test]
 async fn should_reset_peer_failure_for_outbound_multiaddr_on_repeated_connection() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first");
     let test_multiaddr = test_peer.multiaddrs.all().pop().expect("multiaddr");
 
@@ -1972,7 +1980,7 @@ async fn should_reset_peer_failure_for_outbound_multiaddr_on_repeated_connection
 #[tokio::test]
 async fn should_remove_inbound_multiaddr_on_repeated_connection() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first");
 
     let test_multiaddr = make_peer_multiaddr(2077, test_peer.owned_id());
@@ -1994,7 +2002,7 @@ async fn should_remove_inbound_multiaddr_on_repeated_connection() {
 #[tokio::test]
 async fn should_enforce_id_if_not_included_on_repeated_connection() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first");
     let test_multiaddr = test_peer.multiaddrs.all().pop().expect("multiaddr");
 
@@ -2136,7 +2144,7 @@ async fn should_always_include_our_listen_addrs_in_return_from_manager_handle_ra
 #[tokio::test]
 async fn should_accept_always_allow_peer_even_if_we_reach_max_connections_on_new_session() {
     let (mut mgr, _conn_rx) = make_manager(0, 10);
-    let _remote_peers = make_sessions(&mut mgr, 10, 5000).await;
+    let _remote_peers = make_sessions(&mut mgr, 10, 5000, SessionType::Outbound).await;
 
     let peer = make_peer(2019);
     let always_allow_peer = make_peer(2077);
@@ -2217,6 +2225,7 @@ async fn should_only_connect_peers_in_allowlist_if_enable_allowlist_only() {
         max_connections: 10,
         same_ip_conn_limit: 99,
         inbound_conn_limit: 5,
+        outbound_conn_limit: 5,
         routine_interval: Duration::from_secs(10),
         peer_dat_file,
     };
@@ -2282,6 +2291,7 @@ async fn should_only_accept_incoming_from_peer_in_allowlist_if_enable_allowlist_
         max_connections: 10,
         same_ip_conn_limit: 9,
         inbound_conn_limit: 5,
+        outbound_conn_limit: 5,
         routine_interval: Duration::from_secs(10),
         peer_dat_file,
     };
@@ -2349,7 +2359,7 @@ async fn should_only_accept_incoming_from_peer_in_allowlist_if_enable_allowlist_
 #[tokio::test]
 async fn should_disconnect_and_ban_peer_for_fatal_feedback_on_trust_metric() {
     let (mut mgr, mut conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
     let target_sid = test_peer.session_id();
 
@@ -2381,7 +2391,7 @@ async fn should_disconnect_and_ban_peer_for_fatal_feedback_on_trust_metric() {
 #[tokio::test]
 async fn should_exclude_always_allow_peer_from_fatal_feedback_ban_on_trust_metric() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
 
     let inner = mgr.core_inner();
@@ -2403,7 +2413,7 @@ async fn should_exclude_always_allow_peer_from_fatal_feedback_ban_on_trust_metri
 #[tokio::test]
 async fn should_add_one_bad_event_for_bad_feedback_on_trust_metric() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
     let trust_metric = test_peer.trust_metric().expect("trust metric");
 
@@ -2423,7 +2433,7 @@ async fn should_add_one_bad_event_for_bad_feedback_on_trust_metric() {
 #[tokio::test]
 async fn should_add_ten_bad_events_for_worse_feedback_on_trust_metric() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
     let trust_metric = test_peer.trust_metric().expect("trust metric");
 
@@ -2444,7 +2454,7 @@ async fn should_add_ten_bad_events_for_worse_feedback_on_trust_metric() {
 async fn should_disconnect_and_soft_ban_peer_if_below_fourty_score_on_worse_feedback_on_trust_metric(
 ) {
     let (mut mgr, mut conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
     let trust_metric = test_peer.trust_metric().expect("trust metric");
     let test_sid = test_peer.session_id();
@@ -2486,7 +2496,7 @@ async fn should_disconnect_and_soft_ban_peer_if_below_fourty_score_on_worse_feed
 #[tokio::test]
 async fn should_not_knock_out_peer_just_set_up_trust_metric_on_worse_feedback_on_trust_metric() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
     let trust_metric = test_peer.trust_metric().expect("trust metric");
 
@@ -2519,7 +2529,7 @@ async fn should_not_knock_out_peer_just_set_up_trust_metric_on_worse_feedback_on
 async fn should_not_punish_always_allow_peer_when_its_score_below_fourty_on_worse_feedback_on_trust_metric(
 ) {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
     let trust_metric = test_peer.trust_metric().expect("trust metric");
 
@@ -2551,7 +2561,7 @@ async fn should_not_punish_always_allow_peer_when_its_score_below_fourty_on_wors
 #[tokio::test]
 async fn should_do_nothing_for_neutral_feedback_on_trust_metric() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
     let trust_metric = test_peer.trust_metric().expect("trust metric");
 
@@ -2576,7 +2586,7 @@ async fn should_do_nothing_for_neutral_feedback_on_trust_metric() {
 #[tokio::test]
 async fn should_add_one_bad_event_for_good_feedback_on_trust_metric() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
     let test_peer = remote_peers.first().expect("get first peer");
     let trust_metric = test_peer.trust_metric().expect("trust metric");
 
@@ -2596,10 +2606,22 @@ async fn should_add_one_bad_event_for_good_feedback_on_trust_metric() {
 #[tokio::test]
 async fn should_pick_good_peer_first_on_finding_connectable_peers() {
     let (mut mgr, mut conn_rx) = make_manager(0, 4);
-    let _remote_peers = make_sessions(&mut mgr, 3, 5000).await;
+    let outbound_conn_limit = mgr.config().outbound_conn_limit;
+    let pre_connected_count = outbound_conn_limit - 1;
+    let _remote_peers = make_sessions(
+        &mut mgr,
+        pre_connected_count as u16,
+        5000,
+        SessionType::Outbound,
+    )
+    .await;
 
     let inner = mgr.core_inner();
-    assert_eq!(inner.connected(), 3, "should have 3 connections");
+    assert_eq!(
+        inner.connected(),
+        pre_connected_count,
+        "should have pre connected connections just one below outbound conn limit"
+    );
 
     // Fill connecting attempts, left one for our test
     let fill_peers = (3..4 + MAX_CONNECTING_MARGIN - 1)
@@ -2647,7 +2669,7 @@ async fn should_pick_good_peer_first_on_finding_connectable_peers() {
 #[tokio::test]
 async fn should_setup_trust_metric_if_none_on_session_closed() {
     let (mut mgr, _conn_rx) = make_manager(2, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     test_peer.remove_trust_metric();
@@ -2667,7 +2689,7 @@ async fn should_setup_trust_metric_if_none_on_session_closed() {
 #[tokio::test]
 async fn should_setup_trust_metric_if_none_on_session_failed() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     test_peer.remove_trust_metric();
@@ -2696,7 +2718,7 @@ async fn should_setup_trust_metric_if_none_on_session_failed() {
 #[tokio::test]
 async fn should_setup_trust_metric_if_none_on_peer_misbehave() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     test_peer.remove_trust_metric();
@@ -2724,7 +2746,7 @@ async fn should_setup_trust_metric_if_none_on_peer_misbehave() {
 #[tokio::test]
 async fn should_setup_trust_metric_if_none_on_session_blocked() {
     let (mut mgr, _conn_rx) = make_manager(0, 20);
-    let remote_peers = make_sessions(&mut mgr, 1, 5000).await;
+    let remote_peers = make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let test_peer = remote_peers.first().expect("get first peer");
     test_peer.remove_trust_metric();
@@ -2822,6 +2844,7 @@ async fn should_reject_same_ip_connection_when_reach_limit_on_new_session() {
         max_connections: 10,
         same_ip_conn_limit: 1,
         inbound_conn_limit: 5,
+        outbound_conn_limit: 5,
         routine_interval: Duration::from_secs(10),
         peer_dat_file,
     };
@@ -2831,7 +2854,7 @@ async fn should_reject_same_ip_connection_when_reach_limit_on_new_session() {
     let manager = PeerManager::new(config, mgr_rx, conn_tx);
 
     let mut mgr = MockManager::new(manager, mgr_tx);
-    make_sessions(&mut mgr, 1, 5000).await;
+    make_sessions(&mut mgr, 1, 5000, SessionType::Outbound).await;
 
     let same_ip_peer = make_peer(9527);
     let expect_sid = same_ip_peer.session_id();

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct ConfigNetwork {
     pub soft_ban_duration:          Option<u64>,
     pub max_connected_peers:        Option<usize>,
     pub same_ip_conn_limit:         Option<usize>,
+    pub inbound_conn_limit:         Option<usize>,
     pub listening_address:          SocketAddr,
     pub rpc_timeout:                Option<u64>,
     pub selfcheck_interval:         Option<u64>,

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -171,9 +171,9 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
 
     // Init network
     let network_config = NetworkConfig::new()
-        .max_connections(config.network.max_connected_peers)
+        .max_connections(config.network.max_connected_peers)?
         .same_ip_conn_limit(config.network.same_ip_conn_limit)
-        .inbound_conn_limit(config.network.inbound_conn_limit)
+        .inbound_conn_limit(config.network.inbound_conn_limit)?
         .allowlist_only(config.network.allowlist_only)
         .peer_trust_metric(
             config.network.trust_interval_duration,

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -173,6 +173,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     let network_config = NetworkConfig::new()
         .max_connections(config.network.max_connected_peers)
         .same_ip_conn_limit(config.network.same_ip_conn_limit)
+        .inbound_conn_limit(config.network.inbound_conn_limit)
         .allowlist_only(config.network.allowlist_only)
         .peer_trust_metric(
             config.network.trust_interval_duration,

--- a/tests/trust_metric_all/node/full_node/default_start.rs
+++ b/tests/trust_metric_all/node/full_node/default_start.rs
@@ -143,7 +143,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
 
     // Init network
     let network_config = NetworkConfig::new()
-        .max_connections(config.network.max_connected_peers)
+        .max_connections(config.network.max_connected_peers)?
         .allowlist_only(config.network.allowlist_only)
         .peer_trust_metric(
             consts::NETWORK_TRUST_METRIC_INTERVAL,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What type of PR is this?**
feat

**What this PR does / why we need it**:
Support limit inbound and outbound connections. Add ```inbound_conn_limit``` to network configuration.
```outbound_conn_limit``` will be subtracted ```inbound_conn_limit``` from ```max_connections```.

Note:
Base on #388 

[DOC PR](https://github.com/nervosnetwork/muta-docs/pull/39)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
