### PR TITLE
fix(network): give up peer due to secio io error

### DIFF
--- a/core/network/src/connection/keeper.rs
+++ b/core/network/src/connection/keeper.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use futures::channel::mpsc::UnboundedSender;
 use log::{debug, error};
+use tentacle::secio::error::SecioError;
 use tentacle::{
     context::ServiceContext,
     error::{DialerErrorKind, HandshakeErrorKind, ListenErrorKind},
@@ -99,6 +100,9 @@ impl ConnectionServiceKeeper {
             }
             HandshakeError(HandshakeErrorKind::Timeout(reason)) => {
                 ConnectionErrorKind::TimeOut(reason)
+            }
+            HandshakeError(HandshakeErrorKind::SecioError(SecioError::IoError(err))) => {
+                ConnectionErrorKind::Io(err)
             }
             HandshakeError(err) => ConnectionErrorKind::SecioHandshake(Box::new(err)),
             TransportError(err) => ConnectionErrorKind::from(err),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
When a peer connection result in secio io error, this peer will be marked
as unconnectable. We will not try to connect to this peer in the future.

In this PR, we treat secio io error as normal io error, don't mark this peer
as unconnectable. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
