### PR TITLE
perf(state): add state cache for trieDB

### DIFF
--- a/benchmark/mod.rs
+++ b/benchmark/mod.rs
@@ -31,7 +31,7 @@ lazy_static::lazy_static! {
 
 macro_rules! benchmark {
     ($payload: expr, $num: expr, $bencher: expr) => {{
-        let memdb = Arc::new(RocksTrieDB::new("./free-space/state", false, 1024).unwrap());
+        let memdb = Arc::new(RocksTrieDB::new("./free-space/state", false, 1024, 2000).unwrap());
 
         let rocks_adapter = Arc::new(RocksAdapter::new("./free-space/block", 1024).unwrap());
 
@@ -76,7 +76,7 @@ macro_rules! benchmark {
 
 macro_rules! perf_exec {
     ($assets_num: expr, $payload: expr, $num: expr, $bencher: expr) => {{
-        let memdb = Arc::new(RocksTrieDB::new("./free-space/state", false, 1024).unwrap());
+        let memdb = Arc::new(RocksTrieDB::new("./free-space/state", false, 1024, 2000).unwrap());
 
         let rocks_adapter = Arc::new(RocksAdapter::new("./free-space/block", 1024).unwrap());
 

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -30,6 +30,7 @@ broadcast_txs_interval = 200
 
 [executor]
 light = false
+triedb_cache_size = 2000
 
 [logger]
 filter = "info"
@@ -43,9 +44,6 @@ metrics = true
 
 [rocksdb]
 max_open_files = 64
-
-# [triedb]
-# cache_size = 2000
 
 # [apm]
 # service_name = "muta"

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -44,6 +44,9 @@ metrics = true
 [rocksdb]
 max_open_files = 64
 
+# [triedb]
+# cache_size = 2000
+
 # [apm]
 # service_name = "muta"
 # tracing_address = "127.0.0.1:6831"

--- a/examples/config-1.toml
+++ b/examples/config-1.toml
@@ -15,6 +15,7 @@ max_payload_size = 1048576
 
 [executor]
 light = false
+triedb_cache_size = 2000
 
 [mempool]
 broadcast_txs_size = 200

--- a/examples/config-2.toml
+++ b/examples/config-2.toml
@@ -19,6 +19,7 @@ max_payload_size = 1048576
 
 [executor]
 light = false
+triedb_cache_size = 2000
 
 [mempool]
 broadcast_txs_size = 200

--- a/examples/config-3.toml
+++ b/examples/config-3.toml
@@ -19,6 +19,7 @@ max_payload_size = 1048576
 
 [executor]
 light = false
+triedb_cache_size = 2000
 
 [mempool]
 broadcast_txs_size = 200

--- a/examples/config-4.toml
+++ b/examples/config-4.toml
@@ -19,6 +19,7 @@ max_payload_size = 1048576
 
 [executor]
 light = false
+triedb_cache_size = 2000
 
 [mempool]
 broadcast_txs_size = 200

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -28,11 +28,14 @@ hex = "0.4"
 serde_json = "1.0"
 log = "0.4"
 rayon = "1.3"
+lru-cache = "0.1"
+lru = "0.6"
+parking_lot = "0.11"
+rand = { version = "0.7", features = ["small_rng"]}
 
 [dev-dependencies]
 async-trait = "0.1"
 toml = "0.5"
 binding-macro = { path = "../binding-macro" }
-rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 muta-codec-derive = "0.2"

--- a/framework/src/binding/state/trie_db.rs
+++ b/framework/src/binding/state/trie_db.rs
@@ -208,19 +208,31 @@ fn to_store_err(e: rocksdb::Error) -> RocksTrieDBError {
 }
 
 #[cfg(test)]
-mod benchmark {
+mod tests {
     extern crate test;
     use test::Bencher;
 
     use super::*;
 
     #[bench]
-    fn bench_insert(b: &mut Bencher) {
+    fn bench_rand(b: &mut Bencher) {
         b.iter(|| {
             let mut rng = SmallRng::seed_from_u64(49999);
             for _ in 0..10000 {
                 rng.gen_range(10, 1000000);
             }
         })
+    }
+
+    #[test]
+    fn test_rand_remove() {
+        let list = (0..10).collect::<Vec<_>>();
+        let keys = list.iter().collect::<Vec<_>>();
+        let to_removed_num = (1..10).collect::<Vec<_>>();
+
+        for num in to_removed_num.into_iter() {
+            let res = rand_remove_list(keys.clone(), num);
+            assert_eq!(res.len(), num);
+        }
     }
 }

--- a/framework/src/binding/state/trie_db.rs
+++ b/framework/src/binding/state/trie_db.rs
@@ -82,7 +82,12 @@ impl cita_trie::DB for RocksTrieDB {
         if res {
             Ok(true)
         } else {
-            Ok(self.db.get(key).map_err(to_store_err)?.is_some())
+            if let Some(val) = self.db.get(key).map_err(to_store_err)? {
+                let mut cache = self.cache.write();
+                cache.insert(key.to_owned(), val.to_owned());
+                return Ok(true);
+            }
+            Ok(false)
         }
     }
 

--- a/framework/src/binding/state/trie_db.rs
+++ b/framework/src/binding/state/trie_db.rs
@@ -1,17 +1,25 @@
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
 use bytes::Bytes;
 use derive_more::{Display, From};
+use parking_lot::RwLock;
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use rocksdb::{Options, WriteBatch, DB};
 
 use common_apm::metrics::storage::{on_storage_get_state, on_storage_put_state};
 use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
 
+const RAND_SEED: u64 = 49999;
+const MAP_SIZE: usize = 2000;
+
 pub struct RocksTrieDB {
     light: bool,
     db:    Arc<DB>,
+
+    cache: RwLock<HashMap<Vec<u8>, Vec<u8>>>,
 }
 
 impl RocksTrieDB {
@@ -26,7 +34,20 @@ impl RocksTrieDB {
         Ok(RocksTrieDB {
             light,
             db: Arc::new(db),
+            cache: RwLock::new(HashMap::new()),
         })
+    }
+
+    fn inner_get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RocksTrieDBError> {
+        let res = {
+            let cache = self.cache.read();
+            cache.get(key).cloned()
+        };
+
+        if res.is_none() {
+            return Ok(self.db.get(key).map_err(to_store_err)?);
+        }
+        Ok(res)
     }
 }
 
@@ -36,19 +57,33 @@ impl cita_trie::DB for RocksTrieDB {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let inst = Instant::now();
 
-        let res = self.db.get(key).map_err(to_store_err)?.map(|v| v.to_vec());
+        let res = self.inner_get(key)?;
 
         on_storage_get_state(inst.elapsed(), 1i64);
         Ok(res)
     }
 
     fn contains(&self, key: &[u8]) -> Result<bool, Self::Error> {
-        Ok(self.db.get(key).map_err(to_store_err)?.is_some())
+        let res = {
+            let cache = self.cache.read();
+            cache.contains_key(key)
+        };
+
+        if res {
+            Ok(true)
+        } else {
+            Ok(self.db.get(key).map_err(to_store_err)?.is_some())
+        }
     }
 
     fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Self::Error> {
         let inst = Instant::now();
         let size = key.len() + value.len();
+
+        {
+            let mut cache = self.cache.write();
+            cache.insert(key.clone(), value.clone());
+        }
 
         self.db
             .put(Bytes::from(key), Bytes::from(value))
@@ -67,13 +102,15 @@ impl cita_trie::DB for RocksTrieDB {
 
         let mut total_size = 0;
         let mut batch = WriteBatch::default();
-        for i in 0..keys.len() {
-            let key = &keys[i];
-            let value = &values[i];
 
-            total_size += key.len();
-            total_size += value.len();
-            batch.put(key, value);
+        {
+            let mut cache = self.cache.write();
+            for (key, val) in keys.iter().zip(values.iter()) {
+                total_size += key.len();
+                total_size += val.len();
+                batch.put(key, val);
+                cache.insert(key.clone(), val.clone());
+            }
         }
 
         self.db.write(batch).map_err(to_store_err)?;
@@ -84,6 +121,10 @@ impl cita_trie::DB for RocksTrieDB {
 
     fn remove(&self, key: &[u8]) -> Result<(), Self::Error> {
         if self.light {
+            {
+                let mut cache = self.cache.write();
+                cache.remove(key);
+            }
             self.db.delete(key).map_err(to_store_err)?;
         }
         Ok(())
@@ -92,19 +133,50 @@ impl cita_trie::DB for RocksTrieDB {
     fn remove_batch(&self, keys: &[Vec<u8>]) -> Result<(), Self::Error> {
         if self.light {
             let mut batch = WriteBatch::default();
-            for key in keys {
-                batch.delete(key);
+            {
+                let mut cache = self.cache.write();
+                for key in keys {
+                    cache.remove(key);
+                    batch.delete(key);
+                }
             }
 
             self.db.write(batch).map_err(to_store_err)?;
         }
-
         Ok(())
     }
 
     fn flush(&self) -> Result<(), Self::Error> {
+        let mut cache = self.cache.write();
+        let len = cache.len();
+
+        if len <= MAP_SIZE {
+            return Ok(());
+        }
+
+        let keys = cache.keys().collect::<Vec<_>>();
+        let remove_list = rand_remove_list(keys, len - MAP_SIZE);
+
+        for item in remove_list.iter() {
+            cache.remove(item);
+        }
         Ok(())
     }
+}
+
+fn rand_remove_list<T: Clone>(keys: Vec<&T>, num: usize) -> Vec<T> {
+    let mut len = keys.len() - 1;
+    let mut idx_list = (0..len).map(|i| i).collect::<Vec<_>>();
+    let mut rng = SmallRng::seed_from_u64(RAND_SEED);
+    let mut ret = Vec::new();
+
+    for _ in 0..num {
+        let tmp = rng.gen_range(0, len);
+        let idx = idx_list.remove(tmp);
+        ret.push(keys[idx].to_owned());
+        len -= 1;
+    }
+    ret
 }
 
 #[derive(Debug, Display, From)]
@@ -133,4 +205,22 @@ impl From<RocksTrieDBError> for ProtocolError {
 fn to_store_err(e: rocksdb::Error) -> RocksTrieDBError {
     log::error!("[framework] trie db {:?}", e);
     RocksTrieDBError::Store
+}
+
+#[cfg(test)]
+mod benchmark {
+    extern crate test;
+    use test::Bencher;
+
+    use super::*;
+
+    #[bench]
+    fn bench_insert(b: &mut Bencher) {
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(49999);
+            for _ in 0..10000 {
+                rng.gen_range(10, 1000000);
+            }
+        })
+    }
 }

--- a/framework/src/binding/state/trie_db.rs
+++ b/framework/src/binding/state/trie_db.rs
@@ -67,6 +67,7 @@ impl RocksTrieDB {
         Ok(res)
     }
 
+    #[cfg(test)]
     pub fn insert_batch_without_cache(&self, keys: Vec<Vec<u8>>, values: Vec<Vec<u8>>) {
         let mut _total_size = 0;
         let mut batch = WriteBatch::default();

--- a/framework/src/binding/state/trie_db.rs
+++ b/framework/src/binding/state/trie_db.rs
@@ -12,6 +12,7 @@ use rocksdb::{Options, WriteBatch, DB};
 use common_apm::metrics::storage::{on_storage_get_state, on_storage_put_state};
 use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
 
+// 49999 is the largest prime number within 50000.
 const RAND_SEED: u64 = 49999;
 
 pub struct RocksTrieDB {
@@ -35,10 +36,11 @@ impl RocksTrieDB {
 
         let db = DB::open(&opts, path).map_err(RocksTrieDBError::from)?;
 
+        // Init HashMap with capacity 2 * cache_size to avoid reallocate memory.
         Ok(RocksTrieDB {
             light,
             db: Arc::new(db),
-            cache: RwLock::new(HashMap::with_capacity(cache_size + 500)),
+            cache: RwLock::new(HashMap::with_capacity(cache_size + cache_size)),
             cache_size,
         })
     }
@@ -232,7 +234,7 @@ mod tests {
     #[bench]
     fn bench_rand(b: &mut Bencher) {
         b.iter(|| {
-            let mut rng = SmallRng::seed_from_u64(49999);
+            let mut rng = SmallRng::seed_from_u64(RAND_SEED);
             for _ in 0..10000 {
                 rng.gen_range(10, 1000000);
             }

--- a/framework/src/binding/state/trie_db.rs
+++ b/framework/src/binding/state/trie_db.rs
@@ -86,7 +86,7 @@ impl cita_trie::DB for RocksTrieDB {
         } else {
             if let Some(val) = self.db.get(key).map_err(to_store_err)? {
                 let mut cache = self.cache.write();
-                cache.insert(key.to_owned(), val.to_owned());
+                cache.insert(key.to_owned(), val);
                 return Ok(true);
             }
             Ok(false)

--- a/framework/src/binding/state/trie_db.rs
+++ b/framework/src/binding/state/trie_db.rs
@@ -70,6 +70,7 @@ impl RocksTrieDB {
     pub fn insert_batch_without_cache(&self, keys: Vec<Vec<u8>>, values: Vec<Vec<u8>>) {
         let mut _total_size = 0;
         let mut batch = WriteBatch::default();
+        assert_eq!(keys.len(), values.len());
 
         for (key, val) in keys.iter().zip(values.iter()) {
             _total_size += key.len();
@@ -88,6 +89,12 @@ impl RocksTrieDB {
     #[cfg(test)]
     pub fn get_without_cache(&self, key: &[u8]) -> Option<Vec<u8>> {
         self.db.get(key).unwrap()
+    }
+
+    #[cfg(test)]
+    pub fn cache(&self) -> HashMap<Vec<u8>, Vec<u8>> {
+        let cache = self.cache.read();
+        cache.clone()
     }
 }
 

--- a/framework/src/binding/state/trie_db.rs
+++ b/framework/src/binding/state/trie_db.rs
@@ -136,8 +136,8 @@ impl cita_trie::DB for RocksTrieDB {
             {
                 let mut cache = self.cache.write();
                 for key in keys {
-                    cache.remove(key);
                     batch.delete(key);
+                    cache.remove(key);
                 }
             }
 
@@ -166,7 +166,7 @@ impl cita_trie::DB for RocksTrieDB {
 
 fn rand_remove_list<T: Clone>(keys: Vec<&T>, num: usize) -> Vec<T> {
     let mut len = keys.len() - 1;
-    let mut idx_list = (0..len).map(|i| i).collect::<Vec<_>>();
+    let mut idx_list = (0..len).collect::<Vec<_>>();
     let mut rng = SmallRng::seed_from_u64(RAND_SEED);
     let mut ret = Vec::new();
 

--- a/framework/src/binding/tests/state.rs
+++ b/framework/src/binding/tests/state.rs
@@ -1,6 +1,7 @@
 extern crate test;
 
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -23,7 +24,7 @@ use crate::binding::state::{GeneralServiceState, MPTTrie, RocksTrieDB};
 /// test binding::tests::state::bench_insert_without_cache       ... bench:       2,491 ns/iter (+/- 486)
 #[bench]
 fn bench_insert_batch_with_cache(b: &mut Bencher) {
-    let triedb = new_triedb();
+    let triedb = new_triedb("bench_insert_batch_with_cache");
 
     let keys = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
     let values = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
@@ -35,7 +36,7 @@ fn bench_insert_batch_with_cache(b: &mut Bencher) {
 
 #[bench]
 fn bench_insert_batch_without_cache(b: &mut Bencher) {
-    let triedb = new_triedb();
+    let triedb = new_triedb("bench_insert_batch_without_cache");
 
     let keys = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
     let values = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
@@ -47,7 +48,7 @@ fn bench_insert_batch_without_cache(b: &mut Bencher) {
 
 #[bench]
 fn bench_insert_with_cache(b: &mut Bencher) {
-    let triedb = new_triedb();
+    let triedb = new_triedb("bench_insert_with_cache");
 
     let key = rand_bytes();
     let value = rand_bytes();
@@ -59,7 +60,7 @@ fn bench_insert_with_cache(b: &mut Bencher) {
 
 #[bench]
 fn bench_insert_without_cache(b: &mut Bencher) {
-    let triedb = new_triedb();
+    let triedb = new_triedb("bench_insert_without_cache");
 
     let key = rand_bytes();
     let value = rand_bytes();
@@ -71,7 +72,7 @@ fn bench_insert_without_cache(b: &mut Bencher) {
 
 #[bench]
 fn bench_get_cache_hit(b: &mut Bencher) {
-    let triedb = new_triedb();
+    let triedb = new_triedb("bench_get_cache_hit");
 
     let keys = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
     let values = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
@@ -86,7 +87,7 @@ fn bench_get_cache_hit(b: &mut Bencher) {
 
 #[bench]
 fn bench_get_cache_miss(b: &mut Bencher) {
-    let triedb = new_triedb();
+    let triedb = new_triedb("bench_get_cache_miss");
 
     let keys = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
     let values = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
@@ -109,7 +110,7 @@ fn bench_get_cache_miss(b: &mut Bencher) {
 
 #[bench]
 fn bench_get_without_cache(b: &mut Bencher) {
-    let triedb = new_triedb();
+    let triedb = new_triedb("bench_get_without_cache");
 
     let keys = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
     let values = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
@@ -124,7 +125,7 @@ fn bench_get_without_cache(b: &mut Bencher) {
 
 #[test]
 fn test_trie_db() {
-    let triedb = new_triedb();
+    let triedb = new_triedb("test_trie_db");
     let key = rand_bytes();
     let value = rand_bytes();
 
@@ -204,8 +205,10 @@ pub fn new_state(memdb: Arc<MemoryDB>, root: Option<MerkleRoot>) -> GeneralServi
     GeneralServiceState::new(trie)
 }
 
-fn new_triedb() -> RocksTrieDB {
-    RocksTrieDB::new("./free-space", false, 1024, 2000).unwrap()
+fn new_triedb(name: &str) -> RocksTrieDB {
+    let mut path = PathBuf::from("./free-space/");
+    path.push(name);
+    RocksTrieDB::new(path, false, 1024, 2000).unwrap()
 }
 
 fn rand_bytes() -> Vec<u8> {

--- a/framework/src/binding/tests/state.rs
+++ b/framework/src/binding/tests/state.rs
@@ -114,7 +114,7 @@ fn bench_get_without_cache(b: &mut Bencher) {
     let keys = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
     let values = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
 
-    triedb.insert_batch_without_cache(keys.clone(), values.clone());
+    triedb.insert_batch_without_cache(keys.clone(), values);
 
     let key = keys[0].clone();
     b.iter(|| {

--- a/framework/src/binding/tests/state.rs
+++ b/framework/src/binding/tests/state.rs
@@ -13,11 +13,10 @@ use protocol::types::{Address, Hash, MerkleRoot};
 use crate::binding::state::{GeneralServiceState, MPTTrie, RocksTrieDB};
 
 #[rustfmt::skip]
-/// Bench in AMD Ryzen 7 3800X 8-Core Processor(16 x 4250)
-/// test binding::state::trie_db::tests::bench_rand              ... bench:      10,702 ns/iter (+/- 341)
+/// Bench in AMD Ryzen 7 3800X 8-Core Processor (16 x 4250)
 /// test binding::tests::state::bench_get_cache_hit              ... bench:          47 ns/iter (+/- 3)
 /// test binding::tests::state::bench_get_cache_miss             ... bench:       1,063 ns/iter (+/- 35)
-/// test binding::tests::state::bench_get_without_cache          ... bench:          47 ns/iter (+/- 0)
+/// test binding::tests::state::bench_get_without_cache          ... bench:         526 ns/iter (+/- 19)
 /// test binding::tests::state::bench_insert_batch_with_cache    ... bench:   1,113,015 ns/iter (+/- 489,068)
 /// test binding::tests::state::bench_insert_batch_without_cache ... bench:     979,408 ns/iter (+/- 510,953)
 /// test binding::tests::state::bench_insert_with_cache          ... bench:       2,716 ns/iter (+/- 602)
@@ -115,13 +114,11 @@ fn bench_get_without_cache(b: &mut Bencher) {
     let keys = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
     let values = (0..1000).map(|_| rand_bytes()).collect::<Vec<_>>();
 
-    for (k, v) in keys.iter().zip(values.iter()) {
-        triedb.insert_without_cache(k.clone(), v.clone());
-    }
+    triedb.insert_batch_without_cache(keys.clone(), values.clone());
 
     let key = keys[0].clone();
     b.iter(|| {
-        let _ = triedb.get(&key).unwrap();
+        let _ = triedb.get_without_cache(&key).unwrap();
     })
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,18 +80,8 @@ pub struct ConfigMempool {
 
 #[derive(Debug, Deserialize)]
 pub struct ConfigExecutor {
-    pub light: bool,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ConfigTrieDB {
-    pub cache_size: usize,
-}
-
-impl Default for ConfigTrieDB {
-    fn default() -> Self {
-        ConfigTrieDB { cache_size: 2000 }
-    }
+    pub light:             bool,
+    pub triedb_cache_size: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -155,8 +145,6 @@ pub struct Config {
     pub logger:    ConfigLogger,
     #[serde(default)]
     pub rocksdb:   ConfigRocksDB,
-    #[serde(default)]
-    pub triedb:    ConfigTrieDB,
     pub apm:       Option<ConfigAPM>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,17 @@ pub struct ConfigExecutor {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct ConfigTrieDB {
+    pub cache_size: usize,
+}
+
+impl Default for ConfigTrieDB {
+    fn default() -> Self {
+        ConfigTrieDB { cache_size: 2000 }
+    }
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ConfigRocksDB {
     pub max_open_files: i32,
 }
@@ -144,6 +155,8 @@ pub struct Config {
     pub logger:    ConfigLogger,
     #[serde(default)]
     pub rocksdb:   ConfigRocksDB,
+    #[serde(default)]
+    pub triedb:    ConfigTrieDB,
     pub apm:       Option<ConfigAPM>,
 }
 

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -96,7 +96,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         path_state,
         config.executor.light,
         config.rocksdb.max_open_files,
-        config.triedb.cache_size,
+        config.executor.triedb_cache_size,
     )?);
 
     // Init genesis
@@ -215,7 +215,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         path_state,
         config.executor.light,
         config.rocksdb.max_open_files,
-        config.triedb.cache_size,
+        config.executor.triedb_cache_size,
     )?);
 
     // Init mempool

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -96,6 +96,7 @@ pub async fn create_genesis<Mapping: 'static + ServiceMapping>(
         path_state,
         config.executor.light,
         config.rocksdb.max_open_files,
+        config.triedb.cache_size,
     )?);
 
     // Init genesis
@@ -214,6 +215,7 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
         path_state,
         config.executor.light,
         config.rocksdb.max_open_files,
+        config.triedb.cache_size,
     )?);
 
     // Init mempool


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Implement an approximately fixed size cache through HashMap. It caches the data used in the latest block, and it will be flushed when committing a block. The size of the cache is 2000, however, this does not mean that it can only store 2000 data. When the data in the cache is more than 2000 when the cache is refreshed, it will be randomly deleted to 2000. The random seed is the largest prime number within 50000, 49999.
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:
  
Ref https://github.com/nervosnetwork/muta-docs/pull/55


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
