### PR TITLE
fix(consensus): recover and insert tx to mempool to avoid inactivation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ tentacle_metrics = ["core-network/tentacle_metrics"]
 
 [[example]]
 name = "muta-chain"
-features = [ "random_leader" ]
 crate-type = ["bin"]
 
 [[test]]

--- a/core/consensus/Cargo.toml
+++ b/core/consensus/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/nervosnetwork/muta"
 
 [dependencies]
 async-trait = "0.1"
-bincode = "1.2"
+bincode = "1.3"
 cita_trie = "2.0"
 creep = "0.2"
 derive_more = "0.99"

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -170,6 +170,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
         let order_hashes_len = order_hashes.len();
         let exemption = { self.exemption_hash.read().contains(&hash) };
         let sync_tx_hashes = block.get_propose_hashes();
+        let pill = block.inner;
 
         // If the block is proposed by self, it does not need to check. Get full signed
         // transactions directly.
@@ -177,12 +178,12 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             let current_timestamp = time_now();
 
             self.adapter
-                .verify_block_header(ctx.clone(), block.inner.block.clone())
+                .verify_block_header(ctx.clone(), pill.block.clone())
                 .await
                 .map_err(|e| {
                     error!(
                         "[consensus] check_block, verify_block_header error, block header: {:?}",
-                        block.inner.block.header
+                        pill.block.header
                     );
                     e
                 })?;
@@ -192,13 +193,13 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             // sync and waste a delay of read
             let previous_block = self
                 .adapter
