### PR TITLE
fix(network): give up a peer without log a reason

### DIFF
--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -971,6 +971,7 @@ impl PeerManager {
                 attempt.peer.set_connectedness(Connectedness::CanConnect);
 
                 if attempt.peer.retry.run_out() {
+                    warn!("give up peer {:?} due to retry run out", attempt.peer.id);
                     attempt.peer.set_connectedness(Connectedness::Unconnectable);
                 }
 
@@ -1076,7 +1077,10 @@ impl PeerManager {
 
         match kind {
             PingTimeout => peer.retry.inc(),
-            PingUnexpect | Discovery => peer.set_connectedness(Connectedness::Unconnectable), /* Give up this peer */
+            PingUnexpect | Discovery => {
+                warn!("give up peer {:?} because of {}", peer.id, kind);
+                peer.set_connectedness(Connectedness::Unconnectable)
+            }
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Add warn log before give up peer

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
