### PR TITLE
fix(state): If value is an empty byte it needs to return none

### DIFF
--- a/framework/src/binding/state/mod.rs
+++ b/framework/src/binding/state/mod.rs
@@ -34,7 +34,7 @@ impl<DB: TrieDB> GeneralServiceState<DB> {
     }
 
     fn get_bytes_value(&self, key: Bytes) -> ProtocolResult<Option<Bytes>> {
-         if let Some(value_bytes) = self.cache_map.get(&key) {
+        if let Some(value_bytes) = self.cache_map.get(&key) {
             if value_bytes.is_empty() {
                 return Ok(None);
             }
@@ -144,25 +144,23 @@ fn get_address_key<Key: FixedCodec>(address: &Address, key: &Key) -> ProtocolRes
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
     use bytes::Bytes;
+    use std::sync::Arc;
 
     use cita_trie::MemoryDB;
 
     use protocol::traits::ServiceState;
 
-    use crate::binding::state::MPTTrie;
     use super::*;
+    use crate::binding::state::MPTTrie;
 
     #[test]
     fn test_get_trie() {
-        let mut state = GeneralServiceState::new(MPTTrie::new(
-            Arc::new(MemoryDB::new(false)),
-        ));
+        let mut state = GeneralServiceState::new(MPTTrie::new(Arc::new(MemoryDB::new(false))));
 
         let key = Bytes::from("test");
         let value = Bytes::from("test");
-    
+
         state.insert(key.clone(), value.clone()).unwrap();
 
         assert_eq!(state.get::<Bytes, Bytes>(&key).unwrap(), Some(value));

--- a/framework/src/binding/state/mod.rs
+++ b/framework/src/binding/state/mod.rs
@@ -153,6 +153,7 @@ mod tests {
 
     use crate::binding::state::MPTTrie;
     use super::*;
+
     #[test]
     fn test_get_trie() {
         let state = Rc::new(RefCell::new(GeneralServiceState::new(MPTTrie::new(
@@ -162,7 +163,7 @@ mod tests {
         let key = Bytes::from("test");
         let value = Bytes::from("test");
     
-        state.insert(key.clone(), value.clone()).unwrap());
+        state.insert(key.clone(), value.clone()).unwrap();
 
         assert_eq!(state.get(key.clone()).unwrap().unwrap(), value);
         state.insert(key.clone(), Bytes::new()).unwrap();

--- a/framework/src/binding/state/mod.rs
+++ b/framework/src/binding/state/mod.rs
@@ -52,7 +52,7 @@ impl<DB: TrieDB> GeneralServiceState<DB> {
             if value_bytes.is_empty() {
                 return Ok(None);
             }
-            return Ok(Some(value_bytes.clone()));
+            return Ok(Some(value_bytes));
         }
 
         Ok(None)

--- a/framework/src/binding/state/mod.rs
+++ b/framework/src/binding/state/mod.rs
@@ -151,8 +151,8 @@ mod tests {
 
     use cita_trie::MemoryDB;
 
-    use crate::binding::state::{GeneralServiceState, MPTTrie};
-
+    use crate::binding::state::MPTTrie;
+    use super::*;
     #[test]
     fn test_get_trie() {
         let state = Rc::new(RefCell::new(GeneralServiceState::new(MPTTrie::new(

--- a/framework/src/binding/state/mod.rs
+++ b/framework/src/binding/state/mod.rs
@@ -34,25 +34,25 @@ impl<DB: TrieDB> GeneralServiceState<DB> {
     }
 
     fn get_bytes_value(&self, key: Bytes) -> ProtocolResult<Option<Bytes>> {
-         if let Some(value_bytes) = self.cache_map.get(&encoded_key) {
+         if let Some(value_bytes) = self.cache_map.get(&key) {
             if value_bytes.is_empty() {
                 return Ok(None);
             }
-            return Ok(Some(inst));
+            return Ok(Some(value_bytes.clone()));
         }
 
-        if let Some(value_bytes) = self.stash_map.get(&encoded_key) {
+        if let Some(value_bytes) = self.stash_map.get(&key) {
             if value_bytes.is_empty() {
                 return Ok(None);
             }
-            return Ok(Some(inst));
+            return Ok(Some(value_bytes.clone()));
         }
 
-        if let Some(value_bytes) = self.trie.get(&encoded_key)? {
+        if let Some(value_bytes) = self.trie.get(&key)? {
             if value_bytes.is_empty() {
                 return Ok(None);
             }
-            return Ok(Some(value_bytes));
+            return Ok(Some(value_bytes.clone()));
         }
 
         Ok(None)
@@ -64,8 +64,8 @@ impl<DB: TrieDB> ServiceState for GeneralServiceState<DB> {
         let encoded_key = key.encode_fixed()?;
 
         if let Some(value_bytes) = self.get_bytes_value(encoded_key)? {
-            let inst = <_>::decode_fixed(value_bytes.clone())?;
-            Ok(inst)
+            let inst = <_>::decode_fixed(value_bytes)?;
+            Ok(Some(inst))
         } else {
             Ok(None)
         }
@@ -74,7 +74,7 @@ impl<DB: TrieDB> ServiceState for GeneralServiceState<DB> {
     fn contains<Key: FixedCodec>(&self, key: &Key) -> ProtocolResult<bool> {
         let encoded_key = key.encode_fixed()?;
 
-        self.get_bytes_value(encoded_key)?.is_some()
+        Ok(self.get_bytes_value(encoded_key)?.is_some())
     }
 
     // Insert a pair of key / value
@@ -145,30 +145,30 @@ fn get_address_key<Key: FixedCodec>(address: &Address, key: &Key) -> ProtocolRes
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::cell::RefCell;
-    use std::rc::Rc;
     use bytes::Bytes;
 
     use cita_trie::MemoryDB;
+
+    use protocol::traits::ServiceState;
 
     use crate::binding::state::MPTTrie;
     use super::*;
 
     #[test]
     fn test_get_trie() {
-        let state = Rc::new(RefCell::new(GeneralServiceState::new(MPTTrie::new(
+        let mut state = GeneralServiceState::new(MPTTrie::new(
             Arc::new(MemoryDB::new(false)),
-        ))));
+        ));
 
         let key = Bytes::from("test");
         let value = Bytes::from("test");
     
         state.insert(key.clone(), value.clone()).unwrap();
 
-        assert_eq!(state.get(key.clone()).unwrap().unwrap(), value);
+        assert_eq!(state.get::<Bytes, Bytes>(&key).unwrap(), Some(value));
         state.insert(key.clone(), Bytes::new()).unwrap();
 
-        assert_eq!(state.get(key.clone()).unwrap().is_some(), false);
-        assert_eq!(state.contains(key.clone()).unwrap(), false);
+        assert_eq!(state.get::<Bytes, Bytes>(&key).unwrap().is_some(), false);
+        assert_eq!(state.contains(&key).unwrap(), false);
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
If the value is an empty byte it needs to be returned `null` to keep the behavior consistent with the MPT.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
