### PR TITLE
fix!: service field of event is not binded to ctx.service

### DIFF
--- a/built-in-services/asset/src/lib.rs
+++ b/built-in-services/asset/src/lib.rs
@@ -34,6 +34,8 @@ macro_rules! impl_assets {
     }};
 }
 
+pub const ASSET_SERVICE_NAME: &str = "asset";
+
 pub trait Assets {
     fn create_(
         &mut self,
@@ -265,7 +267,11 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<Asset>::from_error(103, format!("{:?}", e));
         }
         let event_str = event_res.unwrap();
-        ctx.emit_event("CreateAsset".to_owned(), event_str);
+        ctx.emit_event(
+            ASSET_SERVICE_NAME.to_owned(),
+            "CreateAsset".to_owned(),
+            event_str,
+        );
 
         ServiceResponse::<Asset>::from_succeed(asset)
     }
@@ -302,7 +308,11 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
-        ctx.emit_event("TransferAsset".to_owned(), event_str);
+        ctx.emit_event(
+            ASSET_SERVICE_NAME.to_owned(),
+            "TransferAsset".to_owned(),
+            event_str,
+        );
 
         ServiceResponse::<()>::from_succeed(())
     }
@@ -351,7 +361,11 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
-        ctx.emit_event("ApproveAsset".to_owned(), event_str);
+        ctx.emit_event(
+            ASSET_SERVICE_NAME.to_owned(),
+            "ApproveAsset".to_owned(),
+            event_str,
+        );
 
         ServiceResponse::<()>::from_succeed(())
     }
@@ -413,7 +427,11 @@ impl<SDK: ServiceSDK> AssetService<SDK> {
             return ServiceResponse::<()>::from_error(103, format!("{:?}", e));
         };
         let event_str = event_res.unwrap();
-        ctx.emit_event("TransferFrom".to_owned(), event_str);
+        ctx.emit_event(
+            ASSET_SERVICE_NAME.to_owned(),
+            "TransferFrom".to_owned(),
+            event_str,
+        );
 
         ServiceResponse::<()>::from_succeed(())
     }

--- a/built-in-services/authorization/src/lib.rs
+++ b/built-in-services/authorization/src/lib.rs
@@ -4,6 +4,8 @@ use protocol::types::{ServiceContext, SignedTransaction};
 
 use multi_signature::MultiSignatureService;
 
+pub const AUTHORIZATION_SERVICE_NAME: &str = "authorization";
+
 pub struct AuthorizationService<SDK> {
     _sdk:      SDK,
     multi_sig: MultiSignatureService<SDK>,

--- a/built-in-services/metadata/src/lib.rs
+++ b/built-in-services/metadata/src/lib.rs
@@ -24,6 +24,8 @@ macro_rules! impl_meatdata {
     }};
 }
 
+pub const METADATA_SERVICE_NAME: &str = "metadata";
+
 pub trait MetaData {
     fn get_(&self, ctx: &ServiceContext) -> Result<Metadata, ServiceResponse<()>>;
 }

--- a/built-in-services/multi-signature/src/lib.rs
+++ b/built-in-services/multi-signature/src/lib.rs
@@ -42,6 +42,7 @@ macro_rules! impl_multisig {
         }
     }};
 }