-                .get_block_by_height(ctx.clone(), block.inner.block.header.height - 1)
+                .get_block_by_height(ctx.clone(), pill.block.header.height - 1)
                 .await?;
 
             // verify block timestamp.
             if !validate_timestamp(
                 current_timestamp,
-                block.inner.block.header.timestamp,
+                pill.block.header.timestamp,
                 previous_block.header.timestamp,
             ) {
                 return Err(ProtocolError::from(ConsensusError::InvalidTimestamp).into());
@@ -208,14 +209,14 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
                 .verify_proof(
                     ctx.clone(),
                     previous_block.clone(),
-                    block.inner.block.header.proof.clone(),
+                    pill.block.header.proof.clone(),
                 )
                 .await
                 .map_err(|e| {
                     error!(
                         "[consensus] check_block, verify_proof error, previous block header: {:?}, proof: {:?}",
                         previous_block.header,
-                        block.inner.block.header.proof
+                        pill.block.header.proof
                     );
                     e
                 })?;
@@ -223,8 +224,8 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             self.adapter
                 .verify_txs(
                     ctx.clone(),
-                    block.inner.block.header.height,
-                    block.inner.block.ordered_tx_hashes.clone(),
+                    pill.block.header.height,
+                    pill.block.ordered_tx_hashes.clone(),
                 )
                 .await
                 .map_err(|e| {
@@ -236,7 +237,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             // period of time.
             let mut check_retry = 0;
             loop {
-                match self.check_block_roots(ctx.clone(), &block.inner.block.header) {
+                match self.check_block_roots(ctx.clone(), &pill.block.header) {
                     Ok(()) => break,
                     Err(e) => {
                         if check_retry >= RETRY_CHECK_ROOT_LIMIT {
@@ -251,9 +252,9 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
 
             let signed_txs = self
                 .adapter
-                .get_full_txs(ctx.clone(), block.inner.block.ordered_tx_hashes.clone())
+                .get_full_txs(ctx.clone(), pill.block.ordered_tx_hashes.clone())
                 .await?;
-            self.check_order_transactions(ctx.clone(), &block.inner.block, &signed_txs)?;
+            self.check_order_transactions(ctx.clone(), &pill.block, &signed_txs)?;
 
             let adapter = Arc::clone(&self.adapter);
             let ctx_clone = ctx.clone();
@@ -276,8 +277,11 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             Instant::now() - time
         );
         let time = Instant::now();
-        self.txs_wal
-            .save(next_height, Hash::from_bytes(hash)?, txs)?;
+        self.txs_wal.save(
+            next_height,
+            pill.block.header.order_signed_transactions_hash,
+            txs,
+        )?;
 
         info!(
             "[consensus-engine]: write wal cost {:?} order_hashes_len {:?}",
@@ -356,18 +360,10 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<FixedPill> for ConsensusEngine<
             .await
         {
             Ok(txs) => txs,
-            Err(_) => {
-                let tmp_txs = self.txs_wal.load(current_height, block_hash)?;
-                if pill.block.header.order_signed_transactions_hash
-                    != digest_signed_transactions(&tmp_txs)?
-                {
-                    return Err(ProtocolError::from(ConsensusError::WalTxsMismatch(
-                        current_height,
-                    ))
-                    .into());
-                }
-                tmp_txs
-            }
+            Err(_) => self.txs_wal.load(
+                current_height,
+                pill.block.header.order_signed_transactions_hash.clone(),
+            )?,
         };
 
         // Execute transactions

--- a/core/consensus/src/lib.rs
+++ b/core/consensus/src/lib.rs
@@ -137,6 +137,9 @@ pub enum ConsensusError {
     #[display(fmt = "Lock in sync")]
     LockInSync,
 
+    #[display(fmt = "Wal transactions mismatch, height {}", _0)]
+    WalTxsMismatch(u64),
+
     #[display(
         fmt = "Commit an outdated block, block_height {}, last_committed_height {}",
         _0,

--- a/core/consensus/src/wal.rs
+++ b/core/consensus/src/wal.rs
@@ -28,7 +28,7 @@ impl SignedTxsWAL {
     pub fn save(
         &self,
         height: u64,
-        block_hash: Hash,
+        ordered_signed_transactions_hash: Hash,
         txs: Vec<SignedTransaction>,
     ) -> ProtocolResult<()> {
         let mut wal_path = self.path.clone();
@@ -37,7 +37,7 @@ impl SignedTxsWAL {
             fs::create_dir(&wal_path).map_err(ConsensusError::WALErr)?;
         }
 
-        wal_path.push(block_hash.as_hex());
+        wal_path.push(ordered_signed_transactions_hash.as_hex());
         wal_path.set_extension("txt");
 
         let mut wal_file = match fs::OpenOptions::new()
@@ -63,10 +63,14 @@ impl SignedTxsWAL {
         Ok(())
     }
 
-    pub fn load(&self, height: u64, block_hash: Hash) -> ProtocolResult<Vec<SignedTransaction>> {
+    pub fn load(
+        &self,
+        height: u64,
+        ordered_signed_transactions_hash: Hash,
+    ) -> ProtocolResult<Vec<SignedTransaction>> {
         let mut file_path = self.path.clone();
         file_path.push(height.to_string());
-        file_path.push(block_hash.as_hex());
+        file_path.push(ordered_signed_transactions_hash.as_hex());
         file_path.set_extension("txt");
 
         self.recover_stxs(file_path)

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -55,15 +55,27 @@ impl<Adapter: 'static> HashMemPool<Adapter>
 where
     Adapter: MemPoolAdapter,
 {
-    pub fn new(pool_size: usize, adapter: Adapter) -> Self {
-        HashMemPool {
+    pub async fn new(
+        pool_size: usize,
+        adapter: Adapter,
+        initial_txs: Vec<SignedTransaction>,
+    ) -> Self {
+        let mempool = HashMemPool {
             pool_size,
             timeout_gap: AtomicU64::new(0),
             tx_cache: TxCache::new(pool_size * 2),
             callback_cache: Arc::new(Map::new(pool_size)),
             adapter: Arc::new(adapter),
             flush_lock: RwLock::new(()),
+        };
+
+        for tx in initial_txs.into_iter() {
+            if let Err(e) = mempool.initial_insert(Context::new(), tx).await {
+                log::warn!("[mempool]: initial insert tx failed {:?}", e);
+            }
         }
+
+        mempool
     }
 
     pub fn get_tx_cache(&self) -> &TxCache {
@@ -89,6 +101,16 @@ where
         }
 
         unknown_hashes
+    }
+
+    async fn initial_insert(&self, ctx: Context, tx: SignedTransaction) -> ProtocolResult<()> {
+        let _lock = self.flush_lock.read().await;
+
+        self.tx_cache.check_exist(&tx.tx_hash).await?;
+        self.adapter
+            .check_storage_exist(ctx.clone(), tx.tx_hash.clone())
+            .await?;
+        self.tx_cache.insert_propose_tx(tx).await
     }
 
     async fn insert_tx(
@@ -175,20 +197,6 @@ where
 {
     async fn insert(&self, ctx: Context, tx: SignedTransaction) -> ProtocolResult<()> {
         self.insert_tx(ctx, tx, TxType::NewTx).await
-    }
-
-    async fn insert_without_check(
-        &self,
-        ctx: Context,
-        tx: SignedTransaction,
-    ) -> ProtocolResult<()> {
-        let _lock = self.flush_lock.read().await;
-
-        self.tx_cache.check_exist(&tx.tx_hash).await?;
-        self.adapter
-            .check_storage_exist(ctx.clone(), tx.tx_hash.clone())
-            .await?;
-        self.tx_cache.insert_propose_tx(tx).await
     }
 
     #[muta_apm::derive::tracing_span(

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -177,6 +177,20 @@ where
         self.insert_tx(ctx, tx, TxType::NewTx).await
     }
 
+    async fn insert_without_check(
+        &self,
+        ctx: Context,
+        tx: SignedTransaction,
+    ) -> ProtocolResult<()> {
+        let _lock = self.flush_lock.read().await;
+
+        self.tx_cache.check_exist(&tx.tx_hash).await?;
+        self.adapter
+            .check_storage_exist(ctx.clone(), tx.tx_hash.clone())
+            .await?;
+        self.tx_cache.insert_propose_tx(tx).await
+    }
+
     #[muta_apm::derive::tracing_span(
         kind = "mempool",
         logs = "{'cycles_limit': 'cycles_limit', 'tx_num_limit': 'tx_num_limit'}"

--- a/core/mempool/src/tests/mod.rs
+++ b/core/mempool/src/tests/mod.rs
@@ -114,18 +114,23 @@ fn mock_txs(valid_size: usize, invalid_size: usize, timeout: u64) -> Vec<SignedT
     vec
 }
 
-fn default_mempool() -> HashMemPool<HashMemPoolAdapter> {
-    new_mempool(POOL_SIZE, TIMEOUT_GAP, CYCLE_LIMIT, MAX_TX_SIZE)
+fn default_mempool_sync() -> HashMemPool<HashMemPoolAdapter> {
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(default_mempool())
 }
 
-fn new_mempool(
+async fn default_mempool() -> HashMemPool<HashMemPoolAdapter> {
+    new_mempool(POOL_SIZE, TIMEOUT_GAP, CYCLE_LIMIT, MAX_TX_SIZE).await
+}
+
+async fn new_mempool(
     pool_size: usize,
     timeout_gap: u64,
     cycles_limit: u64,
     max_tx_size: u64,
 ) -> HashMemPool<HashMemPoolAdapter> {
     let adapter = HashMemPoolAdapter::new();
-    let mempool = HashMemPool::new(pool_size, adapter);
+    let mempool = HashMemPool::new(pool_size, adapter, vec![]).await;
     mempool.set_args(timeout_gap, cycles_limit, max_tx_size);
     mempool
 }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -19,7 +19,7 @@ prost = "0.6"
 bytes = { version = "0.5", features = ["serde"] }
 hasher = { version = "0.1", features = ['hash-keccak'] }
 creep = "0.2"
-bincode = "1.2"
+bincode = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rlp = "0.4"
@@ -34,4 +34,4 @@ arc-swap = "0.4"
 
 [dev-dependencies]
 rayon = "1.3"
-rand = "0.6"
+rand = "0.7"

--- a/protocol/src/traits/mempool.rs
+++ b/protocol/src/traits/mempool.rs
@@ -20,6 +20,9 @@ impl MixedTxHashes {
 pub trait MemPool: Send + Sync {
     async fn insert(&self, ctx: Context, tx: SignedTransaction) -> ProtocolResult<()>;
 
+    async fn insert_without_check(&self, ctx: Context, tx: SignedTransaction)
+        -> ProtocolResult<()>;
+
     async fn package(
         &self,
         ctx: Context,

--- a/protocol/src/traits/mempool.rs
+++ b/protocol/src/traits/mempool.rs
@@ -20,9 +20,6 @@ impl MixedTxHashes {
 pub trait MemPool: Send + Sync {
     async fn insert(&self, ctx: Context, tx: SignedTransaction) -> ProtocolResult<()>;
 
-    async fn insert_without_check(&self, ctx: Context, tx: SignedTransaction)
-        -> ProtocolResult<()>;
-
     async fn package(
         &self,
         ctx: Context,

--- a/src/default_start.rs
+++ b/src/default_start.rs
@@ -254,7 +254,9 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
     );
 
     for tx in current_stxs.into_iter() {
-        let _ = mempool.insert(Context::new(), tx).await;
+        if let Err(e) = mempool.insert_without_check(Context::new(), tx).await {
+            log::warn!("Re-insert tx to mempool when reboot error {:?}", e);
+        }
     }
 
     let monitor_mempool = Arc::clone(&mempool);

--- a/tests/common/node/full_node/default_start.rs
+++ b/tests/common/node/full_node/default_start.rs
@@ -205,7 +205,8 @@ pub async fn start<Mapping: 'static + ServiceMapping>(
             config.mempool.broadcast_txs_size,
             config.mempool.broadcast_txs_interval,
         );
-    let mempool = Arc::new(HashMemPool::new(consts::MEMPOOL_POOL_SIZE, mempool_adapter));
+    let mempool =
+        Arc::new(HashMemPool::new(consts::MEMPOOL_POOL_SIZE, mempool_adapter, vec![]).await);
 
     // self private key
     let hex_privkey = hex::decode(config.privkey.as_string_trim0x()).map_err(MainError::FromHex)?;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
1. Fix a bug that may cause inactivation. Recover signed transactions from wal when reboot. Then insert them to the mempool.
2. Add a check of the ordered transaction hash when commit.
3. Upgrade overlord version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
