### PR TITLE
feat(logger): add a json macro to generate json object

### DIFF
--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/nervosnetwork/muta"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+env_logger = "0.7"
 log = "0.4"
 # Turn off gzip feature, it hurts performance. For more information, reference
 # log4rs document.

--- a/common/logger/README.md
+++ b/common/logger/README.md
@@ -74,7 +74,7 @@ to identify this event. `Context` is used to extract trace id. `msg` is `JsonVal
 Useage example:
 
 ```rust
-common_logger::log(Level::Info, "network", "netw0001", &ctx, common_logger::object!{"music": "beautiful world"});
+common_logger::log(Level::Info, "network", "netw0001", &ctx, common_logger::json!({"music", "beautiful world"; "movie", "fury"}));
 ```
 
 ## Yaml File

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -20,6 +20,13 @@ use date_fixed_roller::DateFixedWindowRoller;
 pub use json::array;
 pub use json::object;
 
+/// Example
+/// ```rust
+///     let json_obj = json!({
+///         "key_01", value_01;
+///         "key_02", value_02;
+///    });
+/// ```
 #[macro_export]
 macro_rules! json {
     ({$($key: expr, $value: expr); *}) => {{

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -20,13 +20,13 @@ use date_fixed_roller::DateFixedWindowRoller;
 pub use json::array;
 pub use json::object;
 
-/// Example
-/// ```rust
-///     let json_obj = json!({
-///         "key_01", value_01;
-///         "key_02", value_02;
-///    });
-/// ```
+// Example
+// ```rust
+//     let json_obj = json!({
+//         "key_01", value_01;
+//         "key_02", value_02;
+//    });
+// ```
 #[macro_export]
 macro_rules! json {
     ({$($key: expr, $value: expr); *}) => {{

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -20,6 +20,15 @@ use date_fixed_roller::DateFixedWindowRoller;
 pub use json::array;
 pub use json::object;
 
+#[macro_export]
+macro_rules! json {
+    ({$($key: expr, $value: expr); *}) => {{
+        let mut evt = JsonValue::new_object();
+        $(evt[$key] = $value.into();)*
+        evt
+    }};
+}
+
 pub fn init<S: ::std::hash::BuildHasher>(
     filter: String,
     log_to_console: bool,
@@ -162,5 +171,26 @@ fn trace_context(ctx: &Context) -> Option<TraceContext> {
             Some(trace_ctx)
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_json() {
+        env_logger::init();
+        let json = json!({"height", 1; "msg", "asset_01"; "is_connected", true});
+        log(
+            Level::Warn,
+            "logger",
+            "logg_001",
+            &Context::new(),
+            json.clone(),
+        );
+        assert_eq!(json["height"], 1);
+        assert_eq!(json["msg"], "asset_01");
+        assert_eq!(json["is_connected"], true);
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Add a json macro to generate json object.

example:
```rust
     let json_obj = json!({
         "key_01", value_01;
         "key_02", value_02
    });
 ```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
