### PR TITLE
fix(network): negative connecting metric number

### DIFF
--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -801,7 +801,8 @@ impl PeerManager {
     }
 
     fn new_unidentified_session(&mut self, pubkey: PublicKey, ctx: Arc<SessionContext>) {
-        common_apm::metrics::network::NETWORK_OUTBOUND_CONNECTING_PEERS.dec();
+        common_apm::metrics::network::NETWORK_OUTBOUND_CONNECTING_PEERS
+            .set(self.connecting.len() as i64);
 
         let peer_id = pubkey.peer_id();
         if let Err(err) = self.new_session_pre_check(&pubkey, &ctx) {
@@ -976,7 +977,8 @@ impl PeerManager {
                     attempt.peer.set_connectedness(Connectedness::Unconnectable);
                 }
 
-                common_apm::metrics::network::NETWORK_OUTBOUND_CONNECTING_PEERS.dec();
+                common_apm::metrics::network::NETWORK_OUTBOUND_CONNECTING_PEERS
+                    .set(self.connecting.len() as i64);
             // FIXME
             // if let Some(trust_metric) = attempt.peer.trust_metric() {
             //     trust_metric.bad_events(1);
@@ -1489,10 +1491,10 @@ impl Future for PeerManager {
             );
 
             if !connectable_peers.is_empty() {
-                common_apm::metrics::network::NETWORK_OUTBOUND_CONNECTING_PEERS
-                    .add(connectable_peers.len() as i64);
-
                 self.connect_peers(connectable_peers);
+
+                common_apm::metrics::network::NETWORK_OUTBOUND_CONNECTING_PEERS
+                    .set(self.connecting.len() as i64);
             }
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Use collection's length directly, this should fix negative connecting number gauge now.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