+pub const MULTI_SIG_SERVICE_NAME: &str = "multi_signature";
 
 pub trait MultiSignature {
     fn verify_signature_(

--- a/built-in-services/util/src/lib.rs
+++ b/built-in-services/util/src/lib.rs
@@ -12,6 +12,8 @@ use crate::types::{KeccakPayload, KeccakResponse, SigVerifyPayload, SigVerifyRes
 mod tests;
 pub mod types;
 
+pub const UTIL_SERVICE_NAME: &str = "util";
+
 pub struct UtilService<SDK> {
     _sdk: SDK,
 }

--- a/examples/muta-chain.rs
+++ b/examples/muta-chain.rs
@@ -1,12 +1,13 @@
-use asset::AssetService;
-use authorization::AuthorizationService;
 use derive_more::{Display, From};
-use metadata::MetadataService;
-use multi_signature::MultiSignatureService;
-use muta::MutaBuilder;
 use protocol::traits::{SDKFactory, Service, ServiceMapping, ServiceSDK};
 use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
-use util::UtilService;
+
+use asset::{AssetService, ASSET_SERVICE_NAME};
+use authorization::{AuthorizationService, AUTHORIZATION_SERVICE_NAME};
+use metadata::{MetadataService, METADATA_SERVICE_NAME};
+use multi_signature::{MultiSignatureService, MULTI_SIG_SERVICE_NAME};
+use muta::MutaBuilder;
+use util::{UtilService, UTIL_SERVICE_NAME};
 
 struct DefaultServiceMapping;
 
@@ -18,17 +19,17 @@ impl ServiceMapping for DefaultServiceMapping {
     ) -> ProtocolResult<Box<dyn Service>> {
         let sdk = factory.get_sdk(name)?;
         let service = match name {
-            "authorization" => {
+            AUTHORIZATION_SERVICE_NAME => {
                 let multi_sig_sdk = factory.get_sdk("multi_signature")?;
                 Box::new(AuthorizationService::new(
                     sdk,
                     MultiSignatureService::new(multi_sig_sdk),
                 )) as Box<dyn Service>
             }
-            "asset" => Box::new(AssetService::new(sdk)) as Box<dyn Service>,
-            "metadata" => Box::new(MetadataService::new(sdk)) as Box<dyn Service>,
-            "multi_signature" => Box::new(MultiSignatureService::new(sdk)) as Box<dyn Service>,
-            "util" => Box::new(UtilService::new(sdk)) as Box<dyn Service>,
+            ASSET_SERVICE_NAME => Box::new(AssetService::new(sdk)) as Box<dyn Service>,
+            METADATA_SERVICE_NAME => Box::new(MetadataService::new(sdk)) as Box<dyn Service>,
+            MULTI_SIG_SERVICE_NAME => Box::new(MultiSignatureService::new(sdk)) as Box<dyn Service>,
+            UTIL_SERVICE_NAME => Box::new(UtilService::new(sdk)) as Box<dyn Service>,
             _ => {
                 return Err(MappingError::NotFoundService {
                     service: name.to_owned(),
@@ -42,11 +43,11 @@ impl ServiceMapping for DefaultServiceMapping {
 
     fn list_service_name(&self) -> Vec<String> {
         vec![
-            "asset".to_owned(),
-            "authorization".to_owned(),
-            "metadata".to_owned(),
-            "multi_signature".to_owned(),
-            "util".to_owned(),
+            ASSET_SERVICE_NAME.to_owned(),
+            AUTHORIZATION_SERVICE_NAME.to_owned(),
+            METADATA_SERVICE_NAME.to_owned(),
+            MULTI_SIG_SERVICE_NAME.to_owned(),
+            UTIL_SERVICE_NAME.to_owned(),
         ]
     }
 }

--- a/framework/src/executor/tests/framework.rs
+++ b/framework/src/executor/tests/framework.rs
@@ -217,14 +217,22 @@ impl<SDK: ServiceSDK> TestService<SDK> {
     #[cycles(300_00)]
     #[write]
     fn test_write(&mut self, ctx: ServiceContext) -> ServiceResponse<String> {
-        ctx.emit_event("write".to_owned(), "write".to_owned());
+        ctx.emit_event(
+            "test_service".to_owned(),
+            "write".to_owned(),
+            "write".to_owned(),
+        );
         ServiceResponse::from_succeed("".to_owned())
     }
 
     #[tx_hook_before]
     fn test_tx_hook_before(&mut self, ctx: ServiceContext) -> ServiceResponse<()> {
         // we emit an event
-        ctx.emit_event("before".to_owned(), "before".to_owned());
+        ctx.emit_event(
+            "test_service".to_owned(),
+            "before".to_owned(),
+            "before".to_owned(),
+        );
         if ctx.get_payload().contains("before") {
             return ServiceResponse::from_error(2, "before_error".to_owned());
         }
@@ -236,7 +244,11 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         if ctx.get_payload().contains("after") {
             return ServiceResponse::from_error(2, "after_error".to_owned());
         }
-        ctx.emit_event("after".to_owned(), "after".to_owned());
+        ctx.emit_event(
+            "test_service".to_owned(),
+            "after".to_owned(),
+            "after".to_owned(),
+        );
         ServiceResponse::from_succeed(())
     }
 }

--- a/framework/src/executor/tests/mod.rs
+++ b/framework/src/executor/tests/mod.rs
@@ -177,7 +177,8 @@ fn test_emit_event() {
     assert_eq!(receipt.response.response.code, 0);
     assert_eq!(receipt.events.len(), 1);
     assert_eq!(&receipt.events[0].data, "test");
-    assert_eq!(&receipt.events[0].name, "wow");
+    assert_eq!(&receipt.events[0].name, "test-name");
+    assert_eq!(&receipt.events[0].service, "wow");
 }
 
 #[test]

--- a/framework/src/executor/tests/mod.rs
+++ b/framework/src/executor/tests/mod.rs
@@ -177,6 +177,7 @@ fn test_emit_event() {
     assert_eq!(receipt.response.response.code, 0);
     assert_eq!(receipt.events.len(), 1);
     assert_eq!(&receipt.events[0].data, "test");
+    assert_eq!(&receipt.events[0].name, "wow");
 }
 
 #[test]

--- a/framework/src/executor/tests/test_service.rs
+++ b/framework/src/executor/tests/test_service.rs
@@ -59,7 +59,7 @@ impl<SDK: ServiceSDK> TestService<SDK> {
         ctx: ServiceContext,
         _: TestWritePayload,
     ) -> ServiceResponse<TestWriteResponse> {
-        ctx.emit_event("test-name".to_owned(), "test".to_owned());
+        ctx.emit_event("wow".to_owned(), "test-name".to_owned(), "test".to_owned());
         ServiceResponse::from_succeed(TestWriteResponse::default())
     }
 
@@ -114,6 +114,7 @@ impl<SDK: ServiceSDK> TestService<SDK> {
             && ctx.get_payload().to_owned().contains("test_hook_before")
         {
             ctx.emit_event(
+                "test_service".to_owned(),
                 "test-name".to_owned(),
                 "test_tx_hook_before invoked".to_owned(),
             );
@@ -133,6 +134,7 @@ impl<SDK: ServiceSDK> TestService<SDK> {
             && ctx.get_payload().to_owned().contains("test_hook_after")
         {
             ctx.emit_event(
+                "test_service".to_owned(),
                 "test-name".to_owned(),
                 "test_tx_hook_after invoked".to_owned(),
             );

--- a/protocol/src/types/service_context.rs
+++ b/protocol/src/types/service_context.rs
@@ -162,9 +162,9 @@ impl ServiceContext {
         *self.canceled.borrow_mut() = Some(reason);
     }
 
-    pub fn emit_event(&self, name: String, message: String) {
+    pub fn emit_event(&self, service: String, name: String, message: String) {
         self.events.borrow_mut().push(Event {
-            service: self.service_name.clone(),
+            service,
             name,
             data: message,
         })


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: service field of event is not binded to ctx.service

**Which issue(s) this PR fixes**:
the service field of event was binded to ctx.event.
now it is free to set, in order to indicate which service emits the give events

**Which docs this PR relation**:

Ref #  n/a, this is an internal fix
toolchain change N/A.

**Which toolchain this PR adaption**:

Breaking Change

**Special notes for your reviewer**:
