### PR TITLE
feat(network): ping metric from gauge vec to histogram vec

### DIFF
--- a/common/apm/src/metrics.rs
+++ b/common/apm/src/metrics.rs
@@ -10,9 +10,9 @@ pub use prometheus::{
 
 use derive_more::Display;
 use prometheus::{
-    exponential_buckets, register_counter_vec, register_histogram, register_histogram_vec,
-    register_int_counter, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
-    Encoder, TextEncoder,
+    exponential_buckets, linear_buckets, register_counter_vec, register_histogram,
+    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
+    register_int_gauge_vec, Encoder, TextEncoder,
 };
 use prometheus_static_metric::{auto_flush_from, make_auto_flush_static_metric};
 use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};

--- a/common/apm/src/metrics/network.rs
+++ b/common/apm/src/metrics/network.rs
@@ -1,9 +1,9 @@
 use lazy_static::lazy_static;
 
 use crate::metrics::{
-    auto_flush_from, exponential_buckets, make_auto_flush_static_metric, register_histogram_vec,
-    register_int_counter, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
-    HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    auto_flush_from, exponential_buckets, linear_buckets, make_auto_flush_static_metric,
+    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
+    register_int_gauge_vec, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 
 make_auto_flush_static_metric! {
@@ -60,6 +60,13 @@ lazy_static! {
         exponential_buckets(0.01, 2.0, 20).expect("network protocol time expontial")
     )
     .expect("network protocol time cost");
+    pub static ref NETWORK_PING_HISTOGRAM_VEC: HistogramVec = register_histogram_vec!(
+        "muta_network_ping_in_ms",
+        "Network peer ping time",
+        &["ip"],
+        linear_buckets(100.0, 200.0, 5).expect("network ping time linear buckets")
+    )
+    .expect("network ping time");
 }
 
 lazy_static! {
@@ -98,9 +105,6 @@ lazy_static! {
     pub static ref NETWORK_CONNECTED_PEERS: IntGauge =
         register_int_gauge!("muta_network_connected_peers", "Total connected peer count")
             .expect("network total connecteds");
-    pub static ref NETWORK_PING_IP_IN_MS_VEC: IntGaugeVec =
-        register_int_gauge_vec!("muta_network_ip_ping_in_ms", "Ping to ip in ms", &["ip"])
-            .expect("network ping ip value");
     pub static ref NETWORK_IP_DISCONNECTED_COUNT_VEC: IntCounterVec = register_int_counter_vec!(
         "muta_network_ip_disconnected_count",
         "Total number of ip disconnected count",

--- a/core/network/src/protocols/ping/behaviour.rs
+++ b/core/network/src/protocols/ping/behaviour.rs
@@ -62,9 +62,10 @@ impl Future for EventTranslator {
                 PingEvent::Ping(ref _pid) => continue,
                 PingEvent::Pong(ref pid, ref connected_addr, ping_time) => {
                     let host = &connected_addr.host;
-                    common_apm::metrics::network::NETWORK_PING_IP_IN_MS_VEC
+
+                    common_apm::metrics::network::NETWORK_PING_HISTOGRAM_VEC
                         .with_label_values(&[host])
-                        .set(ping_time.as_millis() as i64);
+                        .observe(ping_time.as_millis() as f64);
 
                     PeerManagerEvent::PeerAlive { pid: pid.clone() }
                 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
To better calculate peer ping p90, change ping metric from gauge vec to histogram vec.
In this PR, we set up 5 buckets, [100, 300, 500, 700, 900].

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
