### PR TITLE
refactor: return Ok(None) when get none

### DIFF
--- a/framework/src/binding/store/array.rs
+++ b/framework/src/binding/store/array.rs
@@ -7,9 +7,9 @@ use bytes::Bytes;
 use protocol::fixed_codec::FixedCodec;
 use protocol::traits::{ServiceState, StoreArray};
 use protocol::types::Hash;
-use protocol::{ProtocolError, ProtocolResult};
+use protocol::ProtocolResult;
 
-use crate::binding::store::{FixedKeys, StoreError};
+use crate::binding::store::FixedKeys;
 
 pub struct DefaultStoreArray<S: ServiceState, E: FixedCodec> {
     state:    Rc<RefCell<S>>,
@@ -43,14 +43,10 @@ impl<S: ServiceState, E: FixedCodec> DefaultStoreArray<S, E> {
 
     fn inner_get(&self, index: u64) -> ProtocolResult<Option<E>> {
         if let Some(k) = self.keys.inner.get(index as usize) {
-            self.state.borrow().get(k)?.map_or_else(
-                || {
-                    let e: E = <_>::decode_fixed(Bytes::new())
-                        .map_err(|_| ProtocolError::from(StoreError::DecodeError))?;
-                    Ok(Some(e))
-                },
-                |e| Ok(Some(e)),
-            )
+            self.state
+                .borrow()
+                .get(k)?
+                .map_or_else(|| Ok(None), |v| Ok(Some(v)))
         } else {
             Ok(None)
         }

--- a/framework/src/binding/store/map.rs
+++ b/framework/src/binding/store/map.rs
@@ -9,9 +9,9 @@ use rayon::prelude::*;
 use protocol::fixed_codec::FixedCodec;
 use protocol::traits::{ServiceState, StoreMap};
 use protocol::types::Hash;
-use protocol::{ProtocolError, ProtocolResult};
+use protocol::ProtocolResult;
 
-use crate::binding::store::{get_bucket_index, Bucket, FixedBuckets, StoreError};
+use crate::binding::store::{get_bucket_index, Bucket, FixedBuckets};
 
 pub struct DefaultStoreMap<S: ServiceState, K: FixedCodec + PartialEq, V: FixedCodec> {
     state:    Rc<RefCell<S>>,
@@ -71,14 +71,7 @@ where
             self.state
                 .borrow()
                 .get(&self.get_map_key(&key_bytes))?
-                .map_or_else(
-                    || {
-                        Ok(Some(<_>::decode_fixed(Bytes::new()).map_err(|_| {
-                            ProtocolError::from(StoreError::DecodeError)
-                        })?))
-                    },
-                    |v| Ok(Some(v)),
-                )
+                .map_or_else(|| Ok(None), |v| Ok(Some(v)))
         } else {
             Ok(None)
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
The `inner_get()` function of `DefaultStoreArray` and `DefaultStoreMap`  return `Ok(None)` when get nothing.
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
