### PR TITLE
fix(network): identify protocol: possible dead lock in identification

### DIFF
--- a/core/network/src/protocols/identify/identification.rs
+++ b/core/network/src/protocols/identify/identification.rs
@@ -85,13 +85,19 @@ impl Identification {
     }
 
     fn done(&self, ret: Result<(), super::protocol::Error>) {
-        let mut status = self.status.lock();
+        let wakerset = {
+            let mut status = self.status.lock();
 
-        if let IdentificationStatus::Pending(wakerset) =
-            std::mem::replace(&mut *status, IdentificationStatus::Done(ret))
-        {
-            wakerset.wake()
-        }
+            if let IdentificationStatus::Pending(wakerset) =
+                std::mem::replace(&mut *status, IdentificationStatus::Done(ret))
+            {
+                wakerset
+            } else {
+                return;
+            }
+        };
+
+        wakerset.wake()
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Status lock may still be hold when we wake up identification wait futures.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
