### PR TITLE
feat(logger): split log file by size

### DIFF
--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/nervosnetwork/muta"
 
 [dependencies]
 log = "0.4"
-log4rs = "0.8"
+log4rs = { version = "0.13", features = ["all_components", "file", "yaml_format"] }
 json = "0.12"

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -11,3 +11,6 @@ repository = "https://github.com/nervosnetwork/muta"
 log = "0.4"
 log4rs = { version = "0.13", features = ["all_components", "file", "yaml_format"] }
 json = "0.12"
+serde = "1.0"
+serde_derive = "1.0"
+chrono = "0.4"

--- a/common/logger/src/date_fixed_roller.rs
+++ b/common/logger/src/date_fixed_roller.rs
@@ -1,0 +1,155 @@
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use chrono::prelude::Utc;
+use log4rs::append::rolling_file::policy::compound::roll::Roll;
+use log4rs::file::{Deserialize, Deserializers};
+
+#[derive(serde_derive::Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct DateFixedWindowRollerConfig {
+    pattern: String,
+}
+
+pub struct DateFixedWindowRollerBuilder;
+
+impl DateFixedWindowRollerBuilder {
+    pub fn build(
+        self,
+        pattern: &str,
+    ) -> Result<DateFixedWindowRoller, Box<dyn Error + Sync + Send>> {
+        if !pattern.contains("{date}") || !pattern.contains("{timestamp}") {
+            return Err("pattern doesn't contain `{date}` or `{timestamp}`".into());
+        }
+
+        let roller = DateFixedWindowRoller {
+            pattern: pattern.into(),
+        };
+
+        Ok(roller)
+    }
+}
+
+/// The pattern takes two interpolation arguments, {date} and {timestamp}.
+/// {date} and {timestamp} will be replaced with actual date and timestamp
+/// value.
+///
+/// For example:
+/// For pattern `log/{date}.muta.{timestamp}.log`, it will generate
+/// `log/2020-08-27.muta.83748392743.log`.
+#[derive(Debug)]
+pub struct DateFixedWindowRoller {
+    pattern: String,
+}
+
+impl DateFixedWindowRoller {
+    pub fn builder() -> DateFixedWindowRollerBuilder {
+        DateFixedWindowRollerBuilder
+    }
+
+    fn roll_file(
+        &self,
+        cur_log: &Path,
+        date: &str,
+        timestamp: &str,
+    ) -> Result<(), Box<dyn Error + Sync + Send>> {
+        let archived_log = {
+            let pattern = self.pattern.clone();
+            let partial_log = pattern.replace("{date}", date);
+            partial_log.replace("{timestamp}", &timestamp)
+        };
+
+        if let Some(parent) = Path::new(&archived_log).parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        match fs::rename(cur_log, &archived_log) {
+            Ok(()) => return Ok(()),
+            Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(_) => {}
+        }
+
+        // fall back to a copy
+        fs::copy(cur_log, &archived_log).and_then(|_| fs::remove_file(cur_log))?;
+        Ok(())
+    }
+}
+
+impl Roll for DateFixedWindowRoller {
+    fn roll(&self, cur_log: &Path) -> Result<(), Box<dyn Error + Sync + Send>> {
+        let now = Utc::now();
+        self.roll_file(
+            cur_log,
+            &now.format("%Y-%m-%d").to_string(),
+            &now.timestamp().to_string(),
+        )
+    }
+}
+
+pub struct DateFixedWindowRollerDeserializer;
+
+impl Deserialize for DateFixedWindowRollerDeserializer {
+    type Config = DateFixedWindowRollerConfig;
+    type Trait = dyn Roll;
+
+    fn deserialize(
+        &self,
+        config: Self::Config,
+        _: &Deserializers,
+    ) -> Result<Box<Self::Trait>, Box<dyn Error + Sync + Send>> {
+        let roll = DateFixedWindowRoller {
+            pattern: config.pattern,
+        };
+
+        Ok(Box::new(roll))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::{Read, Write};
+
+    use chrono::prelude::Utc;
+
+    use super::DateFixedWindowRoller;
+
+    #[test]
+    fn test_rotation() {
+        let temp_dir = std::env::temp_dir();
+        let pattern = format!(
+            "{}/{{date}}.muta.{{timestamp}}.log",
+            temp_dir.as_path().to_string_lossy()
+        );
+        let roller = DateFixedWindowRoller::builder().build(&pattern).unwrap();
+
+        let test_log = {
+            let mut temp_file = temp_dir.clone();
+            temp_file.push("logger_test.log");
+            temp_file
+        };
+        File::create(&test_log).unwrap().write_all(b"test").unwrap();
+
+        let now = Utc::now();
+        let date = &now.format("%Y-%m-%d").to_string();
+        let timestamp = &now.timestamp().to_string();
+
+        roller.roll_file(&test_log, &date, &timestamp).unwrap();
+        assert!(!test_log.exists());
+
+        let mut log_data = vec![];
+        let archived_log = {
+            let mut temp_file = temp_dir.clone();
+            temp_file.push(&format!("{}.muta.{}.log", &date, &timestamp));
+            temp_file
+        };
+
+        File::open(archived_log)
+            .unwrap()
+            .read_to_end(&mut log_data)
+            .unwrap();
+
+        assert_eq!(log_data, b"test");
+    }
+}

--- a/common/logger/src/date_fixed_roller.rs
+++ b/common/logger/src/date_fixed_roller.rs
@@ -140,7 +140,7 @@ mod tests {
 
         let mut log_data = vec![];
         let archived_log = {
-            let mut temp_file = temp_dir.clone();
+            let mut temp_file = temp_dir;
             temp_file.push(&format!("{}.muta.{}.log", &date, &timestamp));
             temp_file
         };

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -1,3 +1,5 @@
+mod date_fixed_roller;
+
 use std::collections::HashMap;
 use std::path::PathBuf;
 

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -6,10 +6,14 @@ use std::path::PathBuf;
 use json::JsonValue;
 use log::LevelFilter;
 use log4rs::append::console::ConsoleAppender;
-use log4rs::append::file::FileAppender;
+use log4rs::append::rolling_file::policy::compound::trigger::size::SizeTrigger;
+use log4rs::append::rolling_file::policy::compound::CompoundPolicy;
+use log4rs::append::rolling_file::RollingFileAppender;
 use log4rs::config::{Appender, Config, Logger, Root};
 use log4rs::encode::json::JsonEncoder;
 use log4rs::encode::pattern::PatternEncoder;
+
+use date_fixed_roller::DateFixedWindowRoller;
 
 pub use json::array;
 pub use json::object;
@@ -21,6 +25,7 @@ pub fn init<S: ::std::hash::BuildHasher>(
     log_to_file: bool,
     metrics: bool,
     log_path: PathBuf,
+    file_size_limit: u64, // bytes
     modules_level: HashMap<String, String, S>,
 ) {
     let console = ConsoleAppender::builder()
@@ -33,15 +38,34 @@ pub fn init<S: ::std::hash::BuildHasher>(
         )))
         .build();
 
-    let file = FileAppender::builder()
-        .encoder(Box::new(JsonEncoder::new()))
-        .build(log_path.join("muta.log"))
-        .unwrap();
+    let muta_roller_pat = log_path.join("{date}.muta.{timestamp}.log");
+    let metrics_roller_pat = log_path.join("{date}.metrics.{timestamp}.log");
 
-    let metrics_appender = FileAppender::builder()
-        .encoder(Box::new(JsonEncoder::new()))
-        .build(log_path.join("metrics.log"))
-        .unwrap();
+    let file = {
+        let size_trigger = SizeTrigger::new(file_size_limit);
+        let roller = DateFixedWindowRoller::builder()
+            .build(&muta_roller_pat.to_string_lossy())
+            .unwrap();
+        let policy = CompoundPolicy::new(Box::new(size_trigger), Box::new(roller));
+
+        RollingFileAppender::builder()
+            .encoder(Box::new(JsonEncoder::new()))
+            .build(log_path.join("muta.log"), Box::new(policy))
+            .unwrap()
+    };
+
+    let metrics_appender = {
+        let size_trigger = SizeTrigger::new(file_size_limit);
+        let roller = DateFixedWindowRoller::builder()
+            .build(&metrics_roller_pat.to_string_lossy())
+            .unwrap();
+        let policy = CompoundPolicy::new(Box::new(size_trigger), Box::new(roller));
+
+        RollingFileAppender::builder()
+            .encoder(Box::new(JsonEncoder::new()))
+            .build(log_path.join("metrics.log"), Box::new(policy))
+            .unwrap()
+    };
 
     let mut root_builder = Root::builder();
     if log_to_console {

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -42,6 +42,7 @@ log_to_console = true
 console_show_file_and_line = false
 log_path = "logs/"
 log_to_file = true
+file_size_limit = 1073741824 # 1 GiB
 metrics = true
 # you can specify log level for modules with config below
 # modules_level = { "overlord::state::process" = "debug", core_consensus = "error" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,6 +112,7 @@ pub struct ConfigLogger {
     pub log_to_file:                bool,
     pub metrics:                    bool,
     pub log_path:                   PathBuf,
+    pub file_size_limit:            u64,
     #[serde(default)]
     pub modules_level:              HashMap<String, String>,
 }
@@ -125,6 +126,7 @@ impl Default for ConfigLogger {
             log_to_file:                true,
             metrics:                    true,
             log_path:                   "logs/".into(),
+            file_size_limit:            1024 * 1024 * 1024, // GiB
             modules_level:              HashMap::new(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ impl<Mapping: 'static + ServiceMapping> Muta<Mapping> {
             self.config.logger.log_to_file,
             self.config.logger.metrics,
             self.config.logger.log_path.clone(),
+            self.config.logger.file_size_limit,
             self.config.logger.modules_level.clone(),
         );
 

--- a/tests/trust_metric_all/logger.rs
+++ b/tests/trust_metric_all/logger.rs
@@ -5,6 +5,7 @@ const LOGGER_LOG_TO_CONSOLE: bool = true;
 const LOGGER_CONSOLE_SHOW_FILE_AND_LINE: bool = false;
 const LOGGER_LOG_TO_FILE: bool = false;
 const LOGGER_METRICS: bool = false;
+const LOGGER_FILE_SIZE_LIMIT: u64 = 1024 * 1024 * 1024;
 
 #[allow(dead_code)]
 pub fn init() {
@@ -20,6 +21,7 @@ pub fn init() {
         LOGGER_LOG_TO_FILE,
         LOGGER_METRICS,
         log_path,
+        LOGGER_FILE_SIZE_LIMIT,
         modules_level,
     )
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR add ```file_size_limit``` to ```logger``` config. When log file reaches given file size limit, current log
file will be "archived" into ```[data].muta.[timestamp].log```.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #
https://github.com/nervosnetwork/muta-docs/pull/62


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
