### PR TITLE
fix(network): give up peer because of handshake timeout

### DIFF
--- a/core/network/src/connection/keeper.rs
+++ b/core/network/src/connection/keeper.rs
@@ -4,7 +4,7 @@ use futures::channel::mpsc::UnboundedSender;
 use log::{debug, error};
 use tentacle::{
     context::ServiceContext,
-    error::{DialerErrorKind, ListenErrorKind},
+    error::{DialerErrorKind, HandshakeErrorKind, ListenErrorKind},
     multiaddr::Multiaddr,
     service::{ServiceError, ServiceEvent},
     traits::ServiceHandle,
@@ -96,6 +96,9 @@ impl ConnectionServiceKeeper {
                 let ty = ConnectionType::Outbound;
                 let repeated_connection = PeerManagerEvent::RepeatedConnection { ty, sid, addr };
                 return self.report_peer(repeated_connection);
+            }
+            HandshakeError(HandshakeErrorKind::Timeout(reason)) => {
+                ConnectionErrorKind::TimeOut(reason)
             }
             HandshakeError(err) => ConnectionErrorKind::SecioHandshake(Box::new(err)),
             TransportError(err) => ConnectionErrorKind::from(err),

--- a/core/network/src/event.rs
+++ b/core/network/src/event.rs
@@ -49,6 +49,9 @@ pub enum ConnectionErrorKind {
     #[display(fmt = "handshake {}", _0)]
     SecioHandshake(Box<dyn Error + Send>),
 
+    #[display(fmt = "timeout {}", _0)]
+    TimeOut(String),
+
     #[display(fmt = "remote peer doesn't match one in multiaddr")]
     PeerIdNotMatch,
 

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -894,6 +894,7 @@ impl PeerManager {
     fn connect_failed(&mut self, addr: Multiaddr, error_kind: ConnectionErrorKind) {
         use ConnectionErrorKind::{
             DNSResolver, Io, MultiaddrNotSuppored, PeerIdNotMatch, ProtocolHandle, SecioHandshake,
+            TimeOut,
         };
 
         let peer_addr: PeerMultiaddr = match addr.clone().try_into() {
@@ -924,6 +925,10 @@ impl PeerManager {
             PeerIdNotMatch => {
                 warn!("give up multiaddr {} because peer id not match", peer_addr);
                 peer.multiaddrs.give_up(&peer_addr);
+            }
+            TimeOut(reason) => {
+                info!("connect timeout {}", reason);
+                peer.multiaddrs.inc_failure(&peer_addr);
             }
             SecioHandshake(_) | ProtocolHandle => {
                 warn!("give up peer {:?} becasue {}", peer.id, error_kind);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Right now, we will give up a peer after secio handshake timeout. This PR handle this timeout error, instead
of give up peer, we just increase its address failure count, so that we can try this peer again.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
