### PR TITLE
fix: fix framework to deal with state while tx runs fail

### DIFF
--- a/framework/src/executor/mod.rs
+++ b/framework/src/executor/mod.rs
@@ -419,6 +419,8 @@ impl<S: 'static + Storage, DB: 'static + TrieDB, Mapping: 'static + ServiceMappi
         };
 
         if ret.is_error() {
+            event.borrow_mut().truncate(event_index);
+            self.states.revert_cache()?;
             service_context.cancel("tx_exec_return_code_not_zero".to_owned());
         }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: fix framework to deal with state while tx runs fail

The state should be revert_cache to the previous point(just after tx hook before) while tx body runs fail.

**Which docs this PR relation**:

Ref # N/A


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
No toolchain and docs affected