### PR TITLE
fix(network): connecting hang

### DIFF
--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.7"
 serde = "1.0"
 serde_derive = "1.0"
 snap = "0.2"
-tentacle = { git = "http://github.com/zeroqn/p2p", rev = "492ed8f", features = ["molc"]}
+tentacle = { git = "http://github.com/zeroqn/p2p", rev = "b2682d2", features = ["molc"]}
 tokio = { version = "0.2", features = ["macros", "rt-core"]}
 tokio-util = { version = "0.2", features = ["codec"] }
 hostname = "0.3"

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -1554,7 +1554,9 @@ impl Future for PeerManager {
             });
             timeouted_attempts.flatten().collect::<Vec<_>>()
         };
-        log::info!("timeouted connecting found: {:?}", timeouted_mutiaddrs);
+        if !timeouted_mutiaddrs.is_empty() {
+            log::info!("timeouted connecting found: {:?}", timeouted_mutiaddrs);
+        }
         for peer_multiaddr in timeouted_mutiaddrs {
             self.connect_failed(
                 Into::<Multiaddr>::into(peer_multiaddr),

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -42,7 +42,7 @@ use rand::seq::IteratorRandom;
 use serde_derive::{Deserialize, Serialize};
 use tentacle::multiaddr::Multiaddr;
 use tentacle::secio::{PeerId, PublicKey};
-use tentacle::service::{SessionType, TargetProtocol};
+use tentacle::service::SessionType;
 use tentacle::SessionId;
 
 use crate::common::{resolve_if_unspecified, HeartBeat};
@@ -52,7 +52,8 @@ use crate::event::{
     SessionErrorKind,
 };
 use crate::protocols::identify::{self, Identify, WaitIdentification};
-use crate::traits::MultiaddrExt;
+use crate::protocols::CoreProtocol;
+use crate::traits::{MultiaddrExt, NetworkProtocol};
 
 use addr_set::PeerAddrSet;
 use retry::Retry;
@@ -1263,7 +1264,7 @@ impl PeerManager {
 
         let connect_attempt = ConnectionEvent::Connect {
             addrs,
-            proto: TargetProtocol::All,
+            proto: CoreProtocol::target(),
         };
 
         if self.conn_tx.unbounded_send(connect_attempt).is_err() {

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -1263,6 +1263,10 @@ impl PeerManager {
 
     fn connect_peers(&mut self, peers: Vec<ArcPeer>) {
         let connectable = |p: ArcPeer| -> Option<ArcPeer> {
+            if p.multiaddrs.len() == 0 {
+                return None;
+            }
+
             if self.config.allowlist_only
                 && !p.tags.contains(&PeerTag::AlwaysAllow)
                 && !p.tags.contains(&PeerTag::Consensus)

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -201,6 +201,11 @@ impl ConnectingAttempt {
     fn is_timeout(&self) -> bool {
         self.at.elapsed() >= MAX_CONNECTING_TIMEOUT
     }
+
+    #[cfg(test)]
+    fn set_at(&mut self, duration: Duration) {
+        self.at = self.at.checked_sub(duration).unwrap();
+    }
 }
 
 impl Borrow<PeerId> for ConnectingAttempt {

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -880,6 +880,11 @@ impl PeerManager {
         if self.unidentified_backlog.take(&sid).is_some() {
             return;
         }
+        if let Some(_) = self.connecting.take(&pid) {
+            log::info!("connecting peer {:?} session closed", pid);
+            common_apm::metrics::network::NETWORK_OUTBOUND_CONNECTING_PEERS
+                .set(self.connecting.len() as i64);
+        }
         common_apm::metrics::network::NETWORK_CONNECTED_PEERS.dec();
 
         // Session may be removed by other event or rejected

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -894,7 +894,7 @@ impl PeerManager {
             common_apm::metrics::network::NETWORK_CONNECTED_PEERS.dec();
         }
 
-        if let Some(_) = self.connecting.take(&pid) {
+        if self.connecting.take(&pid).is_some() {
             log::info!("connecting peer {:?} session closed", pid);
             common_apm::metrics::network::NETWORK_OUTBOUND_CONNECTING_PEERS
                 .set(self.connecting.len() as i64);

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -761,7 +761,6 @@ impl PeerManager {
                             "session peer {:?} is been replaced by peer {:?}",
                             session.peer.id, remote_peer.id
                         );
-                        session.peer.mark_disconnected();
                         self.disconnect_session(session.id);
                         return true;
                     }

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -953,8 +953,17 @@ impl PeerManager {
             }
         } else {
             // Set up a short ban, so we won't retry this peer immediately
+            if remote_peer.tags.contains(&PeerTag::Consensus)
+                || remote_peer.tags.contains(&PeerTag::AlwaysAllow)
+            {
+                return;
+            }
+
             let rand_next_retry = {
-                let duration = rand::random::<u64>() % MAX_RANDOM_NEXT_RETRY;
+                let mut duration = rand::random::<u64>() % MAX_RANDOM_NEXT_RETRY;
+                if duration < 2 {
+                    duration = 2; // At least 2 seconds
+                }
                 Duration::from_secs(duration)
             };
 

--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -72,7 +72,7 @@ const MAX_RETRY_INTERVAL: u64 = 512; // seconds
 const MAX_RETRY_COUNT: u8 = 30;
 const SHORT_ALIVE_SESSION: u64 = 3; // seconds
 const MAX_CONNECTING_MARGIN: usize = 10;
-const MAX_RANDOM_NEXT_RETRY: u64 = 20;
+const MAX_RANDOM_NEXT_RETRY: u64 = 10;
 const MAX_CONNECTING_TIMEOUT: Duration = Duration::from_secs(30);
 
 const GOOD_TRUST_SCORE: u8 = 80u8;

--- a/core/network/src/protocols/identify.rs
+++ b/core/network/src/protocols/identify.rs
@@ -22,7 +22,7 @@ use self::protocol::IdentifyProtocol;
 use behaviour::IdentifyBehaviour;
 
 pub use self::identification::WaitIdentification;
-pub use self::protocol::Error;
+pub use self::protocol::{Error, DEFAULT_TIMEOUT};
 
 pub const NAME: &str = "chain_identify";
 pub const SUPPORT_VERSIONS: [&str; 1] = ["0.2"];

--- a/core/network/src/protocols/identify/protocol.rs
+++ b/core/network/src/protocols/identify/protocol.rs
@@ -320,7 +320,10 @@ impl IdentifyProtocol {
 
         match protocol_context.0.session.ty {
             SessionType::Inbound => {
-                log::info!("enter identify inbound procedure for {}", protocol_context.0.session.address);
+                log::info!(
+                    "enter identify inbound procedure for {}",
+                    protocol_context.0.session.address
+                );
 
                 state_context.set_timeout("wait client identity", DEFAULT_TIMEOUT);
 
@@ -330,7 +333,10 @@ impl IdentifyProtocol {
                 };
             }
             SessionType::Outbound => {
-                log::info!("enter identify outbound procedure for {}", protocol_context.0.session.address);
+                log::info!(
+                    "enter identify outbound procedure for {}",
+                    protocol_context.0.session.address
+                );
 
                 self.behaviour.send_identity(&state_context);
                 state_context.set_timeout("wait server ack", DEFAULT_TIMEOUT);

--- a/core/network/src/protocols/identify/protocol.rs
+++ b/core/network/src/protocols/identify/protocol.rs
@@ -320,6 +320,8 @@ impl IdentifyProtocol {
 
         match protocol_context.0.session.ty {
             SessionType::Inbound => {
+                log::info!("enter identify inbound procedure for {}", protocol_context.0.session.address);
+
                 state_context.set_timeout("wait client identity", DEFAULT_TIMEOUT);
 
                 self.state = State::ServerNegotiate {
@@ -328,6 +330,8 @@ impl IdentifyProtocol {
                 };
             }
             SessionType::Outbound => {
+                log::info!("enter identify outbound procedure for {}", protocol_context.0.session.address);
+
                 self.behaviour.send_identity(&state_context);
                 state_context.set_timeout("wait server ack", DEFAULT_TIMEOUT);
 

--- a/core/network/src/protocols/identify/protocol.rs
+++ b/core/network/src/protocols/identify/protocol.rs
@@ -175,6 +175,7 @@ impl StateContext {
             }
 
             log::warn!("peer {} open protocols timeout, disconnect it", remote_peer);
+            finish_identify(&remote_peer, Err(self::Error::Timeout));
             let _ = service_control.disconnect(remote_peer.sid);
         });
     }

--- a/core/network/src/protocols/identify/protocol.rs
+++ b/core/network/src/protocols/identify/protocol.rs
@@ -207,6 +207,17 @@ impl StateContext {
     }
 }
 
+impl Drop for StateContext {
+    fn drop(&mut self) {
+        // Something wrong happend, disconnect
+        self.disconnect();
+        finish_identify(
+            &self.remote_peer,
+            Err(Error::Other("StateContext dropped".to_owned())),
+        );
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum ClientProcedure {
     #[display(fmt = "client wait for server identity acknowledge")]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Fix peer connecting hang due to inconsistent peer state by unchecked unidentified peer session.

New identify protocol introduces unidentified session to peer manager, we have to do addition checks for these
sessions in ```SessionClosed```, ```ConnectFailed``` and ```RepeatedSession``` events to make sure that related
peers have correct state. 

When ```SessionClosed```, ban that peer a random short time, so these peers dont connect to each other simultaneously (note: this wont' effect consensus peer).

Also add new hardcode timeout to outbound connecting and unidentified sessions in peer manager to ensure that
peer connecting will fail within reasonable time in peer manager side.

Also bump tentacle to latest master.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Which docs this PR relation**:

Ref #


**Which toolchain this PR adaption**:

No Breaking Change


**Special notes for your reviewer**:
