### PR TITLE
refactor(consensus): view change reason adapts to structure log

### DIFF
--- a/core/consensus/Cargo.toml
+++ b/core/consensus/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/nervosnetwork/muta"
 async-trait = "0.1"
 bincode = "1.3"
 cita_trie = "2.0"
+json = "0.12"
 creep = "0.2"
 derive_more = "0.99"
 futures = { version = "0.3", features = ["async-await"] }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
 Overlord view change reason adapts to structure log.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
