### PR TITLE
feat(network): retry unconnectable consensus peer

### DIFF
--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -1230,8 +1230,15 @@ impl PeerManager {
             if connectedness != Connectedness::CanConnect
                 && connectedness != Connectedness::NotConnected
             {
-                debug!("peer {:?} connectedness {}", p.id, connectedness);
-                None
+                if connectedness == Connectedness::Unconnectable
+                    && p.tags.contains(&PeerTag::Consensus)
+                {
+                    // For consensus peer, just try again.
+                    Some(p)
+                } else {
+                    debug!("peer {:?} connectedness {}", p.id, connectedness);
+                    None
+                }
             } else {
                 Some(p)
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Unconnectable peers will be filtered out when peer managers try to connect a list of peers.

This PR change this behaviour, so that consensus peers can be tried again.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
